### PR TITLE
Llama3.2 models:  Created  3B + Update 1B

### DIFF
--- a/models/llama3.2_1b/llama3.2_1b_config.json
+++ b/models/llama3.2_1b/llama3.2_1b_config.json
@@ -21,85 +21,318 @@
     "max_context_size": 4096,
     "prefill_context_size": 128,
     "end_of_turn_token_id": 128009,
-    "decoder_seq_len_buckets": [64, 128, 192, 256, 320, 384, 448, 512],
     "rope_global_layers": []
   },
   "paths": {
     "weights_bin": "llama3.2_1b_bin/weights_llama3.2_1b_hf.bin",
-    "local_weights_bin": "llama3.2_1b_bin/full_model_weights.bin",
     "hf_model_dir": "llama3.2_1b_bin/Llama-3.2-1B-Instruct",
     "hf_model_repo": "meta-llama/Llama-3.2-1B-Instruct",
     "instruction_bin": "llama3.2_1b_bin/llama_instruction.bin",
     "instruction_meta": "llama3.2_1b_bin/llama_instruction.json"
   },
-  "default_prefill_tokens": [128000, 128006, 9125, 128007, 271, 38766, 1303, 33025, 2696, 25, 6790, 220, 2366, 18, 198, 15724, 2696, 25, 220, 975, 2947, 220, 2366, 21, 271, 128009, 128006, 882, 128007, 271, 87, 10, 18, 28, 20, 11, 1148, 374, 865, 30, 128009, 128006, 78191, 128007, 271],
+  "default_prefill_tokens": [
+    128000,
+    128006,
+    9125,
+    128007,
+    271,
+    38766,
+    1303,
+    33025,
+    2696,
+    25,
+    6790,
+    220,
+    2366,
+    18,
+    198,
+    15724,
+    2696,
+    25,
+    220,
+    975,
+    2947,
+    220,
+    2366,
+    21,
+    271,
+    128009,
+    128006,
+    882,
+    128007,
+    271,
+    87,
+    10,
+    18,
+    28,
+    20,
+    11,
+    1148,
+    374,
+    865,
+    30,
+    128009,
+    128006,
+    78191,
+    128007,
+    271
+  ],
   "layers": {
     "structure": [
-      {"key": "BLK0_ATTN_NORM_WEIGHT", "type": "bf16", "attr": "DRAM_ADDR_LAYER0_PRE_NORM_GAMMA"},
-      {"key": "BLK0_ATTN_Q_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_Q_PROJ_SCALE"},
-      {"key": "BLK0_ATTN_Q_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_Q_PROJ_QUANT"},
-      {"key": "BLK0_ATTN_K_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_K_PROJ_SCALE"},
-      {"key": "BLK0_ATTN_K_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_K_PROJ_QUANT"},
-      {"key": "BLK0_ATTN_V_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_V_PROJ_SCALE"},
-      {"key": "BLK0_ATTN_V_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_V_PROJ_QUANT"},
-      {"key": "BLK0_ATTN_Q_NORM_WEIGHT", "type": "bf16", "attr": "DRAM_ADDR_LAYER0_Q_NORM_GAMMA"},
-      {"key": "BLK0_ATTN_K_NORM_WEIGHT", "type": "bf16", "attr": "DRAM_ADDR_LAYER0_K_NORM_GAMMA"},
-      {"key": "BLK0_ATTN_OUTPUT_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE"},
-      {"key": "BLK0_ATTN_OUTPUT_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT"},
-      {"key": "BLK0_POST_ATTENTION_NORM_WEIGHT", "type": "bf16", "attr": "DRAM_ADDR_LAYER0_POST_NORM_GAMMA"},
-      {"key": "BLK0_FFN_NORM_WEIGHT", "type": "bf16", "attr": "DRAM_ADDR_LAYER0_FFN_NORM_GAMMA"},
-      {"key": "BLK0_FFN_UP_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_MLP_UP_SCALE"},
-      {"key": "BLK0_FFN_UP_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_MLP_UP_QUANT"},
-      {"key": "BLK0_FFN_GATE_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_MLP_GATE_SCALE"},
-      {"key": "BLK0_FFN_GATE_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_MLP_GATE_QUANT"},
-      {"key": "BLK0_FFN_DOWN_WEIGHT_SCALE", "type": "bf16_scale", "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_SCALE"},
-      {"key": "BLK0_FFN_DOWN_WEIGHT_DATA", "type": "int4", "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_QUANT"},
-      {"key": "BLK0_POST_FFW_NORM_WEIGHT", "type": "bf16", "attr": "DRAM_ADDR_LAYER0_POST_FFW_NORM_GAMMA"}
+      {
+        "key": "BLK0_ATTN_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_PRE_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_ATTN_Q_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_Q_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_Q_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_Q_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_ATTN_K_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_K_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_K_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_K_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_ATTN_V_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_V_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_V_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_V_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_ATTN_Q_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_Q_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_ATTN_K_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_K_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_ATTN_OUTPUT_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_OUTPUT_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_POST_ATTENTION_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_POST_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_FFN_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_FFN_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_FFN_UP_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_MLP_UP_SCALE"
+      },
+      {
+        "key": "BLK0_FFN_UP_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_MLP_UP_QUANT"
+      },
+      {
+        "key": "BLK0_FFN_GATE_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_MLP_GATE_SCALE"
+      },
+      {
+        "key": "BLK0_FFN_GATE_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_MLP_GATE_QUANT"
+      },
+      {
+        "key": "BLK0_FFN_DOWN_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_SCALE"
+      },
+      {
+        "key": "BLK0_FFN_DOWN_WEIGHT_DATA",
+        "type": "if4",
+        "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_QUANT"
+      },
+      {
+        "key": "BLK0_POST_FFW_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_POST_FFW_NORM_GAMMA"
+      }
     ],
     "non_layer": [
-      {"key": "ROPE_LOCAL", "attr": "DRAM_ADDR_ROPE_LOCAL"},
-      {"key": "ROPE_GLOBAL", "attr": "DRAM_ADDR_ROPE_GLOBAL"},
-      {"key": "OUTPUT_NORM_WEIGHT", "attr": "DRAM_ADDR_OUTPUT_NORM_GAMMA"},
-      {"key": "LM_HEAD_WEIGHT_SCALE", "attr": "DRAM_ADDR_LM_HEAD_SCALE"},
-      {"key": "LM_HEAD_WEIGHT_DATA", "attr": "DRAM_ADDR_LM_HEAD_QUANT"}
+      {
+        "key": "ROPE_LOCAL",
+        "attr": "DRAM_ADDR_ROPE_LOCAL"
+      },
+      {
+        "key": "ROPE_GLOBAL",
+        "attr": "DRAM_ADDR_ROPE_GLOBAL"
+      },
+      {
+        "key": "OUTPUT_NORM_WEIGHT",
+        "attr": "DRAM_ADDR_OUTPUT_NORM_GAMMA"
+      },
+      {
+        "key": "LM_HEAD_WEIGHT_SCALE",
+        "attr": "DRAM_ADDR_LM_HEAD_SCALE"
+      },
+      {
+        "key": "LM_HEAD_WEIGHT_DATA",
+        "attr": "DRAM_ADDR_LM_HEAD_QUANT"
+      }
     ]
   },
   "regions": {
-    "BLK0_ATTN_NORM_WEIGHT": {"offset": "0x1f500000", "size": 4096, "type": "bf16"},
-    "BLK0_ATTN_Q_WEIGHT_SCALE": {"offset": "0x1f501000", "size": 131072, "type": "bf16_scale"},
-    "BLK0_ATTN_Q_WEIGHT_DATA": {"offset": "0x1f521000", "size": 2097152, "type": "int4"},
-    "BLK0_ATTN_K_WEIGHT_SCALE": {"offset": "0x1f721000", "size": 32768, "type": "bf16_scale"},
-    "BLK0_ATTN_K_WEIGHT_DATA": {"offset": "0x1f729000", "size": 524288, "type": "int4"},
-    "BLK0_ATTN_V_WEIGHT_SCALE": {"offset": "0x1f7a9000", "size": 32768, "type": "bf16_scale"},
-    "BLK0_ATTN_V_WEIGHT_DATA": {"offset": "0x1f7b1000", "size": 524288, "type": "int4"},
-    "BLK0_ATTN_Q_NORM_WEIGHT": {"offset": "0x1f831000", "size": 1024, "type": "bf16"},
-    "BLK0_ATTN_K_NORM_WEIGHT": {"offset": "0x1f831400", "size": 1024, "type": "bf16"},
-    "BLK0_ATTN_OUTPUT_WEIGHT_SCALE": {"offset": "0x1f831800", "size": 131072, "type": "bf16_scale"},
-    "BLK0_ATTN_OUTPUT_WEIGHT_DATA": {"offset": "0x1f851800", "size": 2097152, "type": "int4"},
-    "BLK0_POST_ATTENTION_NORM_WEIGHT": {"offset": "0x1fa51800", "size": 4096, "type": "bf16"},
-    "BLK0_FFN_NORM_WEIGHT": {"offset": "0x1fa52800", "size": 4096, "type": "bf16"},
-    "BLK0_FFN_UP_WEIGHT_SCALE": {"offset": "0x1fa53800", "size": 524288, "type": "bf16_scale"},
-    "BLK0_FFN_UP_WEIGHT_DATA": {"offset": "0x1fad3800", "size": 8388608, "type": "int4"},
-    "BLK0_FFN_GATE_WEIGHT_SCALE": {"offset": "0x202d3800", "size": 524288, "type": "bf16_scale"},
-    "BLK0_FFN_GATE_WEIGHT_DATA": {"offset": "0x20353800", "size": 8388608, "type": "int4"},
-    "BLK0_FFN_DOWN_WEIGHT_SCALE": {"offset": "0x20b53800", "size": 524288, "type": "bf16_scale"},
-    "BLK0_FFN_DOWN_WEIGHT_DATA": {"offset": "0x20bd3800", "size": 8388608, "type": "int4"},
-    "BLK0_POST_FFW_NORM_WEIGHT": {"offset": "0x213d3800", "size": 4096, "type": "bf16"}
+    "BLK0_ATTN_NORM_WEIGHT": {
+      "offset": "0x1f500000",
+      "size": 4096,
+      "type": "bf16"
+    },
+    "BLK0_ATTN_Q_WEIGHT_SCALE": {
+      "offset": "0x1f501000",
+      "size": 131072,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_Q_WEIGHT_DATA": {
+      "offset": "0x1f521000",
+      "size": 2097152,
+      "type": "if4"
+    },
+    "BLK0_ATTN_K_WEIGHT_SCALE": {
+      "offset": "0x1f721000",
+      "size": 32768,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_K_WEIGHT_DATA": {
+      "offset": "0x1f729000",
+      "size": 524288,
+      "type": "if4"
+    },
+    "BLK0_ATTN_V_WEIGHT_SCALE": {
+      "offset": "0x1f7a9000",
+      "size": 32768,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_V_WEIGHT_DATA": {
+      "offset": "0x1f7b1000",
+      "size": 524288,
+      "type": "if4"
+    },
+    "BLK0_ATTN_Q_NORM_WEIGHT": {
+      "offset": "0x1f831000",
+      "size": 1024,
+      "type": "bf16"
+    },
+    "BLK0_ATTN_K_NORM_WEIGHT": {
+      "offset": "0x1f831400",
+      "size": 1024,
+      "type": "bf16"
+    },
+    "BLK0_ATTN_OUTPUT_WEIGHT_SCALE": {
+      "offset": "0x1f831800",
+      "size": 131072,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_OUTPUT_WEIGHT_DATA": {
+      "offset": "0x1f851800",
+      "size": 2097152,
+      "type": "if4"
+    },
+    "BLK0_POST_ATTENTION_NORM_WEIGHT": {
+      "offset": "0x1fa51800",
+      "size": 4096,
+      "type": "bf16"
+    },
+    "BLK0_FFN_NORM_WEIGHT": {
+      "offset": "0x1fa52800",
+      "size": 4096,
+      "type": "bf16"
+    },
+    "BLK0_FFN_UP_WEIGHT_SCALE": {
+      "offset": "0x1fa53800",
+      "size": 524288,
+      "type": "bf16_scale"
+    },
+    "BLK0_FFN_UP_WEIGHT_DATA": {
+      "offset": "0x1fad3800",
+      "size": 8388608,
+      "type": "if4"
+    },
+    "BLK0_FFN_GATE_WEIGHT_SCALE": {
+      "offset": "0x202d3800",
+      "size": 524288,
+      "type": "bf16_scale"
+    },
+    "BLK0_FFN_GATE_WEIGHT_DATA": {
+      "offset": "0x20353800",
+      "size": 8388608,
+      "type": "if4"
+    },
+    "BLK0_FFN_DOWN_WEIGHT_SCALE": {
+      "offset": "0x20b53800",
+      "size": 524288,
+      "type": "bf16_scale"
+    },
+    "BLK0_FFN_DOWN_WEIGHT_DATA": {
+      "offset": "0x20bd3800",
+      "size": 8388608,
+      "type": "if4"
+    },
+    "BLK0_POST_FFW_NORM_WEIGHT": {
+      "offset": "0x213d3800",
+      "size": 4096,
+      "type": "bf16"
+    }
   },
   "non_layer_regions": {
-    "OUTPUT_NORM_WEIGHT": {"offset": "0x3e248000", "size": 4096},
-    "LM_HEAD_WEIGHT_SCALE": {"offset": "0x3e249000", "size": 8208384},
-    "LM_HEAD_WEIGHT_DATA": {"offset": "0x3ea1d000", "size": 131334144},
-    "ROPE_LOCAL": {"offset": "0x46800000", "size": 8388608},
-    "ROPE_GLOBAL": {"offset": "0x47000000", "size": 8388608}
+    "OUTPUT_NORM_WEIGHT": {
+      "offset": "0x3e248000",
+      "size": 4096
+    },
+    "LM_HEAD_WEIGHT_SCALE": {
+      "offset": "0x3e249000",
+      "size": 8208384
+    },
+    "LM_HEAD_WEIGHT_DATA": {
+      "offset": "0x3ea1d000",
+      "size": 131334144
+    },
+    "ROPE_LOCAL": {
+      "offset": "0x46800000",
+      "size": 8388608
+    },
+    "ROPE_GLOBAL": {
+      "offset": "0x47000000",
+      "size": 8388608
+    }
   },
   "special": {
     "embedding": {
       "token_embd_offset": "0x0",
       "token_embd_size": "0x1f500000",
       "vocab_size": 128256,
-      "embedding_dim": 2048,
-      "scale": 0.5
+      "embedding_dim": 2048
     },
     "rope": {
       "head_dim": 512,
@@ -109,8 +342,7 @@
     },
     "quantization": {
       "block_size": 64,
-      "bits": 4,
-      "range": [-8, 7]
+      "_note": "1B = pure FP4 (quantize_fp4, E2M1 per 64-block) — best 4-bit scheme for 1B by WikiText-2 PPL; see src/models/llama3.2_1b/compare/summary.md. Packed in the HW 4-bit container with positive scale, so the FPGA IF4 dispatch reads it as FP4. (3B uses MixMSE IF4 — scheme chosen per model.)"
     },
     "rms_norm": {
       "gamma_offset": 0.0

--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -18,8 +18,10 @@ running ``llama3.2_1b_test.py`` once on a build machine that has HF access):
 Design mirrors test.py §A–§D (see notes_llama3.2_1b.md): full-4 GB DRAM layout,
 dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
 and sampling decode (recency-decayed / windowed / structural-exempt repetition
-penalty; temperature 0.6 default). The shipped bin is compiled with LM-head
-writeback enabled, so both sampling (temp>0) and greedy (temp 0) work.
+penalty). DECODE DEFAULT is PENALIZED GREEDY (temp 0 + rep-pen 1.1): argmax of the
+penalty-adjusted logits — deterministic, correct math, loop-free; see notes §D. The
+shipped bin is compiled with LM-head writeback enabled, so sampling (temp>0),
+penalized greedy (temp 0 + rep-pen), and pure greedy (temp 0, rep-pen 1.0) all work.
 
 Usage:
   python llama3.2_1b_run_from_bin.py
@@ -429,7 +431,11 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
 
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        _sampling = float(getattr(self, "temperature", 0.0)) > 0
+        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
+        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
+        _temperature = float(getattr(self, "temperature", 0.0))
+        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
 
         import shutil
         _use_status = sys.stdout.isatty()
@@ -476,7 +482,7 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            if _sampling:
+            if _use_logit_readback:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -533,13 +539,15 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Sampling — defaults match llama3.2_1b_test.py (the values the shipped bin was tuned with).
-    parser.add_argument("--temperature", type=float, default=0.6,
-                        help="0 = greedy (HW argmax); >0 = sampling. Default 0.6.")
-    parser.add_argument("--top-k", type=int, default=0, help="Top-k filter (0=off). Default 0.")
+    # Sampling — defaults match llama3.2_1b_test.py (temp 0.4 + top-k 40 fixes FPGA
+    # arithmetic errors while keeping long-context clean; see notes §D).
+    parser.add_argument("--temperature", type=float, default=0.0,
+                        help="0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, correct math, loop-free; the default). >0 = sampling. Default 0.")
+    parser.add_argument("--top-k", type=int, default=40,
+                        help="Top-k filter (0=off). Caps the tail so wrong tokens can't be sampled. Default 40.")
     parser.add_argument("--top-p", type=float, default=0.9, help="Top-p (nucleus) filter. Default 0.9.")
-    parser.add_argument("--repetition-penalty", type=float, default=1.2,
-                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
+    parser.add_argument("--repetition-penalty", type=float, default=1.1,
+                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.1.")
     parser.add_argument("--rep-window", type=int, default=256,
                         help="Repetition penalty look-back window in tokens. Default 256.")
     parser.add_argument("--rep-decay", type=float, default=0.97,

--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -18,10 +18,10 @@ running ``llama3.2_1b_test.py`` once on a build machine that has HF access):
 Design mirrors test.py §A–§D (see notes_llama3.2_1b.md): full-4 GB DRAM layout,
 dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
 and sampling decode (recency-decayed / windowed / structural-exempt repetition
-penalty). DECODE DEFAULT is PENALIZED GREEDY (temp 0 + rep-pen 1.1): argmax of the
-penalty-adjusted logits — deterministic, correct math, loop-free; see notes §D. The
-shipped bin is compiled with LM-head writeback enabled, so sampling (temp>0),
-penalized greedy (temp 0 + rep-pen), and pure greedy (temp 0, rep-pen 1.0) all work.
+penalty). DECODE DEFAULT is a position-gated HYBRID (temp 0): pure greedy for the first
+greedy_until (512) tokens — correct math/reasoning — then repetition penalty 1.2 breaks
+long-context loops; deterministic, see notes §D. The shipped bin is compiled with LM-head
+writeback enabled, so sampling (temp>0), the hybrid, and pure greedy (rep-pen 1.0) all work.
 
 Usage:
   python llama3.2_1b_run_from_bin.py
@@ -341,25 +341,19 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
                 factor = rep_pen ** weight[nz]
                 v = logits[nz]
                 logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        temp = float(getattr(self, "temperature", 1.0))
-        if temp <= 0:
-            return int(logits.argmax().item())
-        logits = logits / temp
-        top_k = int(getattr(self, "top_k", 0) or 0)
-        if top_k > 0 and top_k < vocab:
-            kth = torch.topk(logits, top_k).values[-1]
-            logits[logits < kth] = float("-inf")
-        top_p = float(getattr(self, "top_p", 1.0))
-        if 0.0 < top_p < 1.0:
-            sorted_logits, sorted_idx = torch.sort(logits, descending=True)
-            probs = torch.softmax(sorted_logits, dim=-1)
-            cumprob = torch.cumsum(probs, dim=-1)
-            keep = cumprob <= top_p
-            keep[0] = True
-            drop_idx = sorted_idx[~keep]
-            logits[drop_idx] = float("-inf")
-        probs = torch.softmax(logits, dim=-1)
-        return int(torch.multinomial(probs, num_samples=1).item())
+        # Deterministic selection: argmax of the (penalty-adjusted) logits.
+        return int(logits.argmax().item())
+        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
+        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
+        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
+        # if top_k > 0 and top_k < vocab:
+        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
+        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
+        # if 0.0 < top_p < 1.0:
+        #     sl, si = torch.sort(logits, descending=True)
+        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
+        #     logits[si[~keep]] = float("-inf")
+        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
 
     # ---- run path (dynamic-PBI single bin: preamble + jump_abs) -------------
     def run_llama(self) -> None:
@@ -431,11 +425,11 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
 
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
-        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
-        _temperature = float(getattr(self, "temperature", 0.0))
+        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
+        # repetition penalty turns on to break long-context loops.
         _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
+        _greedy_until = int(getattr(self, "greedy_until", 0))
 
         import shutil
         _use_status = sys.stdout.isatty()
@@ -482,7 +476,10 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            if _use_logit_readback:
+            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
+            # repetition penalty (read logits, argmax of penalized logits).
+            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
+            if _penalty_active:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -539,20 +536,24 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Sampling — defaults match llama3.2_1b_test.py (temp 0.4 + top-k 40 fixes FPGA
-    # arithmetic errors while keeping long-context clean; see notes §D).
-    parser.add_argument("--temperature", type=float, default=0.0,
-                        help="0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, correct math, loop-free; the default). >0 = sampling. Default 0.")
-    parser.add_argument("--top-k", type=int, default=40,
-                        help="Top-k filter (0=off). Caps the tail so wrong tokens can't be sampled. Default 40.")
-    parser.add_argument("--top-p", type=float, default=0.9, help="Top-p (nucleus) filter. Default 0.9.")
-    parser.add_argument("--repetition-penalty", type=float, default=1.1,
-                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.1.")
+    # Decode defaults match llama3.2_1b_test.py: deterministic hybrid (greedy 512 + rep-pen 1.2);
+    # see notes §D. (Sampling controls disabled below.)
+    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
+    #     sample_next_token() to re-enable stochastic sampling ---
+    # parser.add_argument("--temperature", type=float, default=0.0, help=">0 enables sampling.")
+    # parser.add_argument("--top-k", type=int, default=40, help="Top-k filter (sampling only).")
+    # parser.add_argument("--top-p", type=float, default=0.9, help="Top-p nucleus filter (sampling only).")
+    parser.add_argument("--repetition-penalty", type=float, default=1.2,
+                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
     parser.add_argument("--rep-window", type=int, default=256,
                         help="Repetition penalty look-back window in tokens. Default 256.")
     parser.add_argument("--rep-decay", type=float, default=0.97,
                         help="Recency decay for the repetition penalty (per-token age). Default 0.97.")
-    parser.add_argument("--seed", type=int, default=None, help="RNG seed for reproducible sampling.")
+    # parser.add_argument("--seed", type=int, default=None, help="RNG seed (sampling only).")
+    parser.add_argument("--greedy-until", type=int, default=512,
+                        help="Hybrid decode (temp 0): pure greedy for the first N decoded tokens "
+                             "(correct math/reasoning), then the repetition penalty breaks long-context "
+                             "loops. 0 = penalty from the start. Default 512.")
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -587,22 +588,19 @@ def main():
         prefill_seq = tuple(cfg["default_prefill_tokens"])
 
     ue.prefill_seq = prefill_seq
-    ue.temperature = float(args.temperature)
-    ue.top_k = int(args.top_k)
-    ue.top_p = float(args.top_p)
+    # Sampling controls (temperature/top_k/top_p/seed) disabled — decode is deterministic.
     ue.repetition_penalty = float(args.repetition_penalty)
     ue.rep_window = int(args.rep_window)
     ue.rep_decay = float(args.rep_decay)
+    ue.greedy_until = int(args.greedy_until)
     ue._generated_tokens = list(prefill_seq)
-    if args.seed is not None and ue.temperature > 0:
-        torch.manual_seed(args.seed)
-    if ue.temperature > 0:
-        _original_print(f"Sampling: temperature={ue.temperature}  top_k={ue.top_k}  top_p={ue.top_p}  "
-                        f"repetition_penalty={ue.repetition_penalty}  rep_window={ue.rep_window}  "
-                        f"rep_decay={ue.rep_decay}  seed={args.seed}")
-        if ue.repetition_penalty != 1.0:
-            _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
-            _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
+    _penalty_used = ue.repetition_penalty != 1.0
+    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
+             if _penalty_used else "no penalty")
+    _original_print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
+    if _penalty_used:
+        _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
+        _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
 
     ue.run_llama()
     ue.clear_dram()

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -989,17 +989,18 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            # LM head: in greedy mode the HW argmax register is populated as a
-            # pipeline side-effect, so skip the full vocab-logits writeback to DRAM
-            # (write_back_disable). For sampling (temperature > 0) writeback MUST be
-            # enabled so the host can DMA the logits row back for repetition-penalty /
-            # top-k / top-p / multinomial in sample_next_token(). This is a compile-time
-            # gate reading ue.temperature, which main() sets before compile_llama().
-            _greedy_lm_head = float(getattr(self, "temperature", 0.0)) <= 0
+            # LM head: the full vocab-logits writeback to DRAM is needed whenever the host
+            # reads logits — sampling (temp>0) OR penalized greedy (temp 0 + rep_pen!=1, which
+            # argmaxes the penalty-adjusted logits). Disable it ONLY for pure unpenalized greedy
+            # (temp 0 + rep_pen 1.0), where the HW argmax register suffices. This compile-time
+            # gate MUST match the decode dispatch (_use_logit_readback); else the host reads a
+            # never-written LOGITS_DRAM → NaN/garbage ("!!!"). main() sets both before compile.
+            _need_logit_writeback = (float(getattr(self, "temperature", 0.0)) > 0
+                                     or float(getattr(self, "repetition_penalty", 1.0)) != 1.0)
             total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
-                write_back_disable=_greedy_lm_head)
+                write_back_disable=not _need_logit_writeback)
 
         self.generate_instruction_halt()
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
@@ -1255,7 +1256,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         # Falls back to the full prompt when run without main() (e.g. run_from_bin).
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        _sampling = float(getattr(self, "temperature", 0.0)) > 0
+        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
+        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
+        _temperature = float(getattr(self, "temperature", 0.0))
+        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1311,9 +1316,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # Sampling reads the full logits row (writeback enabled at compile time);
-            # greedy uses the HW argmax register (no host readback).
-            if _sampling:
+            # readback path = sampling or penalized greedy (temp<=0 -> argmax of the
+            # penalty-adjusted logits); pure HW argmax only for unpenalized greedy.
+            if _use_logit_readback:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -1348,24 +1353,20 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Sampling DEFAULTS tuned for the quantized FPGA model (temp 0.6 / top-p 0.9 /
-    # rep-penalty 1.2, recency-decayed + structural-exempt). Two findings drive this:
-    #   - Greedy (temp 0) loops on the FPGA: its reduced-precision arithmetic perturbs
-    #     the logits enough that argmax falls into repetition (greedy is fine on a clean
-    #     4-bit GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
-    #     => need temperature > 0 to escape the loops.
-    #   - High temp (0.7) samples from the 4-bit-noisy tail and drifts. => keep it modest.
-    # 0.6 is the compromise: enough randomness (with the repetition penalty) to escape
-    # the arithmetic-induced loops, low enough to stay near the robust argmax region.
-    # Pass --temperature 0 for deterministic greedy (HW argmax, no logit readback).
-    parser.add_argument('--temperature', type=float, default=0.6,
-                        help='Sampling temperature (0=greedy via HW argmax; >0 enables SW sampling). Default 0.6.')
-    parser.add_argument('--top-k', type=int, default=0,
-                        help='Top-k filter (0=disabled). Active only when --temperature > 0. Default 0.')
+    # Decode default: penalized greedy (temperature 0 + repetition penalty 1.1) — argmax of
+    # the penalty-adjusted logits: deterministic and arithmetic-accurate, with the penalty
+    # preventing loops on long generations. --temperature > 0 switches to stochastic sampling
+    # (top-k / top-p apply only then). Rationale: notes_llama3.2_1b.md §D.
+    parser.add_argument('--temperature', type=float, default=0.0,
+                        help='0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, '
+                             'correct math, loop-free; the default). >0 = stochastic sampling. Default 0.')
+    parser.add_argument('--top-k', type=int, default=40,
+                        help='Top-k filter (0=disabled). Only used when --temperature > 0 (ignored by penalized '
+                             'greedy). Caps the sampling tail. Default 40.')
     parser.add_argument('--top-p', type=float, default=0.9,
                         help='Top-p (nucleus) filter, 0<p<1 keeps the smallest set with cumulative prob >= p. Default 0.9.')
-    parser.add_argument('--repetition-penalty', type=float, default=1.2,
-                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.2.')
+    parser.add_argument('--repetition-penalty', type=float, default=1.1,
+                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.1.')
     parser.add_argument('--rep-window', type=int, default=256,
                         help='Repetition penalty considers only the last N tokens (and never penalizes '
                              'punctuation/whitespace/special tokens). Smaller = less structural starvation '

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -989,14 +989,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            # LM head: the full vocab-logits writeback to DRAM is needed whenever the host
-            # reads logits — sampling (temp>0) OR penalized greedy (temp 0 + rep_pen!=1, which
-            # argmaxes the penalty-adjusted logits). Disable it ONLY for pure unpenalized greedy
-            # (temp 0 + rep_pen 1.0), where the HW argmax register suffices. This compile-time
-            # gate MUST match the decode dispatch (_use_logit_readback); else the host reads a
-            # never-written LOGITS_DRAM → NaN/garbage ("!!!"). main() sets both before compile.
-            _need_logit_writeback = (float(getattr(self, "temperature", 0.0)) > 0
-                                     or float(getattr(self, "repetition_penalty", 1.0)) != 1.0)
+            # LM head: write the full vocab-logits row to DRAM only when the host reads it —
+            # i.e. when the repetition penalty is on (penalized greedy reads + argmaxes the
+            # penalty-adjusted logits). Pure unpenalized greedy (rep_pen 1.0) uses the HW argmax
+            # register, so writeback is disabled. This compile-time gate MUST match the decode
+            # readback condition; else the host reads a never-written LOGITS_DRAM → garbage ("!!!").
+            _need_logit_writeback = float(getattr(self, "repetition_penalty", 1.0)) != 1.0
             total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
@@ -1156,29 +1154,19 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 factor = rep_pen ** weight[nz]                        # >= 1, grows with recency*count
                 v = logits[nz]
                 logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        # Temperature
-        temp = float(getattr(self, "temperature", 1.0))
-        if temp <= 0:
-            return int(logits.argmax().item())
-        logits = logits / temp
-        # Top-k
-        top_k = int(getattr(self, "top_k", 0) or 0)
-        if top_k > 0 and top_k < vocab:
-            kth = torch.topk(logits, top_k).values[-1]
-            logits[logits < kth] = float("-inf")
-        # Top-p (nucleus)
-        top_p = float(getattr(self, "top_p", 1.0))
-        if 0.0 < top_p < 1.0:
-            sorted_logits, sorted_idx = torch.sort(logits, descending=True)
-            probs = torch.softmax(sorted_logits, dim=-1)
-            cumprob = torch.cumsum(probs, dim=-1)
-            # mask tokens whose cumulative prob > top_p (keep at least 1)
-            keep = cumprob <= top_p
-            keep[0] = True
-            drop_idx = sorted_idx[~keep]
-            logits[drop_idx] = float("-inf")
-        probs = torch.softmax(logits, dim=-1)
-        return int(torch.multinomial(probs, num_samples=1).item())
+        # Deterministic selection: argmax of the (penalty-adjusted) logits.
+        return int(logits.argmax().item())
+        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
+        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
+        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
+        # if top_k > 0 and top_k < vocab:
+        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
+        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
+        # if 0.0 < top_p < 1.0:
+        #     sl, si = torch.sort(logits, descending=True)
+        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
+        #     logits[si[~keep]] = float("-inf")
+        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
 
     def run_llama(self) -> None:
         """Load the unified instruction image and run prefill + decoder loop.
@@ -1256,11 +1244,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         # Falls back to the full prompt when run without main() (e.g. run_from_bin).
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
-        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
-        _temperature = float(getattr(self, "temperature", 0.0))
+        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
+        # repetition penalty turns on to break long-context loops.
         _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
+        _greedy_until = int(getattr(self, "greedy_until", 0))
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1316,9 +1304,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # readback path = sampling or penalized greedy (temp<=0 -> argmax of the
-            # penalty-adjusted logits); pure HW argmax only for unpenalized greedy.
-            if _use_logit_readback:
+            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
+            # repetition penalty (read logits, argmax of penalized logits).
+            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
+            if _penalty_active:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -1353,20 +1342,16 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Decode default: penalized greedy (temperature 0 + repetition penalty 1.1) — argmax of
-    # the penalty-adjusted logits: deterministic and arithmetic-accurate, with the penalty
-    # preventing loops on long generations. --temperature > 0 switches to stochastic sampling
-    # (top-k / top-p apply only then). Rationale: notes_llama3.2_1b.md §D.
-    parser.add_argument('--temperature', type=float, default=0.0,
-                        help='0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, '
-                             'correct math, loop-free; the default). >0 = stochastic sampling. Default 0.')
-    parser.add_argument('--top-k', type=int, default=40,
-                        help='Top-k filter (0=disabled). Only used when --temperature > 0 (ignored by penalized '
-                             'greedy). Caps the sampling tail. Default 40.')
-    parser.add_argument('--top-p', type=float, default=0.9,
-                        help='Top-p (nucleus) filter, 0<p<1 keeps the smallest set with cumulative prob >= p. Default 0.9.')
-    parser.add_argument('--repetition-penalty', type=float, default=1.1,
-                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.1.')
+    # Decode is a position-gated hybrid (deterministic): PURE greedy for the first
+    # `greedy_until` (512) decoded tokens — correct math/reasoning, which lands early — then
+    # repetition penalty 1.2 to break long-context loops. Rationale: notes_llama3.2_1b.md §D.
+    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
+    #     sample_next_token() to re-enable stochastic sampling ---
+    # parser.add_argument('--temperature', type=float, default=0.0, help='>0 enables sampling.')
+    # parser.add_argument('--top-k', type=int, default=40, help='Top-k filter (sampling only).')
+    # parser.add_argument('--top-p', type=float, default=0.9, help='Top-p nucleus filter (sampling only).')
+    parser.add_argument('--repetition-penalty', type=float, default=1.2,
+                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Active after greedy_until in hybrid mode. Default 1.2.')
     parser.add_argument('--rep-window', type=int, default=256,
                         help='Repetition penalty considers only the last N tokens (and never penalizes '
                              'punctuation/whitespace/special tokens). Smaller = less structural starvation '
@@ -1376,8 +1361,11 @@ def main():
                              'k tokens ago contributes rep_decay**k to its penalty weight. 1.0 = pure '
                              'frequency (no decay); lower = only very recent repeats matter. Default 0.97 '
                              '(half-life ~23 tokens).')
-    parser.add_argument('--seed', type=int, default=None,
-                        help='RNG seed for reproducible sampling (only when --temperature > 0).')
+    # parser.add_argument('--seed', type=int, default=None, help='RNG seed (sampling only).')
+    parser.add_argument('--greedy-until', type=int, default=512,
+                        help='Hybrid decode (temp 0 only): pure greedy for the first N decoded tokens '
+                             '(correct math/reasoning, which lands early), then the repetition penalty '
+                             'turns on to break long-context loops. 0 = penalty from the start. Default 512.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1417,27 +1405,24 @@ def main():
 
     ue.prefill_seq = prefill_seq
 
-    # Sampling config (consumed by sample_next_token / the LM-head writeback gate).
-    # Must be set BEFORE compile_llama() so the decoder bin is compiled with logits
-    # writeback ON when temperature > 0. Mirrors qwen3_1.7b.
-    ue.temperature = float(args.temperature)
-    ue.top_k = int(args.top_k)
-    ue.top_p = float(args.top_p)
+    # Decode config (consumed by the decode loop / repetition penalty / LM-head writeback
+    # gate). Must be set BEFORE compile_llama() so the bin is compiled with logits writeback
+    # ON when a repetition penalty is used. Sampling controls (temperature/top_k/top_p/seed)
+    # are disabled — decode is deterministic.
     ue.repetition_penalty = float(args.repetition_penalty)
     ue.rep_window = int(args.rep_window)
     ue.rep_decay = float(args.rep_decay)
+    ue.greedy_until = int(args.greedy_until)
     ue._generated_tokens = list(prefill_seq)   # seed repetition penalty with the prompt
-    if args.seed is not None and ue.temperature > 0:
-        torch.manual_seed(args.seed)
-    if ue.temperature > 0:
-        print(f"Sampling: temperature={ue.temperature}  top_k={ue.top_k}  "
-              f"top_p={ue.top_p}  repetition_penalty={ue.repetition_penalty}  "
-              f"rep_window={ue.rep_window}  rep_decay={ue.rep_decay}  seed={args.seed}")
-        # Precompute the structural-token exemption set upfront (one vocab scan) so it
-        # doesn't stall the first decode step.
-        if ue.repetition_penalty != 1.0:
-            _n = len(ue._structural_token_ids())
-            print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+    _penalty_used = ue.repetition_penalty != 1.0
+    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
+             if _penalty_used else "no penalty")
+    print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
+    # Precompute the structural-token exemption set upfront (one vocab scan) so it
+    # doesn't stall the first decode step where the penalty turns on.
+    if _penalty_used:
+        _n = len(ue._structural_token_ids())
+        print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
 
     print("\n--- Compiling ---")
     timer = time.perf_counter()

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -46,6 +46,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(SCRIPT_DIR)))
 import user_dma_core
 from user_dma_core import DMA_DEVICE_H2C, TYPE, UE_MODE, UE_FMAX_CONTEXT_SIZE, UE_VECTOR_SIZE, URAM_NEAR_FULL_ELEMENTS, URAM_FULL_ELEMENTS, set_dma_device, ue_35bit_addr_shifter, INSTRUCTION_SIZE_BYTES
 from user_dma_core import UnifiedEngine
+# Canonical, HW-aligned 4-bit codec shared across all model templates.
+# 1B uses pure FP4 (E2M1) — the best 4-bit scheme for this model by WikiText-2
+# perplexity; see src/models/llama3.2_1b/compare/summary.md. FP4 blocks are stored
+# in the HW 4-bit container with a positive scale, so the FPGA's IF4 dispatch reads
+# them as FP4. (3B uses MixMSE IF4 instead — the scheme is chosen per model.)
+from quant_lib import quantize_fp4
 
 # --- BROAD PRINT SUPPRESSION FOR LIBRARIES ---
 import builtins
@@ -67,24 +73,6 @@ def _parse_offset(val) -> int:
     if isinstance(val, str):
         return int(val, 0)
     return int(val)
-
-def _quantize_bf16_to_int4_packed(weight_bf16: torch.Tensor, block_size: int = 64) -> tuple[bytes, bytes]:
-    """Quantize bf16 weight (N_w, K_w) to INT4 packed + scale per block of 64 along K. Returns (data_bytes, scale_bytes)."""
-    w = weight_bf16.detach().cpu().float().reshape(-1)
-    N_w, K_w = weight_bf16.shape
-    assert K_w % block_size == 0
-    w_blocks = w.reshape(N_w, K_w // block_size, block_size)
-    scale = w_blocks.abs().amax(dim=-1).clamp(min=1e-8) / 7.0
-    # IF4 dispatches INT4 vs FP4 by bf16 scale sign (negative=INT4 codebook).
-    scale_bf16 = (-scale).to(torch.bfloat16)
-    w_int8 = (w_blocks / scale.unsqueeze(-1)).round().clamp(-8, 7).to(torch.int8)
-    w_nibbles = w_int8.numpy().astype(np.int16) & 0x0F
-    low = w_nibbles[:, :, 0::2].reshape(N_w, -1)
-    high = w_nibbles[:, :, 1::2].reshape(N_w, -1)
-    packed = (high << 4) | low
-    data_bytes = packed.astype(np.uint8).tobytes()
-    scale_bytes = scale_bf16.contiguous().view(torch.uint8).numpy().tobytes()
-    return (data_bytes, scale_bytes)
 
 def _rope_kv_perm(num_kv_heads: int, actual_head_dim: int) -> torch.Tensor:
     """Return the 1-D index permutation that reorders a combined KV-head vector from
@@ -117,6 +105,9 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
     paths = cfg["paths"]
     paths_full = os.path.join(script_dir, paths["weights_bin"])
     out_path = output_path or paths_full
+
+    _q = cfg["special"]["quantization"]
+    block_size = _q.get("block_size", 64)
 
     model, model_dir = _ensure_hf_model(script_dir, cfg)
     gamma_offset = cfg["special"]["rms_norm"]["gamma_offset"]  # 0.0 for LLaMA
@@ -189,17 +180,17 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
 
         region_writes = [
             (gamma_in, "bf16"),
-            (q_w, "int4"),
-            (k_w, "int4"),
-            (v_w, "int4"),
+            (q_w, "if4"),
+            (k_w, "if4"),
+            (v_w, "if4"),
             (gamma_q, "bf16"),
             (gamma_k, "bf16"),
-            (o_w, "int4"),
+            (o_w, "if4"),
             (gamma_post, "bf16"),
             (gamma_ffn, "bf16"),
-            (up_w, "int4"),
-            (gate_w, "int4"),
-            (down_w, "int4"),
+            (up_w, "if4"),
+            (gate_w, "if4"),
+            (down_w, "if4"),
             (gamma_post_ffn, "bf16"),
         ]
         j = 0
@@ -211,10 +202,10 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
             sz = weight_defs[sz_key]
             file_off = off + layer_idx * LAYER_WEIGHT_SIZE
             tensor, kind = region_writes[j]
-            if kind == "int4":
+            if kind == "if4":
                 next_key = blk0_structure[i + 1]["key"]
                 data_sz = weight_defs[f"{next_key}_SIZE"]
-                data_bytes, scale_bytes = _quantize_bf16_to_int4_packed(tensor)
+                data_bytes, scale_bytes = quantize_fp4(tensor, block_size=block_size)
                 scale_padded = (scale_bytes + b"\x00" * sz)[:sz]
                 data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
                 write_at(file_off, scale_padded)
@@ -266,7 +257,7 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
     lm_head_w = model.get_input_embeddings().weight.detach().cpu().to(torch.bfloat16)
     scale_sz = weight_defs["LM_HEAD_WEIGHT_SCALE_SIZE"]
     data_sz = weight_defs["LM_HEAD_WEIGHT_DATA_SIZE"]
-    data_bytes, scale_bytes = _quantize_bf16_to_int4_packed(lm_head_w)
+    data_bytes, scale_bytes = quantize_fp4(lm_head_w, block_size=block_size)
     scale_padded = (scale_bytes + b"\x00" * scale_sz)[:scale_sz]
     data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
     write_at(weight_defs["LM_HEAD_WEIGHT_SCALE"], scale_padded)
@@ -1361,9 +1352,9 @@ def main():
     # rep-penalty 1.2, recency-decayed + structural-exempt). Two findings drive this:
     #   - Greedy (temp 0) loops on the FPGA: its reduced-precision arithmetic perturbs
     #     the logits enough that argmax falls into repetition (greedy is fine on a clean
-    #     int4 GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
+    #     4-bit GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
     #     => need temperature > 0 to escape the loops.
-    #   - High temp (0.7) samples from the int4-noisy tail and drifts. => keep it modest.
+    #   - High temp (0.7) samples from the 4-bit-noisy tail and drifts. => keep it modest.
     # 0.6 is the compromise: enough randomness (with the repetition penalty) to escape
     # the arithmetic-induced loops, low enough to stay near the robust argmax region.
     # Pass --temperature 0 for deterministic greedy (HW argmax, no logit readback).

--- a/models/llama3.2_3b/README.md
+++ b/models/llama3.2_3b/README.md
@@ -1,0 +1,79 @@
+# LLaMA 3.2 3B
+
+LLaMA 3.2 3B prefill + decode on the accelerator. Same architecture family as 1B,
+but 28 layers, hidden=3072, 8 KV heads, group_size=3, **per-head RoPE (N=128)**.
+4096-token context, dynamic-PBI single instruction bin, sampling decode.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `llama3.2_3b_test.py`         | First run: downloads the HF model, generates the weight bin + unified instruction bin, then runs. Later runs reuse the cached bins. |
+| `llama3.2_3b_run_from_bin.py` | Runtime-only: loads the pre-built bins and runs. No HuggingFace access, no recompile, no import from the test script. Fails loudly if a required artifact is missing. |
+| `llama3.2_3b_config.json`     | Model dims + weight-bin region offsets. |
+| `llama3.2_3b_bin/`            | Generated artifacts (created on first run). |
+
+## Usage
+
+Run from the repo root (so `user_dma_core` is on the path), or from this folder.
+
+```bash
+# Default prompt
+python llama3.2_3b_test.py
+python llama3.2_3b_run_from_bin.py
+
+# Custom prompt (uses the model's chat template)
+python llama3.2_3b_test.py --prompt "What is 2+2?"
+
+# Sampling controls (defaults: temperature 0.6, top-p 0.9, repetition-penalty 1.2)
+python llama3.2_3b_test.py --prompt "..." --temperature 0.6 --top-p 0.9 --seed 7
+python llama3.2_3b_test.py --prompt "..." --temperature 0        # greedy (HW argmax)
+
+# DMA device / clock period
+python llama3.2_3b_test.py --dev xdma0 --cycle 5.88
+```
+
+Both scripts share `--prompt`, `--dev`, `--cycle`, and the sampling flags
+`--temperature`, `--top-k`, `--top-p`, `--repetition-penalty`, `--rep-window`,
+`--rep-decay`, `--seed`. Prompts up to 128 tokens are supported (`prefill_context_size`).
+
+## First run vs cached run
+
+| Step | First `test.py` run | Cached `test.py` / any `run_from_bin.py` |
+|---|---|---|
+| HF model download | once (cached after) | skipped |
+| Build weight bin (quantize) | ~few min | skipped |
+| Compile unified instruction bin (~63 MB) | ~8 s | skipped — loaded from disk |
+| Prefill + decode | runs | runs |
+
+## Forcing a rebuild
+
+```bash
+# Recompile the instruction bin (e.g. after editing the compile path)
+rm llama3.2_3b_bin/llama3.2_3b_instruction.bin llama3.2_3b_bin/llama3.2_3b_instruction.json
+
+# Re-quantize the weight bin (from the cached HF model)
+rm llama3.2_3b_bin/weights_llama3.2_3b_hf.bin
+```
+
+## Shipping `run_from_bin`
+
+To run on a machine with no HuggingFace access / no internet, ship
+`llama3.2_3b_run_from_bin.py`, `llama3.2_3b_config.json`, and the
+`llama3.2_3b_bin/` artifacts — the weight bin, the instruction bin + meta, and the
+tokenizer files under `Llama-3.2-3B-Instruct/` (`tokenizer.json` /
+`tokenizer_config.json`; the model safetensors are **not** needed). `run_from_bin.py`
+imports nothing from the test script and never contacts HuggingFace.
+
+## DRAM layout (4096 context)
+
+Full-4 GB layout set in the engine `__init__` (params is bigger than 1B, so the
+tensor base moves up vs 1B):
+
+| Region | Base | Size | Used @ 4096 |
+|---|---|---|---|
+| Params  | `0x00000000` | 1.75 GiB | ~1.61 GiB (weights + RoPE) |
+| Tensor  | `0x70000000` | 1.75 GiB | ~1.59 GiB (KV cache + activations) |
+| Program | `0xE0000000` | 512 MiB  | ~63 MB (instruction bin) |
+
+Total ~3.3 GB of 4 GB. (The HF embedding stays host-side.)

--- a/models/llama3.2_3b/llama3.2_3b_config.json
+++ b/models/llama3.2_3b/llama3.2_3b_config.json
@@ -1,0 +1,357 @@
+{
+  "_template_note": "Llama-3.2-3B-Instruct config. Same architecture as 1B (GQA, no q/k norm, no post-attn/post-mlp norm, tied lm_head) but: hidden 3072, layers 28, head_dim_actual 128, num_kv_heads 8, group_size 3, mlp 8192. Because actual_head_dim=128 satisfies rope_hf_core N>=128 per head, 3B uses per-head rope (N=128) rather than the 1B grouped layout (N=512). See notes/notes_llama3.2_3b.md.",
+  "fixed_isa_regs": {
+    "V_CACHE_SIZE_REG": 1,
+    "TMP_REG": 2,
+    "ROPE_SIZE_REG": 3,
+    "GPR_BUCKET_IDX_REG": 4,
+    "GPR_SEQ_LEN_REG": 5
+  },
+  "file_info": {
+    "layer_size": 53506048,
+    "num_layers": 28,
+    "head_dim": 1024,
+    "actual_head_dim": 128,
+    "hidden_size": 3072,
+    "embedding_vocab": 128256,
+    "group_size": 3,
+    "mlp_elements": 8192,
+    "bytes_per_element": 2
+  },
+  "model": {
+    "max_context_size": 4096,
+    "prefill_context_size": 128,
+    "end_of_turn_token_id": 128009,
+    "rope_global_layers": []
+  },
+  "paths": {
+    "weights_bin": "llama3.2_3b_bin/weights_llama3.2_3b_hf.bin",
+    "hf_model_dir": "llama3.2_3b_bin/Llama-3.2-3B-Instruct",
+    "hf_model_repo": "meta-llama/Llama-3.2-3B-Instruct",
+    "instruction_bin": "llama3.2_3b_bin/llama3.2_3b_instruction.bin",
+    "instruction_meta": "llama3.2_3b_bin/llama3.2_3b_instruction.json"
+  },
+  "default_prefill_tokens": [
+    128000,
+    128006,
+    9125,
+    128007,
+    271,
+    38766,
+    1303,
+    33025,
+    2696,
+    25,
+    6790,
+    220,
+    2366,
+    18,
+    198,
+    15724,
+    2696,
+    25,
+    220,
+    975,
+    2947,
+    220,
+    2366,
+    21,
+    271,
+    128009,
+    128006,
+    882,
+    128007,
+    271,
+    87,
+    10,
+    18,
+    28,
+    20,
+    11,
+    1148,
+    374,
+    865,
+    30,
+    128009,
+    128006,
+    78191,
+    128007,
+    271
+  ],
+  "layers": {
+    "structure": [
+      {
+        "key": "BLK0_ATTN_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_PRE_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_ATTN_Q_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_Q_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_Q_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_Q_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_ATTN_K_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_K_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_K_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_K_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_ATTN_V_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_V_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_V_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_V_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_ATTN_Q_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_Q_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_ATTN_K_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_K_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_ATTN_OUTPUT_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE"
+      },
+      {
+        "key": "BLK0_ATTN_OUTPUT_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT"
+      },
+      {
+        "key": "BLK0_POST_ATTENTION_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_POST_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_FFN_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_FFN_NORM_GAMMA"
+      },
+      {
+        "key": "BLK0_FFN_UP_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_MLP_UP_SCALE"
+      },
+      {
+        "key": "BLK0_FFN_UP_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_MLP_UP_QUANT"
+      },
+      {
+        "key": "BLK0_FFN_GATE_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_MLP_GATE_SCALE"
+      },
+      {
+        "key": "BLK0_FFN_GATE_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_MLP_GATE_QUANT"
+      },
+      {
+        "key": "BLK0_FFN_DOWN_WEIGHT_SCALE",
+        "type": "bf16_scale",
+        "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_SCALE"
+      },
+      {
+        "key": "BLK0_FFN_DOWN_WEIGHT_DATA",
+        "type": "int4",
+        "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_QUANT"
+      },
+      {
+        "key": "BLK0_POST_FFW_NORM_WEIGHT",
+        "type": "bf16",
+        "attr": "DRAM_ADDR_LAYER0_POST_FFW_NORM_GAMMA"
+      }
+    ],
+    "non_layer": [
+      {
+        "key": "ROPE_LOCAL",
+        "attr": "DRAM_ADDR_ROPE_LOCAL"
+      },
+      {
+        "key": "ROPE_GLOBAL",
+        "attr": "DRAM_ADDR_ROPE_GLOBAL"
+      },
+      {
+        "key": "OUTPUT_NORM_WEIGHT",
+        "attr": "DRAM_ADDR_OUTPUT_NORM_GAMMA"
+      },
+      {
+        "key": "LM_HEAD_WEIGHT_SCALE",
+        "attr": "DRAM_ADDR_LM_HEAD_SCALE"
+      },
+      {
+        "key": "LM_HEAD_WEIGHT_DATA",
+        "attr": "DRAM_ADDR_LM_HEAD_QUANT"
+      }
+    ]
+  },
+  "regions": {
+    "BLK0_ATTN_NORM_WEIGHT": {
+      "offset": "0x2F000000",
+      "size": 6144,
+      "type": "bf16"
+    },
+    "BLK0_ATTN_Q_WEIGHT_SCALE": {
+      "offset": "0x2F001800",
+      "size": 294912,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_Q_WEIGHT_DATA": {
+      "offset": "0x2F049800",
+      "size": 4718592,
+      "type": "int4"
+    },
+    "BLK0_ATTN_K_WEIGHT_SCALE": {
+      "offset": "0x2F4C9800",
+      "size": 98304,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_K_WEIGHT_DATA": {
+      "offset": "0x2F4E1800",
+      "size": 1572864,
+      "type": "int4"
+    },
+    "BLK0_ATTN_V_WEIGHT_SCALE": {
+      "offset": "0x2F661800",
+      "size": 98304,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_V_WEIGHT_DATA": {
+      "offset": "0x2F679800",
+      "size": 1572864,
+      "type": "int4"
+    },
+    "BLK0_ATTN_Q_NORM_WEIGHT": {
+      "offset": "0x2F7F9800",
+      "size": 2048,
+      "type": "bf16"
+    },
+    "BLK0_ATTN_K_NORM_WEIGHT": {
+      "offset": "0x2F7FA000",
+      "size": 2048,
+      "type": "bf16"
+    },
+    "BLK0_ATTN_OUTPUT_WEIGHT_SCALE": {
+      "offset": "0x2F7FA800",
+      "size": 294912,
+      "type": "bf16_scale"
+    },
+    "BLK0_ATTN_OUTPUT_WEIGHT_DATA": {
+      "offset": "0x2F842800",
+      "size": 4718592,
+      "type": "int4"
+    },
+    "BLK0_POST_ATTENTION_NORM_WEIGHT": {
+      "offset": "0x2FCC2800",
+      "size": 6144,
+      "type": "bf16"
+    },
+    "BLK0_FFN_NORM_WEIGHT": {
+      "offset": "0x2FCC4000",
+      "size": 6144,
+      "type": "bf16"
+    },
+    "BLK0_FFN_UP_WEIGHT_SCALE": {
+      "offset": "0x2FCC5800",
+      "size": 786432,
+      "type": "bf16_scale"
+    },
+    "BLK0_FFN_UP_WEIGHT_DATA": {
+      "offset": "0x2FD85800",
+      "size": 12582912,
+      "type": "int4"
+    },
+    "BLK0_FFN_GATE_WEIGHT_SCALE": {
+      "offset": "0x30985800",
+      "size": 786432,
+      "type": "bf16_scale"
+    },
+    "BLK0_FFN_GATE_WEIGHT_DATA": {
+      "offset": "0x30A45800",
+      "size": 12582912,
+      "type": "int4"
+    },
+    "BLK0_FFN_DOWN_WEIGHT_SCALE": {
+      "offset": "0x31645800",
+      "size": 786432,
+      "type": "bf16_scale"
+    },
+    "BLK0_FFN_DOWN_WEIGHT_DATA": {
+      "offset": "0x31705800",
+      "size": 12582912,
+      "type": "int4"
+    },
+    "BLK0_POST_FFW_NORM_WEIGHT": {
+      "offset": "0x32305800",
+      "size": 6144,
+      "type": "bf16"
+    }
+  },
+  "non_layer_regions": {
+    "OUTPUT_NORM_WEIGHT": {
+      "offset": "0x884C4000",
+      "size": 6144
+    },
+    "LM_HEAD_WEIGHT_SCALE": {
+      "offset": "0x884C5800",
+      "size": 12312576
+    },
+    "LM_HEAD_WEIGHT_DATA": {
+      "offset": "0x89083800",
+      "size": 197001216
+    },
+    "ROPE_LOCAL": {
+      "offset": "0x95000000",
+      "size": 16777216
+    },
+    "ROPE_GLOBAL": {
+      "offset": "0x96000000",
+      "size": 16777216
+    }
+  },
+  "special": {
+    "embedding": {
+      "token_embd_offset": "0x0",
+      "token_embd_size": "0x2F000000",
+      "vocab_size": 128256,
+      "embedding_dim": 3072,
+      "scale": 0.5
+    },
+    "rope": {
+      "head_dim": 1024,
+      "num_positions": 4096,
+      "theta": 500000.0,
+      "local_base": 500000.0
+    },
+    "quantization": {
+      "block_size": 64,
+      "bits": 4,
+      "range": [
+        -8,
+        7
+      ]
+    },
+    "rms_norm": {
+      "gamma_offset": 0.0
+    }
+  }
+}

--- a/models/llama3.2_3b/llama3.2_3b_config.json
+++ b/models/llama3.2_3b/llama3.2_3b_config.json
@@ -92,7 +92,7 @@
       },
       {
         "key": "BLK0_ATTN_Q_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_Q_PROJ_QUANT"
       },
       {
@@ -102,7 +102,7 @@
       },
       {
         "key": "BLK0_ATTN_K_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_K_PROJ_QUANT"
       },
       {
@@ -112,7 +112,7 @@
       },
       {
         "key": "BLK0_ATTN_V_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_V_PROJ_QUANT"
       },
       {
@@ -132,7 +132,7 @@
       },
       {
         "key": "BLK0_ATTN_OUTPUT_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT"
       },
       {
@@ -152,7 +152,7 @@
       },
       {
         "key": "BLK0_FFN_UP_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_MLP_UP_QUANT"
       },
       {
@@ -162,7 +162,7 @@
       },
       {
         "key": "BLK0_FFN_GATE_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_MLP_GATE_QUANT"
       },
       {
@@ -172,7 +172,7 @@
       },
       {
         "key": "BLK0_FFN_DOWN_WEIGHT_DATA",
-        "type": "int4",
+        "type": "if4",
         "attr": "DRAM_ADDR_LAYER0_MLP_DOWN_QUANT"
       },
       {
@@ -218,7 +218,7 @@
     "BLK0_ATTN_Q_WEIGHT_DATA": {
       "offset": "0x2F049800",
       "size": 4718592,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_ATTN_K_WEIGHT_SCALE": {
       "offset": "0x2F4C9800",
@@ -228,7 +228,7 @@
     "BLK0_ATTN_K_WEIGHT_DATA": {
       "offset": "0x2F4E1800",
       "size": 1572864,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_ATTN_V_WEIGHT_SCALE": {
       "offset": "0x2F661800",
@@ -238,7 +238,7 @@
     "BLK0_ATTN_V_WEIGHT_DATA": {
       "offset": "0x2F679800",
       "size": 1572864,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_ATTN_Q_NORM_WEIGHT": {
       "offset": "0x2F7F9800",
@@ -258,7 +258,7 @@
     "BLK0_ATTN_OUTPUT_WEIGHT_DATA": {
       "offset": "0x2F842800",
       "size": 4718592,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_POST_ATTENTION_NORM_WEIGHT": {
       "offset": "0x2FCC2800",
@@ -278,7 +278,7 @@
     "BLK0_FFN_UP_WEIGHT_DATA": {
       "offset": "0x2FD85800",
       "size": 12582912,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_FFN_GATE_WEIGHT_SCALE": {
       "offset": "0x30985800",
@@ -288,7 +288,7 @@
     "BLK0_FFN_GATE_WEIGHT_DATA": {
       "offset": "0x30A45800",
       "size": 12582912,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_FFN_DOWN_WEIGHT_SCALE": {
       "offset": "0x31645800",
@@ -298,7 +298,7 @@
     "BLK0_FFN_DOWN_WEIGHT_DATA": {
       "offset": "0x31705800",
       "size": 12582912,
-      "type": "int4"
+      "type": "if4"
     },
     "BLK0_POST_FFW_NORM_WEIGHT": {
       "offset": "0x32305800",
@@ -333,8 +333,7 @@
       "token_embd_offset": "0x0",
       "token_embd_size": "0x2F000000",
       "vocab_size": 128256,
-      "embedding_dim": 3072,
-      "scale": 0.5
+      "embedding_dim": 3072
     },
     "rope": {
       "head_dim": 1024,
@@ -344,11 +343,8 @@
     },
     "quantization": {
       "block_size": 64,
-      "bits": 4,
-      "range": [
-        -8,
-        7
-      ]
+      "if4_variant": "mix",
+      "_note": "4-bit IF4 container (per-block scale sign selects INT4 vs FP4). if4_variant picks the packing policy: int=pure INT4, fp=pure FP4, mix=per-block MixMSE. 3B best=mix; see src/models/llama3.2_3b/compare/summary.md."
     },
     "rms_norm": {
       "gamma_offset": 0.0

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Llama-3.2-3B inference from pre-compiled bins — runtime-only, fully self-contained.
+
+This is the runtime counterpart to ``llama3.2_3b_test.py``. It imports **nothing**
+from the test script — only ``user_dma_core`` and a *local* tokenizer — so it can
+ship to users with just the bin files and run with no build-time code, no
+HuggingFace model, and no internet. If any required local artifact is missing it
+aborts with a clear error before touching the FPGA.
+
+Required artifacts (in ``llama3.2_3b_bin/`` next to this script — produced by
+running ``llama3.2_3b_test.py`` once on a build machine that has HF access):
+  * ``weights_llama3.2_3b_hf.bin``   IF4 layer weights + bf16 embedding
+  * ``llama_instruction.bin``        unified dynamic-PBI instruction bin (prefill + decoder)
+  * ``llama_instruction.json``       per-stage start addresses / sizes / FLOPs
+  * ``Llama-3.2-3B-Instruct/``       tokenizer files only (tokenizer.json /
+                                     tokenizer_config.json). Model weights NOT needed.
+
+Design mirrors test.py §A–§D (see notes_llama3.2_3b.md): full-4 GB DRAM layout,
+dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
+and sampling decode (recency-decayed / windowed / structural-exempt repetition
+penalty; temperature 0.6 default). The shipped bin is compiled with LM-head
+writeback enabled, so both sampling (temp>0) and greedy (temp 0) work.
+
+Usage:
+  python llama3.2_3b_run_from_bin.py
+  python llama3.2_3b_run_from_bin.py --prompt "your question"
+  python llama3.2_3b_run_from_bin.py --temperature 0 --dev xdma0     # greedy
+"""
+
+import json
+import os
+import sys
+import time
+
+import torch
+from transformers import AutoTokenizer
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+
+import user_dma_core
+from user_dma_core import (
+    DMA_DEVICE_H2C, DMA_DEVICE_C2H, UE_FMAX_CONTEXT_SIZE, UE_VECTOR_SIZE,
+    set_dma_device, ue_35bit_addr_shifter,
+)
+from user_dma_core import UnifiedEngine
+
+# Print suppression toggled inside the decode loop to keep the streamed text clean.
+import builtins
+_original_print = builtins.print
+_SILENT_MODE = False
+
+def _quiet_print(*args, **kwargs):
+    if _SILENT_MODE:
+        return
+    _original_print(*args, **kwargs)
+
+builtins.print = _quiet_print
+
+
+def _parse_offset(val) -> int:
+    if isinstance(val, str):
+        return int(val, 0)
+    return int(val)
+
+
+def _load_config(script_dir: str) -> dict:
+    config_path = os.path.join(script_dir, "llama3.2_3b_config.json")
+    with open(config_path, "r") as f:
+        cfg = json.load(f)
+    weight_defs = {"LAYER_WEIGHT_SIZE": cfg["file_info"]["layer_size"]}
+    for key, r in cfg.get("regions", {}).items():
+        weight_defs[key] = _parse_offset(r["offset"])
+        weight_defs[f"{key}_SIZE"] = r["size"]
+    for key, r in cfg.get("non_layer_regions", {}).items():
+        weight_defs[key] = _parse_offset(r["offset"])
+        weight_defs[f"{key}_SIZE"] = r["size"]
+    cfg["_weight_defs"] = weight_defs
+    return cfg
+
+
+class Llama32_3b_RunFromBin(UnifiedEngine):
+    """Self-contained bin-only runtime engine. Loads pre-built weight + instruction
+    bins and runs prefill + sampling decode. No compile, no HF model, no test import."""
+
+    def __init__(self, script_dir: str | None = None):
+        # Full 4 GB DRAM layout — MUST match llama3.2_3b_test.py at capture time:
+        # the instruction bin bakes absolute JUMP_ABS targets AND the tensor-DRAM
+        # addresses the decoder program reads, so the layout has to be identical.
+        #   params 0x00000000 | tensor 0x70000000 | program 0xE0000000
+        super().__init__(
+            params_dram_base=0x00000000,
+            tensor_dram_base=0x70000000,
+            program_dram_base=0xE0000000,
+        )
+        self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
+        self._cfg = _load_config(self.script_dir)
+        self.weight_defs = self._cfg["_weight_defs"]
+
+        fi = self._cfg["file_info"]
+        model = self._cfg["model"]
+        paths = self._cfg["paths"]
+
+        self.vector_length = fi["hidden_size"]
+        self.head_dim = fi["head_dim"]
+        self.bytes_per_element = fi["bytes_per_element"]
+        self.group_size = fi["group_size"]
+        self.mlp_elements = fi["mlp_elements"]
+        self.hf_model_dir = os.path.join(self.script_dir, paths["hf_model_dir"])
+        self.q_size = self.head_dim * self.group_size * self.bytes_per_element
+        self.k_size = self.head_dim * self.bytes_per_element
+        self.actual_head_dim = fi["actual_head_dim"]
+        self.num_kv_heads = self.head_dim // self.actual_head_dim   # 8
+        self.MAX_CONTEXT_SIZE = model["max_context_size"]
+        self.PREFILL_CONTEXT_SIZE = model["prefill_context_size"]
+        self.LAYER_SIZE = fi["num_layers"]
+        self.EMBEDDING_ELEMENTS = fi["embedding_vocab"]
+
+        # Fixed ISA registers (must match capture-time reservation). The runtime
+        # preamble writes these via ADD_SET; PBI loop counters in the bin live at
+        # max(fixed)+1 and above.
+        fixed = self._cfg.get("fixed_isa_regs", {})
+        self.V_CACHE_SIZE_REG = fixed["V_CACHE_SIZE_REG"]
+        self.TMP_REG = fixed["TMP_REG"]
+        self.ROPE_SIZE_REG = fixed["ROPE_SIZE_REG"]
+        self.gpr_bucket_idx = fixed["GPR_BUCKET_IDX_REG"]
+        self.gpr_seq_len = fixed["GPR_SEQ_LEN_REG"]
+        self._isa_reg_counter = max(fixed.values()) + 1
+        self._rope_global_layers = set(model["rope_global_layers"])
+        self._end_of_turn_token_id = model["end_of_turn_token_id"]
+
+        weights_path = os.path.join(self.script_dir, paths["weights_bin"])
+        if not os.path.exists(weights_path):
+            raise FileNotFoundError(
+                f"Weight bin not found: {weights_path}\n"
+                f"This runtime-only script cannot generate it — ship it alongside the script."
+            )
+        with open(weights_path, "rb") as f:
+            self.weight_bin = f.read()
+        self.weight_init()
+        self.tensor_init()
+
+    # ---- embedding + RoPE (from bin / config — no HF model) -----------------
+    def get_embedding_for_tokens(self, token_ids) -> torch.Tensor:
+        tid_t = torch.tensor(token_ids, dtype=torch.long)
+        out = torch.zeros(len(token_ids), self.vector_length, dtype=torch.bfloat16)
+        valid = tid_t < self.embedding_weight.shape[0]
+        out[valid] = self.embedding_weight[tid_t[valid]]
+        return out
+
+    def _load_rope_host(self) -> None:
+        """Host-compute the per-head RoPE table (N=128 per head, no tiling) and DMA it to
+        params DRAM. Deterministic from rope config — no HF lookup. Layout per row:
+        [cos_head(64), cos_head(64), -sin_head(64), sin_head(64)] = 256 bf16 per row."""
+        rope_cfg = self._cfg["special"]["rope"]
+        theta = rope_cfg["theta"]
+        local_base = rope_cfg["local_base"]
+        num_rope_positions = rope_cfg["num_positions"]
+        # 3B per-head RoPE (no KV-head tiling): D_per_head=64; per-position row =
+        # [cos_head, cos_head, -sin_head, sin_head] = 256 elems. Must match test.py.
+        D_per_head = self.actual_head_dim // 2   # 64 freqs per head
+        for name, theta_val, sz_key, attr in [
+            ("ROPE_LOCAL", local_base, "ROPE_LOCAL_SIZE", "DRAM_ADDR_ROPE_LOCAL"),
+            ("ROPE_GLOBAL", theta, "ROPE_GLOBAL_SIZE", "DRAM_ADDR_ROPE_GLOBAL"),
+        ]:
+            inv_freq = 1.0 / (theta_val ** (torch.arange(D_per_head, dtype=torch.float32) / D_per_head))
+            pos = torch.arange(num_rope_positions, dtype=torch.float32)
+            freqs = torch.outer(pos, inv_freq)
+            cos_head = freqs.cos().to(torch.bfloat16)
+            sin_head = freqs.sin().to(torch.bfloat16)
+            rope_tensor = torch.cat([cos_head, cos_head, -sin_head, sin_head], dim=1)
+            sz = self.weight_defs[sz_key]
+            raw = rope_tensor.contiguous().view(torch.uint8).numpy().tobytes()
+            raw = (raw + b"\x00" * sz)[:sz]
+            addr = self.allocate_params_dram(sz)
+            self.dma_write(DMA_DEVICE_H2C, addr, raw, sz)
+            setattr(self, attr, addr)
+
+    def weight_init(self) -> None:
+        """Init DRAM from the weight bin + load the local tokenizer. No HF model;
+        ``local_files_only=True`` fails loudly if tokenizer files are missing."""
+        if not os.path.exists(os.path.join(self.hf_model_dir, "tokenizer.json")) and \
+           not os.path.exists(os.path.join(self.hf_model_dir, "tokenizer_config.json")):
+            raise FileNotFoundError(
+                f"Tokenizer files not found at {self.hf_model_dir}\n"
+                f"Ship tokenizer.json / tokenizer_config.json alongside this script (tiny, no weights)."
+            )
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.hf_model_dir, trust_remote_code=True, local_files_only=True)
+
+        # Embedding straight from the weight bin (bf16) — no HF model.
+        emb_cfg = self._cfg["special"]["embedding"]
+        token_embd_offset = _parse_offset(emb_cfg["token_embd_offset"])
+        vocab_size = emb_cfg["vocab_size"]
+        embedding_dim = emb_cfg["embedding_dim"]
+        emb_nbytes = vocab_size * embedding_dim * self.bytes_per_element
+        raw_emb = self.weight_bin[token_embd_offset:token_embd_offset + emb_nbytes]
+        self.embedding_weight = torch.frombuffer(
+            bytearray(raw_emb), dtype=torch.bfloat16).reshape(vocab_size, embedding_dim).clone()
+
+        LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+        base_layer0 = self.weight_defs["BLK0_ATTN_NORM_WEIGHT"]
+        blk0_regions = [(s["key"], f"{s['key']}_SIZE", s["attr"])
+                        for s in self._cfg["layers"]["structure"]]
+        non_layer = [(s["key"], f"{s['key']}_SIZE", s["attr"])
+                     for s in self._cfg["layers"]["non_layer"]
+                     if s["key"] not in ("ROPE_LOCAL", "ROPE_GLOBAL")]
+
+        _original_print(f"\n--- Weights DRAM allocation, start 0x{self.get_params_dram_addr():X} ---")
+        layers_total = self.LAYER_SIZE * LAYER_WEIGHT_SIZE
+        layers_base_dram = self.allocate_params_dram(layers_total)
+        for layer_idx in range(self.LAYER_SIZE):
+            for off_key, sz_key, attr in blk0_regions:
+                off = self.weight_defs[off_key]
+                sz = self.weight_defs[sz_key]
+                bin_off = off + layer_idx * LAYER_WEIGHT_SIZE
+                raw = self.weight_bin[bin_off:bin_off + sz]
+                dram_addr = layers_base_dram + layer_idx * LAYER_WEIGHT_SIZE + (off - base_layer0)
+                self.dma_write(DMA_DEVICE_H2C, dram_addr, raw, sz)
+            if layer_idx == 0:
+                for off_key, sz_key, attr in blk0_regions:
+                    off = self.weight_defs[off_key]
+                    setattr(self, attr, layers_base_dram + (off - base_layer0))
+        _original_print(f"Layers 0..{self.LAYER_SIZE - 1} loaded: 0x{layers_base_dram:X} size {layers_total}")
+
+        for off_key, sz_key, attr in non_layer:
+            off = self.weight_defs[off_key]
+            sz = self.weight_defs[sz_key]
+            raw = self.weight_bin[off:off + sz]
+            addr = self.allocate_params_dram(sz)
+            self.dma_write(DMA_DEVICE_H2C, addr, raw, sz)
+            setattr(self, attr, addr)
+
+        self._load_rope_host()
+        _original_print(f"    Weights end 0x{self.get_params_dram_addr():X}; tokenizer loaded (local).")
+
+    def tensor_init(self) -> None:
+        """Allocate hardware DRAM tensors. The order + sizes MUST match
+        llama3.2_3b_test.py.tensor_init exactly, because the decoder program in the
+        bin reads baked tensor-DRAM addresses derived from this allocation order."""
+        seq_len = self.MAX_CONTEXT_SIZE
+        q_seq_len = seq_len * self.group_size
+        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+
+        _original_print(f"Allocate tensor dram start 0x{self.get_tensor_dram_addr():X}")
+        self.LAYER0_V_DRAM = self.allocate_tensor_dram(self.LAYER_SIZE * self.MAX_CONTEXT_SIZE * self.k_size)
+        self.LAYER0_K_ROPE_DRAM = self.allocate_tensor_dram(self.LAYER_SIZE * self.MAX_CONTEXT_SIZE * self.k_size)
+        zero_pad = torch.zeros(self.LAYER_SIZE * self.MAX_CONTEXT_SIZE * self.k_size, dtype=torch.bfloat16)
+        self.dma_to_accelerator_memory(self.LAYER0_V_DRAM, zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_K_ROPE_DRAM, zero_pad)
+        zero_add = torch.zeros(seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
+        self.ZERO_DRAM_ADDR = self.allocate_tensor_dram(seq_len * self.head_dim * self.bytes_per_element)
+        self.dma_to_accelerator_memory(self.ZERO_DRAM_ADDR, zero_add)
+        self.IDENTITY_DRAM_ADDR = self.allocate_tensor_dram(UE_VECTOR_SIZE * UE_VECTOR_SIZE * self.bytes_per_element)
+        self.dma_to_accelerator_memory(self.IDENTITY_DRAM_ADDR, torch.eye(UE_VECTOR_SIZE, dtype=torch.bfloat16))
+        self.LAYER0_FLASH_Q_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.head_dim * self.bytes_per_element)
+        self.LAYER0_FLASH_K_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.head_dim * self.bytes_per_element)
+        self.LAYER0_FLASH_V_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.head_dim * self.bytes_per_element)
+        zero_pad = torch.zeros(aligned_seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_Q_DRAM, zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_K_DRAM, zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_V_DRAM, zero_pad)
+        self.LAYER0_INPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_PRE_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_Q_DRAM = self.allocate_tensor_dram(seq_len * self.q_size)
+        self.LAYER0_K_DRAM = self.allocate_tensor_dram(seq_len * self.k_size)
+        self.LAYER0_K_NORM_DRAM = self.LAYER0_K_DRAM
+        self.LAYER0_Q_NORM_DRAM = self.LAYER0_Q_DRAM
+        self.LAYER0_V_PROJ_TEMP = self.allocate_tensor_dram(seq_len * self.k_size)
+        self.LAYER0_FLASH_OUT_HEAD_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.actual_head_dim * self.bytes_per_element)
+        self.LAYER0_FLASH_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.head_dim * self.group_size * self.bytes_per_element)
+        self.LAYER0_FLASH_SCRATCH_DRAM = self.allocate_tensor_dram(max(self.head_dim, UE_FMAX_CONTEXT_SIZE) * aligned_seq_len * 2 + self.head_dim * aligned_seq_len * 2)
+        self.LAYER0_FLASH_BIAS_DRAM = self.allocate_tensor_dram(aligned_seq_len * aligned_seq_len * self.bytes_per_element)
+        self.LAYER0_FLASH_ATTN_P_DRAM = self.allocate_tensor_dram(aligned_seq_len * aligned_seq_len * self.bytes_per_element)
+        self.LAYER0_ATTN_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_POST_ATTN_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_POST_ATTN_RESIDUAL_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_PRE_MLP_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_MLP_GATE_DRAM = self.allocate_tensor_dram(seq_len * self.mlp_elements * 2)
+        self.LAYER0_MLP_UP_DRAM = self.allocate_tensor_dram(seq_len * self.mlp_elements * 2)
+        self.LAYER0_MLP_MULT_DRAM = self.allocate_tensor_dram(seq_len * self.mlp_elements * 2)
+        self.LAYER0_MLP_DOWN_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_POST_MLP_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
+        self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
+        _original_print(f"    Tensor dram end 0x{self.get_tensor_dram_addr():X}, usage {self.get_tensor_dram_usage()} bytes")
+
+    # ---- sampling (identical mechanism to test.py §D) -----------------------
+    def _structural_token_ids(self) -> set:
+        """Token ids never repetition-penalized: punctuation/whitespace/newline/special.
+        Precomputed once from the local tokenizer vocab and cached. Exempting these
+        'glue' tokens is what stops long small-model generations collapsing to word-salad."""
+        cached = getattr(self, "_struct_ids_cache", None)
+        if cached is not None:
+            return cached
+        import string
+        allowed = set(string.punctuation) | set(string.whitespace) | set("—–’‘“”…·•‹›«»¡¿")
+        ids = set(int(i) for i in (getattr(self.tokenizer, "all_special_ids", []) or []))
+        for i in range(self.EMBEDDING_ELEMENTS):
+            s = self.tokenizer.decode([i]).strip()
+            if s == "" or all(ch in allowed for ch in s):
+                ids.add(i)
+        self._struct_ids_cache = ids
+        return ids
+
+    def _structural_ids_tensor(self) -> torch.Tensor:
+        t = getattr(self, "_struct_ids_tensor_cache", None)
+        if t is None:
+            t = torch.tensor(sorted(self._structural_token_ids()), dtype=torch.long)
+            self._struct_ids_tensor_cache = t
+        return t
+
+    def sample_next_token(self, prev_tokens) -> int:
+        """Read the full logits row from LOGITS_DRAM and sample with the configured
+        temperature / top_k / top_p / repetition_penalty (recency-decayed, windowed,
+        structural-exempt). Greedy (temperature<=0) is handled by the caller via the
+        HW argmax register, so this assumes sampling is on."""
+        vocab = self.EMBEDDING_ELEMENTS
+        bpe = self.bytes_per_element
+        buf = torch.empty(vocab, dtype=torch.bfloat16)
+        self.dma_read(DMA_DEVICE_C2H, self.LOGITS_DRAM, buf, vocab * bpe)
+        logits = buf.float()
+        # Recency-decayed frequency repetition penalty over the last rep_window tokens,
+        # exempting structural/special tokens. See notes_llama3.2_3b.md §D.
+        rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        if rep_pen != 1.0 and prev_tokens:
+            rep_window = int(getattr(self, "rep_window", 256))
+            rep_decay = float(getattr(self, "rep_decay", 0.97))
+            window = torch.tensor(prev_tokens[-rep_window:], dtype=torch.long)
+            L = window.numel()
+            ages = torch.arange(L - 1, -1, -1, dtype=torch.float32)
+            contrib = rep_decay ** ages
+            weight = torch.zeros(vocab, dtype=torch.float32)
+            weight.index_add_(0, window, contrib)
+            weight[self._structural_ids_tensor()] = 0.0
+            nz = weight > 0
+            if bool(nz.any()):
+                factor = rep_pen ** weight[nz]
+                v = logits[nz]
+                logits[nz] = torch.where(v > 0, v / factor, v * factor)
+        temp = float(getattr(self, "temperature", 1.0))
+        if temp <= 0:
+            return int(logits.argmax().item())
+        logits = logits / temp
+        top_k = int(getattr(self, "top_k", 0) or 0)
+        if top_k > 0 and top_k < vocab:
+            kth = torch.topk(logits, top_k).values[-1]
+            logits[logits < kth] = float("-inf")
+        top_p = float(getattr(self, "top_p", 1.0))
+        if 0.0 < top_p < 1.0:
+            sorted_logits, sorted_idx = torch.sort(logits, descending=True)
+            probs = torch.softmax(sorted_logits, dim=-1)
+            cumprob = torch.cumsum(probs, dim=-1)
+            keep = cumprob <= top_p
+            keep[0] = True
+            drop_idx = sorted_idx[~keep]
+            logits[drop_idx] = float("-inf")
+        probs = torch.softmax(logits, dim=-1)
+        return int(torch.multinomial(probs, num_samples=1).item())
+
+    # ---- run path (dynamic-PBI single bin: preamble + jump_abs) -------------
+    def run_llama(self) -> None:
+        """Load the unified instruction image and run prefill + decoder loop. A small
+        captured preamble primes the GPRs and jumps into the cached prefill / decoder
+        program. ``self.prefill_seq`` must be set by the caller."""
+        paths_cfg = self._cfg.get("paths", {})
+        meta_path = os.path.join(self.script_dir,
+                                 paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
+        with open(meta_path, "r") as f:
+            meta = json.load(f)
+
+        self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))
+        preamble_addr = self.get_program_dram_addr()
+
+        prefill_program_addr = int(meta["prefill_program_start_addr"], 16)
+        decoder_program_addr = int(meta["decoder_program_start_addr"], 16)
+        template_seq_len = int(meta["prefill_template_seq_len"])
+        flops_prefill_template = meta["prefill_template_flops"]
+        decoder_flops_per_token = meta["decoder_total_flops"]
+        _max_gpr_bucket = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
+        _kv_stride = self.actual_head_dim * self.bytes_per_element
+        _rope_row = 2 * self.actual_head_dim * self.bytes_per_element
+
+        prefill_seq = self.prefill_seq
+        if len(prefill_seq) < 2:
+            raise ValueError("Prefill sequence must have at least 2 tokens.")
+        prefill_seq = prefill_seq[:-1]  # last token seeds the decoder
+        prefill_seq_len = len(prefill_seq)
+        self.seq_len = prefill_seq_len
+
+        q_seq_len = prefill_seq_len * self.group_size
+        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
+        flops_prefill = flops_prefill_template * prefill_seq_len // max(template_seq_len, 1)
+
+        # Prefill preamble: prime gpr_seq_len + gpr_bucket_idx, jump into cached prefill.
+        self.clear_inst_id()
+        self.start_capture()
+        self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
+        self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
+        self.stop_capture()
+        self.write_captured_instructions_to_dram(preamble_addr)
+        self.allocate_program_dram(self.get_capture_instruction_size_bytes())
+        self.clear_capture_buffer()
+
+        embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        rows = torch.arange(aligned_seq_len).unsqueeze(1)
+        cols = torch.arange(aligned_seq_len).unsqueeze(0)
+        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        bias_one_group.masked_fill_(valid_mask, 0.0)
+        bias_one_group[:, q_seq_len:] = float("-inf")
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
+
+        _original_print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
+        timer = time.perf_counter()
+        self.program_execute(preamble_addr, flops=flops_prefill)
+        latency_prefill = time.perf_counter() - timer
+        _original_print(f"Prefill done in {latency_prefill:.2f}s\n")
+
+        _original_print("--- Starting decoder ---")
+        timer = time.perf_counter()
+        token_id = self.prefill_seq[-1]
+        _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
+        global _SILENT_MODE
+
+        if not hasattr(self, "_generated_tokens"):
+            self._generated_tokens = list(self.prefill_seq)
+        _sampling = float(getattr(self, "temperature", 0.0)) > 0
+
+        import shutil
+        _use_status = sys.stdout.isatty()
+        def _status_setup():
+            r = shutil.get_terminal_size().lines
+            sys.stdout.write(f"\033[1;{r - 1}r"); sys.stdout.write(f"\033[{r - 1};1H"); sys.stdout.flush()
+        def _status_update():
+            r = shutil.get_terminal_size().lines
+            n = self.seq_len - prefill_seq_len
+            elapsed = time.perf_counter() - timer
+            rate = n / elapsed if elapsed > 0 else 0.0
+            sys.stdout.write("\0337"); sys.stdout.write(f"\033[{r};1H\033[2K")
+            sys.stdout.write(f" decoding… {n} tokens  (pos {self.seq_len}/{self.MAX_CONTEXT_SIZE})  "
+                             f"{elapsed:.1f}s  {rate:.1f} tok/s")
+            sys.stdout.write("\0338"); sys.stdout.flush()
+        def _status_teardown():
+            r = shutil.get_terminal_size().lines
+            sys.stdout.write("\033[r"); sys.stdout.write(f"\033[{r};1H\033[2K"); sys.stdout.flush()
+        if _use_status:
+            _status_setup()
+
+        while self.seq_len < self.MAX_CONTEXT_SIZE:
+            _SILENT_MODE = True
+            self.seq_len += 1
+            aligned_seq_len = ((self.seq_len + 63) // 64) * 64
+            bucket_idx = min((self.seq_len + 63) // 64, _max_gpr_bucket)
+            decode_pos = self.seq_len - 1
+
+            embedding_tensor = self.get_embedding_for_tokens([token_id])
+            self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+            bias_host = torch.full((1, aligned_seq_len), -1e36, dtype=torch.bfloat16)
+            bias_host[0, :self.seq_len] = 0.0
+            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host)
+
+            # Decoder preamble: prime bucket + 2 position GPRs, jump into cached decoder.
+            self.clear_inst_id()
+            self.start_capture()
+            self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+            self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
+            self.generate_instruction_add_set(self.ROPE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _rope_row))
+            self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
+            self.stop_capture()
+            self.write_captured_instructions_to_dram(preamble_addr)
+            self.clear_capture_buffer()
+
+            self.program_execute(preamble_addr, flops=decoder_flops_per_token)
+            if _sampling:
+                token_id = self.sample_next_token(self._generated_tokens)
+            else:
+                token_id = self.get_arg_max_index(rank=1)
+            self._generated_tokens.append(token_id)
+            token_char = self.tokenizer.decode([token_id])
+            _SILENT_MODE = False
+            if token_id in _llama_stop_tokens:
+                if _use_status:
+                    _status_teardown()
+                _original_print(f"\nStop token {token_id} reached.")
+                break
+            _original_print(token_char, end="", flush=True)
+            if _use_status:
+                _status_update()
+        else:
+            if _use_status:
+                _status_teardown()
+
+        latency_decoder = time.perf_counter() - timer
+        tokens_decoded = self.seq_len - prefill_seq_len
+        _original_print(f"\nDecoder done in {latency_prefill + latency_decoder:.2f}s, "
+                        f"speed: {tokens_decoded / max(latency_decoder, 1e-9):.2f} tokens/s, "
+                        f"total {self.seq_len} tokens.")
+
+
+def _verify_artifacts(script_dir: str, cfg: dict) -> None:
+    """Hard-fail before any FPGA touch if a required artifact is missing."""
+    paths = cfg["paths"]
+    required = [
+        ("llama3.2_3b_config.json", "model config"),
+        (paths["weights_bin"], "weight bin"),
+        (paths["instruction_bin"], "unified instruction bin"),
+        (paths["instruction_meta"], "instruction bin meta"),
+    ]
+    tok_dir = os.path.join(script_dir, paths["hf_model_dir"])
+    missing = [f"  {rel}   ({label})" for rel, label in required
+               if not os.path.exists(os.path.join(script_dir, rel))]
+    if not any(os.path.exists(os.path.join(tok_dir, f)) for f in ("tokenizer.json", "tokenizer_config.json")):
+        missing.append(f"  {paths['hf_model_dir']}/{{tokenizer.json,tokenizer_config.json}}   (tokenizer files)")
+    if missing:
+        _original_print("ERROR: runtime-only script — required pre-built artifacts are missing:")
+        for line in missing:
+            _original_print(line)
+        _original_print("\nGenerate them on a build machine with HF access:\n  python llama3.2_3b_test.py\n"
+                        "then ship the llama3.2_3b_bin/ directory alongside this script.")
+        sys.exit(1)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Llama-3.2-3B inference from pre-compiled bins (no HF, no internet, no test-script import).")
+    parser.add_argument("--prompt", type=str, default=None,
+                        help="Text prompt (tokenized via the local chat template). Overrides the config default.")
+    parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
+    parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
+    # Sampling — defaults match llama3.2_3b_test.py (the values the shipped bin was tuned with).
+    parser.add_argument("--temperature", type=float, default=0.6,
+                        help="0 = greedy (HW argmax); >0 = sampling. Default 0.6.")
+    parser.add_argument("--top-k", type=int, default=0, help="Top-k filter (0=off). Default 0.")
+    parser.add_argument("--top-p", type=float, default=0.9, help="Top-p (nucleus) filter. Default 0.9.")
+    parser.add_argument("--repetition-penalty", type=float, default=1.2,
+                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
+    parser.add_argument("--rep-window", type=int, default=256,
+                        help="Repetition penalty look-back window in tokens. Default 256.")
+    parser.add_argument("--rep-decay", type=float, default=0.97,
+                        help="Recency decay for the repetition penalty (per-token age). Default 0.97.")
+    parser.add_argument("--seed", type=int, default=None, help="RNG seed for reproducible sampling.")
+    args = parser.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    cfg = _load_config(script_dir)
+
+    # Hard-fail BEFORE touching the FPGA if any artifact is missing.
+    _verify_artifacts(script_dir, cfg)
+
+    set_dma_device(args.dev)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    _original_print(f"Llama-3.2-3B on {args.dev} (run from pre-compiled bins)")
+
+    t0 = time.perf_counter()
+    _original_print("Loading weights + tokenizer ...")
+    ue = Llama32_3b_RunFromBin(script_dir=script_dir)
+    _original_print(f"  Weights + tensors: {time.perf_counter() - t0:.2f}s")
+
+    if args.prompt is not None:
+        conversation = [{"role": "user", "content": args.prompt}]
+        prompt_with_template = ue.tokenizer.apply_chat_template(
+            conversation, tokenize=False, add_generation_prompt=True)
+        prefill_seq = tuple(ue.tokenizer.encode(prompt_with_template, add_special_tokens=False))
+        _original_print(f"Prompt ({len(prefill_seq)} tokens): {args.prompt!r}")
+    else:
+        prefill_seq = tuple(cfg["default_prefill_tokens"])
+        _original_print(f"Default prompt ({len(prefill_seq)} tokens)")
+
+    max_prefill = ue.PREFILL_CONTEXT_SIZE
+    if len(prefill_seq) < 2 or len(prefill_seq) > max_prefill + 1:
+        _original_print(f"WARNING: prompt length {len(prefill_seq)} out of range [2, {max_prefill + 1}]; "
+                        f"falling back to the default prompt.")
+        prefill_seq = tuple(cfg["default_prefill_tokens"])
+
+    ue.prefill_seq = prefill_seq
+    ue.temperature = float(args.temperature)
+    ue.top_k = int(args.top_k)
+    ue.top_p = float(args.top_p)
+    ue.repetition_penalty = float(args.repetition_penalty)
+    ue.rep_window = int(args.rep_window)
+    ue.rep_decay = float(args.rep_decay)
+    ue._generated_tokens = list(prefill_seq)
+    if args.seed is not None and ue.temperature > 0:
+        torch.manual_seed(args.seed)
+    if ue.temperature > 0:
+        _original_print(f"Sampling: temperature={ue.temperature}  top_k={ue.top_k}  top_p={ue.top_p}  "
+                        f"repetition_penalty={ue.repetition_penalty}  rep_window={ue.rep_window}  "
+                        f"rep_decay={ue.rep_decay}  seed={args.seed}")
+        if ue.repetition_penalty != 1.0:
+            _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
+            _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
+
+    ue.run_llama()
+    ue.clear_dram()
+    _original_print("Llama-3.2-3B run_from_bin ends.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -18,10 +18,10 @@ running ``llama3.2_3b_test.py`` once on a build machine that has HF access):
 Design mirrors test.py §A–§D (see notes_llama3.2_3b.md): full-4 GB DRAM layout,
 dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
 and sampling decode (recency-decayed / windowed / structural-exempt repetition
-penalty). DECODE DEFAULT is PENALIZED GREEDY (temp 0 + rep-pen 1.1): argmax of the
-penalty-adjusted logits — deterministic, correct math, loop-free; see notes §D. The
-shipped bin is compiled with LM-head writeback enabled, so sampling (temp>0),
-penalized greedy (temp 0 + rep-pen), and pure greedy (temp 0, rep-pen 1.0) all work.
+penalty). DECODE DEFAULT is a position-gated HYBRID (temp 0): pure greedy for the first
+greedy_until (512) tokens — correct math/reasoning — then repetition penalty 1.2 breaks
+long-context loops; deterministic, see notes §D. The shipped bin is compiled with LM-head
+writeback enabled, so sampling (temp>0), the hybrid, and pure greedy (rep-pen 1.0) all work.
 
 Usage:
   python llama3.2_3b_run_from_bin.py
@@ -341,25 +341,19 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
                 factor = rep_pen ** weight[nz]
                 v = logits[nz]
                 logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        temp = float(getattr(self, "temperature", 1.0))
-        if temp <= 0:
-            return int(logits.argmax().item())
-        logits = logits / temp
-        top_k = int(getattr(self, "top_k", 0) or 0)
-        if top_k > 0 and top_k < vocab:
-            kth = torch.topk(logits, top_k).values[-1]
-            logits[logits < kth] = float("-inf")
-        top_p = float(getattr(self, "top_p", 1.0))
-        if 0.0 < top_p < 1.0:
-            sorted_logits, sorted_idx = torch.sort(logits, descending=True)
-            probs = torch.softmax(sorted_logits, dim=-1)
-            cumprob = torch.cumsum(probs, dim=-1)
-            keep = cumprob <= top_p
-            keep[0] = True
-            drop_idx = sorted_idx[~keep]
-            logits[drop_idx] = float("-inf")
-        probs = torch.softmax(logits, dim=-1)
-        return int(torch.multinomial(probs, num_samples=1).item())
+        # Deterministic selection: argmax of the (penalty-adjusted) logits.
+        return int(logits.argmax().item())
+        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
+        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
+        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
+        # if top_k > 0 and top_k < vocab:
+        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
+        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
+        # if 0.0 < top_p < 1.0:
+        #     sl, si = torch.sort(logits, descending=True)
+        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
+        #     logits[si[~keep]] = float("-inf")
+        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
 
     # ---- run path (dynamic-PBI single bin: preamble + jump_abs) -------------
     def run_llama(self) -> None:
@@ -431,11 +425,11 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
 
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
-        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
-        _temperature = float(getattr(self, "temperature", 0.0))
+        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
+        # repetition penalty turns on to break long-context loops.
         _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
+        _greedy_until = int(getattr(self, "greedy_until", 0))
 
         import shutil
         _use_status = sys.stdout.isatty()
@@ -482,7 +476,10 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            if _use_logit_readback:
+            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
+            # repetition penalty (read logits, argmax of penalized logits).
+            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
+            if _penalty_active:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -539,19 +536,23 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Decode — defaults match llama3.2_3b_test.py: penalized greedy (temp 0 + rep-pen 1.1); see notes §D.
-    parser.add_argument("--temperature", type=float, default=0.0,
-                        help="0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, correct math, loop-free; the default). >0 = sampling. Default 0.")
-    parser.add_argument("--top-k", type=int, default=40,
-                        help="Top-k filter (0=off). Caps the tail so wrong tokens can't be sampled. Default 40.")
-    parser.add_argument("--top-p", type=float, default=0.9, help="Top-p (nucleus) filter. Default 0.9.")
-    parser.add_argument("--repetition-penalty", type=float, default=1.1,
-                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.1.")
+    # Decode — defaults match llama3.2_3b_test.py: hybrid (temp 0: greedy then rep-pen 1.2); see notes §D.
+    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
+    #     sample_next_token() to re-enable stochastic sampling ---
+    # parser.add_argument("--temperature", type=float, default=0.0, help=">0 enables sampling.")
+    # parser.add_argument("--top-k", type=int, default=40, help="Top-k filter (sampling only).")
+    # parser.add_argument("--top-p", type=float, default=0.9, help="Top-p nucleus filter (sampling only).")
+    parser.add_argument("--repetition-penalty", type=float, default=1.2,
+                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
     parser.add_argument("--rep-window", type=int, default=256,
                         help="Repetition penalty look-back window in tokens. Default 256.")
     parser.add_argument("--rep-decay", type=float, default=0.97,
                         help="Recency decay for the repetition penalty (per-token age). Default 0.97.")
-    parser.add_argument("--seed", type=int, default=None, help="RNG seed for reproducible sampling.")
+    # parser.add_argument("--seed", type=int, default=None, help="RNG seed (sampling only).")
+    parser.add_argument("--greedy-until", type=int, default=512,
+                        help="Hybrid decode (temp 0): pure greedy for the first N decoded tokens "
+                             "(correct math/reasoning), then the repetition penalty breaks long-context "
+                             "loops. 0 = penalty from the start. Default 512.")
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -586,22 +587,19 @@ def main():
         prefill_seq = tuple(cfg["default_prefill_tokens"])
 
     ue.prefill_seq = prefill_seq
-    ue.temperature = float(args.temperature)
-    ue.top_k = int(args.top_k)
-    ue.top_p = float(args.top_p)
+    # Sampling controls (temperature/top_k/top_p/seed) disabled — decode is deterministic.
     ue.repetition_penalty = float(args.repetition_penalty)
     ue.rep_window = int(args.rep_window)
     ue.rep_decay = float(args.rep_decay)
+    ue.greedy_until = int(args.greedy_until)
     ue._generated_tokens = list(prefill_seq)
-    if args.seed is not None and ue.temperature > 0:
-        torch.manual_seed(args.seed)
-    if ue.temperature > 0:
-        _original_print(f"Sampling: temperature={ue.temperature}  top_k={ue.top_k}  top_p={ue.top_p}  "
-                        f"repetition_penalty={ue.repetition_penalty}  rep_window={ue.rep_window}  "
-                        f"rep_decay={ue.rep_decay}  seed={args.seed}")
-        if ue.repetition_penalty != 1.0:
-            _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
-            _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
+    _penalty_used = ue.repetition_penalty != 1.0
+    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
+             if _penalty_used else "no penalty")
+    _original_print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
+    if _penalty_used:
+        _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
+        _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
 
     ue.run_llama()
     ue.clear_dram()

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -18,8 +18,10 @@ running ``llama3.2_3b_test.py`` once on a build machine that has HF access):
 Design mirrors test.py §A–§D (see notes_llama3.2_3b.md): full-4 GB DRAM layout,
 dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
 and sampling decode (recency-decayed / windowed / structural-exempt repetition
-penalty; temperature 0.6 default). The shipped bin is compiled with LM-head
-writeback enabled, so both sampling (temp>0) and greedy (temp 0) work.
+penalty). DECODE DEFAULT is PENALIZED GREEDY (temp 0 + rep-pen 1.1): argmax of the
+penalty-adjusted logits — deterministic, correct math, loop-free; see notes §D. The
+shipped bin is compiled with LM-head writeback enabled, so sampling (temp>0),
+penalized greedy (temp 0 + rep-pen), and pure greedy (temp 0, rep-pen 1.0) all work.
 
 Usage:
   python llama3.2_3b_run_from_bin.py
@@ -429,7 +431,11 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
 
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        _sampling = float(getattr(self, "temperature", 0.0)) > 0
+        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
+        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
+        _temperature = float(getattr(self, "temperature", 0.0))
+        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
 
         import shutil
         _use_status = sys.stdout.isatty()
@@ -476,7 +482,7 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            if _sampling:
+            if _use_logit_readback:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -533,13 +539,14 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Sampling — defaults match llama3.2_3b_test.py (the values the shipped bin was tuned with).
-    parser.add_argument("--temperature", type=float, default=0.6,
-                        help="0 = greedy (HW argmax); >0 = sampling. Default 0.6.")
-    parser.add_argument("--top-k", type=int, default=0, help="Top-k filter (0=off). Default 0.")
+    # Decode — defaults match llama3.2_3b_test.py: penalized greedy (temp 0 + rep-pen 1.1); see notes §D.
+    parser.add_argument("--temperature", type=float, default=0.0,
+                        help="0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, correct math, loop-free; the default). >0 = sampling. Default 0.")
+    parser.add_argument("--top-k", type=int, default=40,
+                        help="Top-k filter (0=off). Caps the tail so wrong tokens can't be sampled. Default 40.")
     parser.add_argument("--top-p", type=float, default=0.9, help="Top-p (nucleus) filter. Default 0.9.")
-    parser.add_argument("--repetition-penalty", type=float, default=1.2,
-                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
+    parser.add_argument("--repetition-penalty", type=float, default=1.1,
+                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.1.")
     parser.add_argument("--rep-window", type=int, default=256,
                         help="Repetition penalty look-back window in tokens. Default 256.")
     parser.add_argument("--rep-decay", type=float, default=0.97,

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -898,17 +898,18 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            # LM head: in greedy mode the HW argmax register is populated as a
-            # pipeline side-effect, so skip the full vocab-logits writeback to DRAM
-            # (write_back_disable). For sampling (temperature > 0) writeback MUST be
-            # enabled so the host can DMA the logits row back for repetition-penalty /
-            # top-k / top-p / multinomial in sample_next_token(). This is a compile-time
-            # gate reading ue.temperature, which main() sets before compile_llama().
-            _greedy_lm_head = float(getattr(self, "temperature", 0.0)) <= 0
+            # LM head: the full vocab-logits writeback to DRAM is needed whenever the host
+            # reads logits — sampling (temp>0) OR penalized greedy (temp 0 + rep_pen!=1, which
+            # argmaxes the penalty-adjusted logits). Disable it ONLY for pure unpenalized greedy
+            # (temp 0 + rep_pen 1.0), where the HW argmax register suffices. This compile-time
+            # gate MUST match the decode dispatch (_use_logit_readback); else the host reads a
+            # never-written LOGITS_DRAM → NaN/garbage ("!!!"). main() sets both before compile.
+            _need_logit_writeback = (float(getattr(self, "temperature", 0.0)) > 0
+                                     or float(getattr(self, "repetition_penalty", 1.0)) != 1.0)
             total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
-                write_back_disable=_greedy_lm_head)
+                write_back_disable=not _need_logit_writeback)
 
         self.generate_instruction_halt()
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
@@ -1164,7 +1165,11 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         # Falls back to the full prompt when run without main() (e.g. run_from_bin).
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        _sampling = float(getattr(self, "temperature", 0.0)) > 0
+        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
+        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
+        _temperature = float(getattr(self, "temperature", 0.0))
+        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1220,9 +1225,9 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # Sampling reads the full logits row (writeback enabled at compile time);
-            # greedy uses the HW argmax register (no host readback).
-            if _sampling:
+            # readback path = sampling or penalized greedy (temp<=0 -> argmax of the
+            # penalty-adjusted logits); pure HW argmax only for unpenalized greedy.
+            if _use_logit_readback:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -1257,24 +1262,20 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_3b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Sampling DEFAULTS tuned for the quantized FPGA model (temp 0.6 / top-p 0.9 /
-    # rep-penalty 1.2, recency-decayed + structural-exempt). Two findings drive this:
-    #   - Greedy (temp 0) loops on the FPGA: its reduced-precision arithmetic perturbs
-    #     the logits enough that argmax falls into repetition (greedy is fine on a clean
-    #     4-bit GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
-    #     => need temperature > 0 to escape the loops.
-    #   - High temp (0.7) samples from the 4-bit-noisy tail and drifts. => keep it modest.
-    # 0.6 is the compromise: enough randomness (with the repetition penalty) to escape
-    # the arithmetic-induced loops, low enough to stay near the robust argmax region.
-    # Pass --temperature 0 for deterministic greedy (HW argmax, no logit readback).
-    parser.add_argument('--temperature', type=float, default=0.6,
-                        help='Sampling temperature (0=greedy via HW argmax; >0 enables SW sampling). Default 0.6.')
-    parser.add_argument('--top-k', type=int, default=0,
-                        help='Top-k filter (0=disabled). Active only when --temperature > 0. Default 0.')
+    # Decode default: penalized greedy (temperature 0 + repetition penalty 1.1) — argmax of
+    # the penalty-adjusted logits: deterministic and arithmetic-accurate, with the penalty
+    # preventing loops on long generations. --temperature > 0 switches to stochastic sampling
+    # (top-k / top-p apply only then). Rationale: notes_llama3.2_1b.md §D.
+    parser.add_argument('--temperature', type=float, default=0.0,
+                        help='0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, '
+                             'correct math, loop-free; the default). >0 = stochastic sampling. Default 0.')
+    parser.add_argument('--top-k', type=int, default=40,
+                        help='Top-k filter (0=disabled). Only used when --temperature > 0 (ignored by penalized '
+                             'greedy). Caps the sampling tail. Default 40.')
     parser.add_argument('--top-p', type=float, default=0.9,
                         help='Top-p (nucleus) filter, 0<p<1 keeps the smallest set with cumulative prob >= p. Default 0.9.')
-    parser.add_argument('--repetition-penalty', type=float, default=1.2,
-                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.2.')
+    parser.add_argument('--repetition-penalty', type=float, default=1.1,
+                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.1.')
     parser.add_argument('--rep-window', type=int, default=256,
                         help='Repetition penalty considers only the last N tokens (and never penalizes '
                              'punctuation/whitespace/special tokens). Smaller = less structural starvation '

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -902,7 +902,7 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
             # reads logits — sampling (temp>0) OR penalized greedy (temp 0 + rep_pen!=1, which
             # argmaxes the penalty-adjusted logits). Disable it ONLY for pure unpenalized greedy
             # (temp 0 + rep_pen 1.0), where the HW argmax register suffices. This compile-time
-            # gate MUST match the decode dispatch (_use_logit_readback); else the host reads a
+            # gate MUST match the decode readback condition (temp>0 or penalty active); else the host reads a
             # never-written LOGITS_DRAM → NaN/garbage ("!!!"). main() sets both before compile.
             _need_logit_writeback = (float(getattr(self, "temperature", 0.0)) > 0
                                      or float(getattr(self, "repetition_penalty", 1.0)) != 1.0)
@@ -1065,29 +1065,19 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                 factor = rep_pen ** weight[nz]                        # >= 1, grows with recency*count
                 v = logits[nz]
                 logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        # Temperature
-        temp = float(getattr(self, "temperature", 1.0))
-        if temp <= 0:
-            return int(logits.argmax().item())
-        logits = logits / temp
-        # Top-k
-        top_k = int(getattr(self, "top_k", 0) or 0)
-        if top_k > 0 and top_k < vocab:
-            kth = torch.topk(logits, top_k).values[-1]
-            logits[logits < kth] = float("-inf")
-        # Top-p (nucleus)
-        top_p = float(getattr(self, "top_p", 1.0))
-        if 0.0 < top_p < 1.0:
-            sorted_logits, sorted_idx = torch.sort(logits, descending=True)
-            probs = torch.softmax(sorted_logits, dim=-1)
-            cumprob = torch.cumsum(probs, dim=-1)
-            # mask tokens whose cumulative prob > top_p (keep at least 1)
-            keep = cumprob <= top_p
-            keep[0] = True
-            drop_idx = sorted_idx[~keep]
-            logits[drop_idx] = float("-inf")
-        probs = torch.softmax(logits, dim=-1)
-        return int(torch.multinomial(probs, num_samples=1).item())
+        # Deterministic selection: argmax of the (penalty-adjusted) logits.
+        return int(logits.argmax().item())
+        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
+        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
+        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
+        # if top_k > 0 and top_k < vocab:
+        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
+        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
+        # if 0.0 < top_p < 1.0:
+        #     sl, si = torch.sort(logits, descending=True)
+        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
+        #     logits[si[~keep]] = float("-inf")
+        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
 
     def run_llama(self) -> None:
         """Load the unified instruction image and run prefill + decoder loop.
@@ -1165,11 +1155,11 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         # Falls back to the full prompt when run without main() (e.g. run_from_bin).
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Penalized greedy (temp 0 + rep_pen!=1) and sampling (temp>0) read the logits back
-        # so the repetition penalty applies before token selection; pure HW argmax otherwise.
-        _temperature = float(getattr(self, "temperature", 0.0))
+        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
+        # repetition penalty turns on to break long-context loops.
         _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        _use_logit_readback = _temperature > 0 or _rep_pen != 1.0
+        _greedy_until = int(getattr(self, "greedy_until", 0))
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1225,9 +1215,10 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
             self.clear_capture_buffer()
 
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # readback path = sampling or penalized greedy (temp<=0 -> argmax of the
-            # penalty-adjusted logits); pure HW argmax only for unpenalized greedy.
-            if _use_logit_readback:
+            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
+            # repetition penalty (read logits, argmax of penalized logits).
+            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
+            if _penalty_active:
                 token_id = self.sample_next_token(self._generated_tokens)
             else:
                 token_id = self.get_arg_max_index(rank=1)
@@ -1262,20 +1253,16 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_3b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Decode default: penalized greedy (temperature 0 + repetition penalty 1.1) — argmax of
-    # the penalty-adjusted logits: deterministic and arithmetic-accurate, with the penalty
-    # preventing loops on long generations. --temperature > 0 switches to stochastic sampling
-    # (top-k / top-p apply only then). Rationale: notes_llama3.2_1b.md §D.
-    parser.add_argument('--temperature', type=float, default=0.0,
-                        help='0 = penalized greedy (argmax of penalty-adjusted logits — deterministic, '
-                             'correct math, loop-free; the default). >0 = stochastic sampling. Default 0.')
-    parser.add_argument('--top-k', type=int, default=40,
-                        help='Top-k filter (0=disabled). Only used when --temperature > 0 (ignored by penalized '
-                             'greedy). Caps the sampling tail. Default 40.')
-    parser.add_argument('--top-p', type=float, default=0.9,
-                        help='Top-p (nucleus) filter, 0<p<1 keeps the smallest set with cumulative prob >= p. Default 0.9.')
-    parser.add_argument('--repetition-penalty', type=float, default=1.1,
-                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.1.')
+    # Decode is a position-gated hybrid (deterministic): PURE greedy for the first
+    # `greedy_until` (512) decoded tokens — correct math/reasoning, which lands early — then
+    # repetition penalty 1.2 to break long-context loops. Rationale: notes_llama3.2_1b.md §D.
+    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
+    #     sample_next_token() to re-enable stochastic sampling ---
+    # parser.add_argument('--temperature', type=float, default=0.0, help='>0 enables sampling.')
+    # parser.add_argument('--top-k', type=int, default=40, help='Top-k filter (sampling only).')
+    # parser.add_argument('--top-p', type=float, default=0.9, help='Top-p nucleus filter (sampling only).')
+    parser.add_argument('--repetition-penalty', type=float, default=1.2,
+                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Active after greedy_until in hybrid mode. Default 1.2.')
     parser.add_argument('--rep-window', type=int, default=256,
                         help='Repetition penalty considers only the last N tokens (and never penalizes '
                              'punctuation/whitespace/special tokens). Smaller = less structural starvation '
@@ -1285,8 +1272,11 @@ def main():
                              'k tokens ago contributes rep_decay**k to its penalty weight. 1.0 = pure '
                              'frequency (no decay); lower = only very recent repeats matter. Default 0.97 '
                              '(half-life ~23 tokens).')
-    parser.add_argument('--seed', type=int, default=None,
-                        help='RNG seed for reproducible sampling (only when --temperature > 0).')
+    # parser.add_argument('--seed', type=int, default=None, help='RNG seed (sampling only).')
+    parser.add_argument('--greedy-until', type=int, default=512,
+                        help='Hybrid decode (temp 0 only): pure greedy for the first N decoded tokens '
+                             '(correct math/reasoning, which lands early), then the repetition penalty '
+                             'turns on to break long-context loops. 0 = penalty from the start. Default 512.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1326,27 +1316,24 @@ def main():
 
     ue.prefill_seq = prefill_seq
 
-    # Sampling config (consumed by sample_next_token / the LM-head writeback gate).
-    # Must be set BEFORE compile_llama() so the decoder bin is compiled with logits
-    # writeback ON when temperature > 0. Mirrors qwen3_1.7b.
-    ue.temperature = float(args.temperature)
-    ue.top_k = int(args.top_k)
-    ue.top_p = float(args.top_p)
+    # Decode config (consumed by the decode loop / repetition penalty / LM-head writeback
+    # gate). Must be set BEFORE compile_llama() so the bin is compiled with logits writeback
+    # ON when a repetition penalty is used. Sampling controls (temperature/top_k/top_p/seed)
+    # are disabled — decode is deterministic.
     ue.repetition_penalty = float(args.repetition_penalty)
     ue.rep_window = int(args.rep_window)
     ue.rep_decay = float(args.rep_decay)
+    ue.greedy_until = int(args.greedy_until)
     ue._generated_tokens = list(prefill_seq)   # seed repetition penalty with the prompt
-    if args.seed is not None and ue.temperature > 0:
-        torch.manual_seed(args.seed)
-    if ue.temperature > 0:
-        print(f"Sampling: temperature={ue.temperature}  top_k={ue.top_k}  "
-              f"top_p={ue.top_p}  repetition_penalty={ue.repetition_penalty}  "
-              f"rep_window={ue.rep_window}  rep_decay={ue.rep_decay}  seed={args.seed}")
-        # Precompute the structural-token exemption set upfront (one vocab scan) so it
-        # doesn't stall the first decode step.
-        if ue.repetition_penalty != 1.0:
-            _n = len(ue._structural_token_ids())
-            print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+    _penalty_used = ue.repetition_penalty != 1.0
+    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
+             if _penalty_used else "no penalty")
+    print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
+    # Precompute the structural-token exemption set upfront (one vocab scan) so it
+    # doesn't stall the first decode step where the penalty turns on.
+    if _penalty_used:
+        _n = len(ue._structural_token_ids())
+        print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
 
     print("\n--- Compiling ---")
     timer = time.perf_counter()

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -1,0 +1,1370 @@
+#!/usr/bin/env python3
+"""
+Llama-3.2-3B inference on accelerator: prefill + decode.
+
+  - Config from llama3.2_3b_config.json; weights from a single bin (see below).
+  - Prefill: compiled each run. Decoder: if llama3.2_3b_bin/decoder_program.bin and
+    llama3.2_3b_bin/decoder_program.json exist, skip decoder compile and load
+    program sizes from meta; otherwise compile and write the bin + meta.
+  - Run prefill then decode loop.
+
+Architecture differences vs Gemma3:
+  - No per-head Q/K normalization (q_norm, k_norm absent).
+  - No post-attention normalization (Gemma3 only).
+  - No post-FFN normalization (Gemma3 only).
+  - layer.post_attention_layernorm is the pre-FFN norm (not post-attn).
+  - Embedding is NOT scaled by sqrt(hidden_size).
+  - LM head weight is tied to the embedding weight.
+  - gamma_offset = 0.0 (LLaMA uses w directly, not 1+w).
+
+Weights:
+  - Default: llama3.2_3b_bin/weights_llama3.2_3b_hf.bin (generated from HF model if missing).
+  - --local-weights: use llama3.2_3b_bin/full_model_weights.bin instead.
+
+Usage:
+  python llama3.2_3b_test.py
+  python llama3.2_3b_test.py --prompt "your prompt"
+  python llama3.2_3b_test.py --dev xdma0 [--cycle 5.88]
+  python llama3.2_3b_test.py --local-weights
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from huggingface_hub import snapshot_download
+import time
+
+# This file's folder; user_dma_core.py is two folders up (repo root); that directory is added to sys.path.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+
+import user_dma_core
+from user_dma_core import DMA_DEVICE_H2C, TYPE, UE_MODE, UE_FMAX_CONTEXT_SIZE, UE_VECTOR_SIZE, URAM_NEAR_FULL_ELEMENTS, URAM_FULL_ELEMENTS, set_dma_device, ue_35bit_addr_shifter, INSTRUCTION_SIZE_BYTES
+from user_dma_core import UnifiedEngine
+
+# --- BROAD PRINT SUPPRESSION FOR LIBRARIES ---
+import builtins
+
+_original_print = builtins.print
+_SILENT_MODE = False
+
+def quiet_print(*args, **kwargs):
+    """Suppress prints when _SILENT_MODE is True; otherwise print normally."""
+    if _SILENT_MODE:
+        return
+    _original_print(*args, **kwargs)
+
+builtins.print = quiet_print
+# ---------------------------------------------
+
+def _parse_offset(val) -> int:
+    """Parse offset/size from JSON: int or hex string like '0x24000000'."""
+    if isinstance(val, str):
+        return int(val, 0)
+    return int(val)
+
+def _quantize_bf16_to_int4_packed(weight_bf16: torch.Tensor, block_size: int = 64) -> tuple[bytes, bytes]:
+    """Quantize bf16 weight (N_w, K_w) to INT4 packed + scale per block of 64 along K. Returns (data_bytes, scale_bytes)."""
+    w = weight_bf16.detach().cpu().float().reshape(-1)
+    N_w, K_w = weight_bf16.shape
+    assert K_w % block_size == 0
+    w_blocks = w.reshape(N_w, K_w // block_size, block_size)
+    scale = w_blocks.abs().amax(dim=-1).clamp(min=1e-8) / 7.0
+    # IF4 dispatches INT4 vs FP4 by bf16 scale sign (negative=INT4 codebook).
+    scale_bf16 = (-scale).to(torch.bfloat16)
+    w_int8 = (w_blocks / scale.unsqueeze(-1)).round().clamp(-8, 7).to(torch.int8)
+    w_nibbles = w_int8.numpy().astype(np.int16) & 0x0F
+    low = w_nibbles[:, :, 0::2].reshape(N_w, -1)
+    high = w_nibbles[:, :, 1::2].reshape(N_w, -1)
+    packed = (high << 4) | low
+    data_bytes = packed.astype(np.uint8).tobytes()
+    scale_bytes = scale_bf16.contiguous().view(torch.uint8).numpy().tobytes()
+    return (data_bytes, scale_bytes)
+
+
+def weight_bin_generate(script_dir: str | None = None, output_path: str | None = None) -> str:
+    """Generate weights_llama3.2_3b_hf.bin from HuggingFace model per llama3.2_3b_config.json layout.
+    Returns the path to the written file."""
+    script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
+    cfg = _load_config(script_dir)
+    weight_defs = cfg["_weight_defs"]
+    paths = cfg["paths"]
+    paths_full = os.path.join(script_dir, paths["weights_bin"])
+    out_path = output_path or paths_full
+
+    model, model_dir = _ensure_hf_model(script_dir, cfg)
+    gamma_offset = cfg["special"]["rms_norm"]["gamma_offset"]  # 0.0 for LLaMA
+    emb_cfg = cfg["special"]["embedding"]
+    token_embd_offset = _parse_offset(emb_cfg["token_embd_offset"])
+    token_embd_size = _parse_offset(emb_cfg["token_embd_size"])
+    LAYER_WEIGHT_SIZE = weight_defs["LAYER_WEIGHT_SIZE"]
+    base_layer0 = weight_defs["BLK0_ATTN_NORM_WEIGHT"]
+    num_layers = cfg["file_info"]["num_layers"]
+    head_dim = cfg["file_info"]["head_dim"]
+    vector_length = cfg["file_info"]["hidden_size"]
+    group_size = cfg["file_info"]["group_size"]
+    blk0_structure = cfg["layers"]["structure"]
+
+    # 3B uses PER-HEAD RoPE (N=actual_head_dim=128) — NO q/k row permutation. HF's
+    # natural per-head [lo,hi] layout is fed directly to rope_hf_core_dram_gqa(N=128).
+    head_dim_actual = cfg["file_info"]["actual_head_dim"]
+    num_kv_heads = head_dim // head_dim_actual  # 8
+
+    # Compute total file size
+    max_end = 0
+    for key, r in cfg.get("regions", {}).items():
+        off = weight_defs[key]
+        max_end = max(max_end, off + (num_layers - 1) * LAYER_WEIGHT_SIZE + r["size"])
+    for key, r in cfg.get("non_layer_regions", {}).items():
+        off = weight_defs[key]
+        max_end = max(max_end, off + r["size"])
+    max_end = max(max_end, token_embd_offset + token_embd_size)
+    buf = bytearray(max_end)
+
+    def write_at(offset: int, data: bytes) -> None:
+        buf[offset : offset + len(data)] = data[: len(buf) - offset]
+
+    # Embedding: LLaMA does NOT scale by sqrt(hidden_size)
+    embed = model.get_input_embeddings().weight.detach().cpu().to(torch.bfloat16)
+    raw_emb = embed.contiguous().view(torch.uint8).numpy().tobytes()
+    write_at(token_embd_offset, raw_emb)
+
+    # Layers
+    for layer_idx in range(num_layers):
+        layer = model.model.layers[layer_idx]
+        attn = layer.self_attn
+
+        # LLaMA norms: gamma_offset = 0.0 (weight stored as-is)
+        gamma_in = (layer.input_layernorm.weight.detach().cpu().to(torch.bfloat16).float() + gamma_offset).to(torch.bfloat16)
+        # 3B per-head RoPE: NO permutation. HF q/k weights are stored as-is; the matmul
+        # output is in natural per-head order (Q: 24 heads × 128, K: 8 heads × 128), and
+        # each head's native [lo,hi] 128-dim is roped directly by rope_hf_core_dram_gqa(N=128).
+        q_w = attn.q_proj.weight.detach().cpu().to(torch.bfloat16)
+        k_w = attn.k_proj.weight.detach().cpu().to(torch.bfloat16)
+        v_w = attn.v_proj.weight.detach().cpu().to(torch.bfloat16)
+        # LLaMA has no q_norm / k_norm: write zero placeholders (norm steps are skipped in pipeline)
+        gamma_q = torch.zeros(head_dim, dtype=torch.bfloat16)
+        gamma_k = torch.zeros(head_dim, dtype=torch.bfloat16)
+        o_w = attn.o_proj.weight.detach().cpu().to(torch.bfloat16)
+        # LLaMA has no post-attention norm: write zero placeholder (step skipped in pipeline)
+        gamma_post = torch.zeros(vector_length, dtype=torch.bfloat16)
+        # LLaMA's post_attention_layernorm IS the pre-FFN norm
+        gamma_ffn = (layer.post_attention_layernorm.weight.detach().cpu().to(torch.bfloat16).float() + gamma_offset).to(torch.bfloat16)
+        gate_w = layer.mlp.gate_proj.weight.detach().cpu().to(torch.bfloat16)
+        up_w = layer.mlp.up_proj.weight.detach().cpu().to(torch.bfloat16)
+        down_w = layer.mlp.down_proj.weight.detach().cpu().to(torch.bfloat16)
+        # LLaMA has no post-FFN norm: write zero placeholder (step skipped in pipeline)
+        gamma_post_ffn = torch.zeros(vector_length, dtype=torch.bfloat16)
+
+        region_writes = [
+            (gamma_in, "bf16"),
+            (q_w, "int4"),
+            (k_w, "int4"),
+            (v_w, "int4"),
+            (gamma_q, "bf16"),
+            (gamma_k, "bf16"),
+            (o_w, "int4"),
+            (gamma_post, "bf16"),
+            (gamma_ffn, "bf16"),
+            (up_w, "int4"),
+            (gate_w, "int4"),
+            (down_w, "int4"),
+            (gamma_post_ffn, "bf16"),
+        ]
+        j = 0
+        i = 0
+        while i < len(blk0_structure):
+            off_key = blk0_structure[i]["key"]
+            sz_key = f"{off_key}_SIZE"
+            off = weight_defs[off_key]
+            sz = weight_defs[sz_key]
+            file_off = off + layer_idx * LAYER_WEIGHT_SIZE
+            tensor, kind = region_writes[j]
+            if kind == "int4":
+                next_key = blk0_structure[i + 1]["key"]
+                data_sz = weight_defs[f"{next_key}_SIZE"]
+                data_bytes, scale_bytes = _quantize_bf16_to_int4_packed(tensor)
+                scale_padded = (scale_bytes + b"\x00" * sz)[:sz]
+                data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
+                write_at(file_off, scale_padded)
+                data_off = weight_defs[next_key] + layer_idx * LAYER_WEIGHT_SIZE
+                write_at(data_off, data_padded)
+                i += 2
+            else:
+                t = tensor.detach().cpu().to(torch.bfloat16).contiguous()
+                raw = (t.view(torch.uint8).numpy().tobytes() + b"\x00" * sz)[:sz]
+                write_at(file_off, raw)
+                i += 1
+            j += 1
+
+    # ROPE: LLaMA uses a single RoPE table (rope_global_layers is empty, all layers use local/default)
+    rope_cfg = cfg["special"]["rope"]
+    theta = rope_cfg["theta"]
+    local_base = rope_cfg["local_base"]
+    num_positions = rope_cfg["num_positions"]
+    # 3B per-head RoPE: NO tiling across KV heads. D_per_head = actual_head_dim//2 = 64.
+    # Per-position row = [cos_head(64), cos_head(64), -sin_head(64), sin_head(64)] = 256 elems.
+    head_dim_actual = cfg["file_info"]["actual_head_dim"]
+    num_kv_heads = head_dim // head_dim_actual  # = 8
+    D_per_head = head_dim_actual // 2           # = 64
+    for name, theta_val, off_key, sz_key in [
+        ("ROPE_LOCAL", local_base, "ROPE_LOCAL", "ROPE_LOCAL_SIZE"),
+        ("ROPE_GLOBAL", theta, "ROPE_GLOBAL", "ROPE_GLOBAL_SIZE"),
+    ]:
+        inv_freq = 1.0 / (theta_val ** (torch.arange(D_per_head, dtype=torch.float32) / D_per_head))
+        pos = torch.arange(num_positions, dtype=torch.float32)
+        freqs = torch.outer(pos, inv_freq)                     # (num_positions, 64)
+        cos_head = freqs.cos().to(torch.bfloat16)              # (num_positions, 64)
+        sin_head = freqs.sin().to(torch.bfloat16)              # (num_positions, 64)
+        # Per-head layout (no tiling): [cos_head, cos_head, -sin_head, sin_head]
+        rope_tensor = torch.cat([cos_head, cos_head, -sin_head, sin_head], dim=1)
+        sz = weight_defs[sz_key]
+        raw = (rope_tensor.contiguous().view(torch.uint8).numpy().tobytes() + b"\x00" * sz)[:sz]
+        write_at(weight_defs[off_key], raw)
+
+    # OUTPUT_NORM
+    out_norm = (model.model.norm.weight.detach().cpu().to(torch.bfloat16).float() + gamma_offset).to(torch.bfloat16)
+    sz = weight_defs["OUTPUT_NORM_WEIGHT_SIZE"]
+    raw = (out_norm.contiguous().view(torch.uint8).numpy().tobytes() + b"\x00" * sz)[:sz]
+    write_at(weight_defs["OUTPUT_NORM_WEIGHT"], raw)
+
+    # LM_HEAD: LLaMA ties lm_head weight to input embedding
+    lm_head_w = model.get_input_embeddings().weight.detach().cpu().to(torch.bfloat16)
+    scale_sz = weight_defs["LM_HEAD_WEIGHT_SCALE_SIZE"]
+    data_sz = weight_defs["LM_HEAD_WEIGHT_DATA_SIZE"]
+    data_bytes, scale_bytes = _quantize_bf16_to_int4_packed(lm_head_w)
+    scale_padded = (scale_bytes + b"\x00" * scale_sz)[:scale_sz]
+    data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
+    write_at(weight_defs["LM_HEAD_WEIGHT_SCALE"], scale_padded)
+    write_at(weight_defs["LM_HEAD_WEIGHT_DATA"], data_padded)
+
+    with open(out_path, "wb") as f:
+        f.write(buf)
+    print(f"Generated weights bin: {out_path} ({len(buf)} bytes)")
+    return out_path
+
+def _ensure_hf_model(script_dir: str, cfg: dict):
+    """Ensure HF model is downloaded and loaded. Returns (model, model_dir)."""
+    model_dir = os.path.join(script_dir, cfg["paths"]["hf_model_dir"])
+    hf_repo = cfg["paths"]["hf_model_repo"]
+    config_path = os.path.join(model_dir, "config.json")
+    if not os.path.exists(config_path):
+        _original_print(f"Downloading HF model {hf_repo} to {os.path.abspath(model_dir)} ...")
+        snapshot_download(repo_id=hf_repo, local_dir=model_dir, local_dir_use_symlinks=False)
+        _original_print("Download complete.")
+    model = AutoModelForCausalLM.from_pretrained(
+        model_dir, torch_dtype=torch.bfloat16, device_map=None, trust_remote_code=True
+    )
+    return model, model_dir
+
+def _load_config(script_dir: str) -> dict:
+    """Load llama3.2_3b_config.json and build weight_defs (offset/size dict) from regions."""
+    config_path = os.path.join(script_dir, "llama3.2_3b_config.json")
+    with open(config_path, "r") as f:
+        cfg = json.load(f)
+    weight_defs = {"LAYER_WEIGHT_SIZE": cfg["file_info"]["layer_size"]}
+    for key, r in cfg.get("regions", {}).items():
+        weight_defs[key] = _parse_offset(r["offset"])
+        weight_defs[f"{key}_SIZE"] = r["size"]
+    for key, r in cfg.get("non_layer_regions", {}).items():
+        weight_defs[key] = _parse_offset(r["offset"])
+        weight_defs[f"{key}_SIZE"] = r["size"]
+    cfg["_weight_defs"] = weight_defs
+    return cfg
+
+# -----------------------------------------------------------------------------
+# Llama-3.2-3B unified engine
+# -----------------------------------------------------------------------------
+class Llama32_3b_UnifiedEngine(UnifiedEngine):
+    """UnifiedEngine for Llama-3.2-3B: loads config + weight bin, compile_prefill/compile_decoder, run_prefill/run_decoder.
+
+    Key architectural differences from Gemma3:
+      - No Q/K per-head norm (q_norm, k_norm): compile pipeline skips those RMS norm steps.
+      - No post-attention norm: residual is applied directly to o_proj output.
+      - No post-FFN norm: residual is applied directly to down_proj output.
+      - post_attention_layernorm in HF is the pre-FFN norm.
+      - Embedding NOT scaled by sqrt(hidden_size).
+      - LM head weight tied to input embedding.
+    """
+
+    def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None):
+        # Full 4 GB DRAM layout (mirrors qwen3_1.7b): the default split reserves only
+        # 512 MB for the tensor region, which overflows at max_context_size=4096
+        # (attention + activation buffers in tensor_init scale with context). The
+        # tensor region here is 0x58000000..0xE0000000 = 2.25 GB.
+        #   params : 0x00000000 .. 0x58000000  (1.375 GB)  weights + host RoPE
+        #   tensor : 0x58000000 .. 0xE0000000  (2.25 GB)   activations + KV cache
+        #   program: 0xE0000000 .. 0x100000000 (512 MB)    unified instruction bin
+        super().__init__(
+            params_dram_base=0x00000000,
+            tensor_dram_base=0x70000000,
+            program_dram_base=0xE0000000,
+        )
+        self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
+        self._cfg = _load_config(self.script_dir)
+        self.weight_defs = self._cfg["_weight_defs"]
+
+        fi = self._cfg["file_info"]
+        model = self._cfg["model"]
+        paths = self._cfg["paths"]
+
+        self.vector_length = fi["hidden_size"]
+        self.head_dim = fi["head_dim"]
+        self.bytes_per_element = fi["bytes_per_element"]
+        self.group_size = fi["group_size"]
+        self.mlp_elements = fi["mlp_elements"]
+        self.hf_model_dir = hf_model_dir or os.path.join(self.script_dir, paths["hf_model_dir"])
+        self.q_size = self.head_dim * self.group_size * self.bytes_per_element
+        self.k_size = self.head_dim * self.bytes_per_element
+        # LLaMA 3.2 3B GQA: 8 KV heads × 128-dim per head = head_dim=1024 combined,
+        # group_size=3 → 24 Q heads. Per-head RoPE (N=128); no q/k weight permutation.
+        self.actual_head_dim = fi["actual_head_dim"]
+        self.num_kv_heads = self.head_dim // self.actual_head_dim  # = 8
+        self.num_q_heads = self.num_kv_heads * self.group_size     # = 24
+        self.MAX_CONTEXT_SIZE = model["max_context_size"]
+        self.PREFILL_CONTEXT_SIZE = model["prefill_context_size"]
+        self.LAYER_SIZE = fi["num_layers"]
+        self.EMBEDDING_ELEMENTS = fi["embedding_vocab"]
+        fixed = self._cfg.get("fixed_isa_regs", {})
+        self.V_CACHE_SIZE_REG = fixed["V_CACHE_SIZE_REG"]
+        self.TMP_REG = fixed["TMP_REG"]
+        self.ROPE_SIZE_REG = fixed["ROPE_SIZE_REG"]
+        self.gpr_bucket_idx = fixed["GPR_BUCKET_IDX_REG"]
+        self.gpr_seq_len = fixed["GPR_SEQ_LEN_REG"]
+        self._isa_reg_counter = max(fixed.values()) + 1  # must start past all fixed ISA regs
+        self.causal_mask_upper = False
+        self._rope_global_layers = set(model["rope_global_layers"])
+        self._end_of_turn_token_id = model["end_of_turn_token_id"]
+        self._gamma_bin_offset = self._cfg["special"]["rms_norm"]["gamma_offset"]
+
+        # LLaMA architecture flags: these norms do not exist in LLaMA 3.2
+        self._has_q_k_norm = False       # no per-head Q/K normalization
+        self._has_post_attn_norm = False  # no post-attention normalization
+        self._has_post_mlp_norm = False   # no post-FFN normalization
+
+        bin_path = weights_bin or paths["weights_bin"]
+        full_path = os.path.join(self.script_dir, bin_path)
+        if not os.path.exists(full_path):
+            raise FileNotFoundError(f"Bin file not found: {full_path}")
+        with open(full_path, "rb") as f:
+            self.weight_bin = f.read()
+        self.weight_init()
+        self.tensor_init()
+
+    def get_embedding_for_tokens(self, token_ids: list[int] | tuple) -> torch.Tensor:
+        """Return (len(token_ids), vector_length) bfloat16 tensor from self.embedding_weight (HF, scale applied)."""
+        tid_t = torch.tensor(token_ids, dtype=torch.long)
+        out = torch.zeros(len(token_ids), self.vector_length, dtype=torch.bfloat16)
+        valid = tid_t < self.embedding_weight.shape[0]
+        out[valid] = self.embedding_weight[tid_t[valid]]
+        return out
+
+    def _load_rope_host(self, rope_theta: float | None = None, rope_local_base: float | None = None) -> None:
+        """Generate N=512 tiled RoPE table (8 KV heads tiled) and write to DRAM.
+
+        Used with [lo|hi]-permuted k/q_proj weights so rope_hf_core(N=512) correctly
+        applies per-head RoPE. The 32-element per-head frequencies are tiled 8× to cover
+        the full 256-element half of the 512-dim combined vector.
+
+        Layout per position (1024 elements × 2 bytes = 2048 bytes):
+            [cos_full(256), cos_full(256), -sin_full(256), sin_full(256)]
+        rope_hf_core(N=512) reads cos at t*2048 and sin at t*2048+1024.
+
+        This satisfies the N>=128 hardware alignment constraint (N=512 >> 128).
+        """
+        rope_cfg = self._cfg["special"]["rope"]
+        theta = rope_theta if rope_theta is not None else rope_cfg["theta"]
+        local_base = rope_local_base if rope_local_base is not None else rope_cfg["local_base"]
+        num_rope_positions = rope_cfg["num_positions"]
+        # 3B per-head RoPE: D_per_head = actual_head_dim//2 = 64 freqs; NO KV-head tiling.
+        # Each rope_hf_core_dram_gqa(N=128) consumes one head's cos/sin. Per-position row =
+        # [cos_head(64), cos_head(64), -sin_head(64), sin_head(64)] = 256 elems = 512 bytes.
+        D_per_head = self.actual_head_dim // 2  # = 64 frequencies per head
+        for name, theta_val, sz_key, attr in [
+            ("ROPE_LOCAL", local_base, "ROPE_LOCAL_SIZE", "DRAM_ADDR_ROPE_LOCAL"),
+            ("ROPE_GLOBAL", theta, "ROPE_GLOBAL_SIZE", "DRAM_ADDR_ROPE_GLOBAL"),
+        ]:
+            inv_freq = 1.0 / (theta_val ** (torch.arange(D_per_head, dtype=torch.float32) / D_per_head))
+            pos = torch.arange(num_rope_positions, dtype=torch.float32)
+            freqs = torch.outer(pos, inv_freq)
+            cos_head = freqs.cos().to(torch.bfloat16)  # (num_pos, 64)
+            sin_head = freqs.sin().to(torch.bfloat16)  # (num_pos, 64)
+            # Per-head layout (no tiling): [cos_head, cos_head, -sin_head, sin_head]
+            rope_tensor = torch.cat([cos_head, cos_head, -sin_head, sin_head], dim=1)  # (num_pos, 256)
+            sz = self.weight_defs[sz_key]
+            raw = rope_tensor.contiguous().view(torch.uint8).numpy().tobytes()
+            raw = (raw + b"\x00" * sz)[:sz]
+            addr = self.allocate_params_dram(sz)
+            self.dma_write(DMA_DEVICE_H2C, addr, raw, sz)
+            setattr(self, attr, addr)
+
+    def weight_init(self) -> None:
+        """Initialize DRAM: load HF embedding+tokenizer, layer weights from bin, host-computed RoPE, OUTPUT_NORM/LM_HEAD from bin."""
+        model, model_dir = _ensure_hf_model(self.script_dir, self._cfg)
+        # LLaMA does NOT scale the embedding by sqrt(hidden_size)
+        embed = model.get_input_embeddings().weight.detach().cpu().to(torch.bfloat16)
+        self.embedding_weight = embed
+        self.tokenizer = AutoTokenizer.from_pretrained(model_dir, trust_remote_code=True)
+
+        LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+        base_layer0 = self.weight_defs["BLK0_ATTN_NORM_WEIGHT"]
+        blk0_regions = [
+            (s["key"], f"{s['key']}_SIZE", s["attr"])
+            for s in self._cfg["layers"]["structure"]
+        ]
+        non_layer = [
+            (s["key"], f"{s['key']}_SIZE", s["attr"])
+            for s in self._cfg["layers"]["non_layer"]
+            if s["key"] not in ("ROPE_LOCAL", "ROPE_GLOBAL")  # RoPE loaded via _load_rope_host()
+        ]
+
+        layer0_end = (self.weight_defs["BLK0_POST_FFW_NORM_WEIGHT"] - base_layer0
+                      + self.weight_defs["BLK0_POST_FFW_NORM_WEIGHT_SIZE"])
+        assert layer0_end == LAYER_WEIGHT_SIZE, (
+            f"Layer 0 size mismatch: computed {layer0_end} != LAYER_WEIGHT_SIZE {LAYER_WEIGHT_SIZE}"
+        )
+
+        print(f"\n--- Weights DRAM allocation, start at DRAM address: {self.get_params_dram_addr()} ---")
+        layers_total = self.LAYER_SIZE * LAYER_WEIGHT_SIZE
+        layers_base_dram = self.allocate_params_dram(layers_total)
+        for layer_idx in range(self.LAYER_SIZE):
+            for off_key, sz_key, attr in blk0_regions:
+                off = self.weight_defs[off_key]
+                sz = self.weight_defs[sz_key]
+                bin_off = off + layer_idx * LAYER_WEIGHT_SIZE
+                raw = self.weight_bin[bin_off : bin_off + sz]
+                offset_in_layer = off - base_layer0
+                dram_addr = layers_base_dram + layer_idx * LAYER_WEIGHT_SIZE + offset_in_layer
+                self.dma_write(DMA_DEVICE_H2C, dram_addr, raw, sz)
+            if layer_idx == 0:
+                for off_key, sz_key, attr in blk0_regions:
+                    off = self.weight_defs[off_key]
+                    offset_in_layer = off - base_layer0
+                    setattr(self, attr, layers_base_dram + offset_in_layer)
+        print(f"Layers 0..{self.LAYER_SIZE - 1} loaded: 0x{layers_base_dram:X} size {layers_total} (LAYER_WEIGHT_SIZE={LAYER_WEIGHT_SIZE})")
+
+        for off_key, sz_key, attr in non_layer:
+            off = self.weight_defs[off_key]
+            sz = self.weight_defs[sz_key]
+            raw = self.weight_bin[off : off + sz]
+            addr = self.allocate_params_dram(sz)
+            self.dma_write(DMA_DEVICE_H2C, addr, raw, sz)
+            setattr(self, attr, addr)
+
+        self._load_rope_host()
+        print(f"    Allocate weights end at DRAM address: 0x{self.get_params_dram_addr():X}, usage: {self.get_params_dram_usage()} bytes")
+        print("Tokenizer loaded successfully.")
+
+    def tensor_init(self) -> None:
+        """Initialize hardware DRAM tensors for Llama-3.2-3B (layer-wise overlap except for kv cache)."""
+        seq_len = self.MAX_CONTEXT_SIZE
+        q_seq_len = seq_len * self.group_size
+        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+
+        print(f"Allocate tensor dram start at DRAM address: 0x{self.get_tensor_dram_addr():X}")
+        # Allocate shared memory for k v cache (k rope and v projection) and zero pad for decoder use:
+        self.LAYER0_V_DRAM = self.allocate_tensor_dram(self.LAYER_SIZE * self.MAX_CONTEXT_SIZE * self.k_size)
+        self.LAYER0_K_ROPE_DRAM = self.allocate_tensor_dram(self.LAYER_SIZE * self.MAX_CONTEXT_SIZE * self.k_size)
+        zero_pad = torch.zeros(self.LAYER_SIZE * self.MAX_CONTEXT_SIZE * self.k_size, dtype=torch.bfloat16)
+        self.dma_to_accelerator_memory(self.LAYER0_V_DRAM, zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_K_ROPE_DRAM, zero_pad)
+        # Allocate memory for constant zero tensor, identity matrix, and bias:
+        zero_add = torch.zeros(seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
+        self.ZERO_DRAM_ADDR = self.allocate_tensor_dram(seq_len * self.head_dim * self.bytes_per_element)
+        self.dma_to_accelerator_memory(self.ZERO_DRAM_ADDR, zero_add)
+        self.IDENTITY_DRAM_ADDR = self.allocate_tensor_dram(UE_VECTOR_SIZE * UE_VECTOR_SIZE * self.bytes_per_element)
+        self.dma_to_accelerator_memory(self.IDENTITY_DRAM_ADDR, torch.eye(UE_VECTOR_SIZE, dtype=torch.bfloat16))
+        # Allocate memory for flash attention and zero pad:
+        self.LAYER0_FLASH_Q_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.head_dim * self.bytes_per_element)
+        self.LAYER0_FLASH_K_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.head_dim * self.bytes_per_element)
+        self.LAYER0_FLASH_V_DRAM = self.allocate_tensor_dram(aligned_seq_len * self.head_dim * self.bytes_per_element)
+        zero_pad = torch.zeros(aligned_seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_Q_DRAM, zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_K_DRAM, zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_V_DRAM, zero_pad)
+        # Allocate memory for layer intermediate tensors:
+        self.LAYER0_INPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_PRE_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_Q_DRAM = self.allocate_tensor_dram(seq_len * self.q_size)
+        self.LAYER0_K_DRAM = self.allocate_tensor_dram(seq_len * self.k_size)
+        # K_NORM and Q_NORM aliases: for LLaMA these point to K_DRAM/Q_DRAM (no norm applied)
+        self.LAYER0_K_NORM_DRAM = self.LAYER0_K_DRAM
+        self.LAYER0_Q_NORM_DRAM = self.LAYER0_Q_DRAM
+        # Temp buffer: v_proj interleaved output (T, 512) written during prefill before
+        # per-head reorganization into the V KV cache (per-head layout).
+        self.LAYER0_V_PROJ_TEMP = self.allocate_tensor_dram(seq_len * self.k_size)
+        # Per-head flash output (T*group_size, actual_head_dim); reused across 8 KV heads.
+        self.LAYER0_FLASH_OUT_HEAD_DRAM = self.allocate_tensor_dram(
+            aligned_seq_len * self.actual_head_dim * self.bytes_per_element)
+        self.LAYER0_FLASH_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.head_dim * self.group_size * self.bytes_per_element)
+        self.LAYER0_FLASH_SCRATCH_DRAM = self.allocate_tensor_dram(max(self.head_dim, UE_FMAX_CONTEXT_SIZE) * aligned_seq_len * 2 + self.head_dim * aligned_seq_len * 2)
+        self.LAYER0_FLASH_BIAS_DRAM = self.allocate_tensor_dram(aligned_seq_len * aligned_seq_len * self.bytes_per_element)
+        self.LAYER0_FLASH_ATTN_P_DRAM = self.allocate_tensor_dram(aligned_seq_len * aligned_seq_len * self.bytes_per_element)
+        self.LAYER0_ATTN_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_POST_ATTN_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_POST_ATTN_RESIDUAL_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_PRE_MLP_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_MLP_GATE_DRAM = self.allocate_tensor_dram(seq_len * self.mlp_elements * 2)
+        self.LAYER0_MLP_UP_DRAM = self.allocate_tensor_dram(seq_len * self.mlp_elements * 2)
+        self.LAYER0_MLP_MULT_DRAM = self.allocate_tensor_dram(seq_len * self.mlp_elements * 2)
+        self.LAYER0_MLP_DOWN_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_POST_MLP_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
+        self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
+
+        print(f"    Allocate tensor dram end at DRAM address: 0x{self.get_tensor_dram_addr():X}, usage: {self.get_tensor_dram_usage()} bytes")
+
+    def _compile_prefill_program(self, template_seq_len: int, layer_size: int) -> dict:
+        """Compile prefill into the active capture session.
+
+        ``template_seq_len`` is used only for FLOPs accounting and static M= args;
+        all runtime loop counts are driven by ``gpr_seq_len`` / ``gpr_bucket_idx``
+        primed by the caller's preamble, so a single bin works for any seq_len.
+        Returns dict with ``size_bytes`` and ``flops``.
+        """
+        if not getattr(self, "is_capture_on", False):
+            raise RuntimeError("_compile_prefill_program() requires an active capture session")
+        count_at_start = self.capture_count
+        seq_len = template_seq_len
+        q_seq_len = seq_len * self.group_size
+        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+
+        global _SILENT_MODE
+        _SILENT_MODE = True
+        num_bucket = (self.PREFILL_CONTEXT_SIZE * self.group_size + 63) // 64
+        gpr_tmp = self.alloc_isa_reg()
+        self.generate_instruction_reg_mul_imm(gpr_tmp, self.gpr_seq_len, self.vector_length * self.bytes_per_element)
+        total_flops = 0
+        LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+        for layer_idx in range(layer_size):
+            layer_off = layer_idx * LAYER_WEIGHT_SIZE
+            if layer_idx != 0:
+                # Inter-layer copy: previous layer's OUTPUT → next layer's INPUT.
+                # Per-token PBI loop (one row of vector_length per iter, gpr_seq_len trips)
+                # so it never exceeds URAM-A; a single seq_len*vector_length SRAM stage
+                # would overflow URAM once PREFILL_CONTEXT_SIZE > 64 (see notes).
+                self._emit_pbi_scatter_per_token(
+                    read_base=self.LAYER0_OUTPUT_DRAM,
+                    read_stride_bytes=self.vector_length * self.bytes_per_element,
+                    write_specs=[(self.LAYER0_INPUT_DRAM, self.vector_length * self.bytes_per_element)],
+                    sram_byte_addr=0x10000,
+                    element_count=self.vector_length,
+                    gpr_seq_len=self.gpr_seq_len,
+                    template_seq_len=seq_len,
+                )
+            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+                              OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off,
+                              gpr_M_reg=self.gpr_seq_len)
+
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
+                A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                gpr_M_reg=self.gpr_seq_len)
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+                A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                gpr_M_reg=self.gpr_seq_len)
+            # v_proj writes to interleaved temp (T, 512); per-head KV cache populated below.
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+                A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_V_PROJ_TEMP,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                gpr_M_reg=self.gpr_seq_len)
+
+            # LLaMA 3B per-head GQA: rope_hf_core_dram_gqa(N=actual_head_dim=128) applies
+            # RoPE to each Q/K head independently on HF's natural per-head [lo,hi] layout
+            # (NO q/k weight permutation). Then scatter contiguous ahd-dim per-head slices
+            # into per-head flash buffers + KV cache, then flash_attention(head_dim=128) × 8.
+            ROPE_WEIGHT_ADDR = self.DRAM_ADDR_ROPE_GLOBAL if layer_idx in self._rope_global_layers else self.DRAM_ADDR_ROPE_LOCAL
+            ahd      = self.actual_head_dim   # 128
+            nkvh     = self.num_kv_heads      # 8
+            nqh      = self.num_q_heads       # 24 (= nkvh * group_size)
+            qpkv     = self.group_size        # 3
+            bpe      = self.bytes_per_element
+            hd       = self.head_dim          # 1024 (combined KV-head width)
+            total_q_dim = hd * qpkv           # 3072 (o_proj input width = nqh * ahd)
+            rope_row = 2 * ahd * bpe          # 512 bytes per rope table row (N=128)
+
+            # Phase 1: K per-head RoPE in-place (N=ahd=128); K layout [seq_len, nkvh, ahd].
+            # cos/sin shared across heads per token; sin = cos + ahd*bpe (per-head table).
+            total_flops += self.rope_hf_core_dram_gqa(
+                M=seq_len, group_size=nkvh, N=ahd,
+                input_dram_addr=self.LAYER0_K_DRAM,
+                output_dram_addr=self.LAYER0_K_DRAM,
+                cos_dram_addr=ROPE_WEIGHT_ADDR,
+                sin_dram_addr=ROPE_WEIGHT_ADDR + ahd * bpe,
+                gpr_M_reg=self.gpr_seq_len,
+            )
+
+            # Phase 2: Q per-head RoPE in-place (N=ahd=128); Q layout [seq_len, nqh, ahd].
+            total_flops += self.rope_hf_core_dram_gqa(
+                M=seq_len, group_size=nqh, N=ahd,
+                input_dram_addr=self.LAYER0_Q_DRAM,
+                output_dram_addr=self.LAYER0_Q_DRAM,
+                cos_dram_addr=ROPE_WEIGHT_ADDR,
+                sin_dram_addr=ROPE_WEIGHT_ADDR + ahd * bpe,
+                gpr_M_reg=self.gpr_seq_len,
+            )
+
+            # Phase 3: Per-KV-head scatter → KV cache + flash buffers → flash_attention.
+            # Each kv_h owns qpkv consecutive Q heads (kv_h*qpkv .. kv_h*qpkv+qpkv-1) in HF
+            # order; per-head ahd-dim slices are CONTIGUOUS (no lo/hi split, no permutation).
+            for kv_h in range(nkvh):
+                k_cache_base = (self.LAYER0_K_ROPE_DRAM
+                                + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                                + kv_h * self.MAX_CONTEXT_SIZE * ahd * bpe)
+                v_cache_base = (self.LAYER0_V_DRAM
+                                + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                                + kv_h * self.MAX_CONTEXT_SIZE * ahd * bpe)
+
+                # Scatter K head (contiguous ahd at kv_h*ahd in K_DRAM[seq,hd]) → KV cache + FLASH_K (qpkv copies)
+                self._emit_pbi_scatter_per_token(
+                    read_base=self.LAYER0_K_DRAM + kv_h * ahd * bpe,
+                    read_stride_bytes=hd * bpe,
+                    write_specs=(
+                        [(k_cache_base, ahd * bpe)]
+                        + [(self.LAYER0_FLASH_K_DRAM + g * ahd * bpe, qpkv * ahd * bpe) for g in range(qpkv)]
+                    ),
+                    sram_byte_addr=0x10000,
+                    element_count=ahd,
+                    gpr_seq_len=self.gpr_seq_len,
+                    template_seq_len=seq_len,
+                )
+
+                # Scatter V head (contiguous ahd) from V_PROJ_TEMP[seq, nkvh, ahd] → KV cache + FLASH_V (qpkv copies)
+                self._emit_pbi_scatter_per_token(
+                    read_base=self.LAYER0_V_PROJ_TEMP + kv_h * ahd * bpe,
+                    read_stride_bytes=nkvh * ahd * bpe,
+                    write_specs=(
+                        [(v_cache_base, ahd * bpe)]
+                        + [(self.LAYER0_FLASH_V_DRAM + g * ahd * bpe, qpkv * ahd * bpe) for g in range(qpkv)]
+                    ),
+                    sram_byte_addr=0x20000,
+                    element_count=ahd,
+                    gpr_seq_len=self.gpr_seq_len,
+                    template_seq_len=seq_len,
+                )
+
+                # Scatter this KV head's qpkv Q heads (each contiguous ahd at (kv_h*qpkv+q)*ahd) → FLASH_Q
+                for q in range(qpkv):
+                    self._emit_pbi_scatter_per_token(
+                        read_base=self.LAYER0_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe,
+                        read_stride_bytes=total_q_dim * bpe,
+                        write_specs=[(self.LAYER0_FLASH_Q_DRAM + q * ahd * bpe, qpkv * ahd * bpe)],
+                        sram_byte_addr=0x30000,
+                        element_count=ahd,
+                        gpr_seq_len=self.gpr_seq_len,
+                        template_seq_len=seq_len,
+                    )
+
+                # Flash attention for this KV head (head_dim=64) — PBI bucket dispatcher;
+                # gpr_bucket_idx is primed at program start (ADD_SET above) so the dispatcher
+                # routes to the correct bucket body for the actual runtime seq_len.
+                flash_result = self.flash_attention_core(
+                    head_dim=ahd,
+                    seq_len=aligned_seq_len,
+                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
+                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                    ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
+                    gpr_bucket_idx=self.gpr_bucket_idx,
+                    num_buckets=num_bucket,
+                )
+                total_flops += flash_result[num_bucket - 1]
+
+                # Assemble output into LAYER0_FLASH_OUTPUT_DRAM
+                # Standard GQA layout per token: [kv0_q0(64), kv0_q1..q3, kv1_q0..q3, ...]
+                out_h_base = kv_h * qpkv * ahd * bpe
+                t_reg = self.alloc_isa_reg()
+                src_off_reg = self.alloc_isa_reg()
+                dst_off_reg = self.alloc_isa_reg()
+                self.generate_instruction_add_set(t_reg, 0)
+                self.loop_start(loop_cnt=seq_len, gpr_loop_cnt=self.gpr_seq_len)
+                self.generate_instruction_reg_mul_imm(src_off_reg, t_reg, ue_35bit_addr_shifter(qpkv * ahd * bpe))
+                self.generate_instruction_reg_mul_imm(dst_off_reg, t_reg, ue_35bit_addr_shifter(total_q_dim * bpe))
+                for g in range(qpkv):
+                    self.generate_instruction_add_imm(src_off_reg, ue_35bit_addr_shifter(self.LAYER0_FLASH_OUT_HEAD_DRAM + g * ahd * bpe), self.TMP_REG)
+                    self.accelerator_memory_to_sram(0, 0x40000, ahd, general_reg_src=self.TMP_REG)
+                    self.generate_instruction_add_imm(dst_off_reg, ue_35bit_addr_shifter(self.LAYER0_FLASH_OUTPUT_DRAM + out_h_base + g * ahd * bpe), self.TMP_REG)
+                    self.sram_to_accelerator_memory(0x40000, 0, ahd, general_reg_src=self.TMP_REG)
+                self.generate_instruction_add_inc(t_reg)
+                self.loop_end()
+                self.release_isa_reg()  # dst_off_reg
+                self.release_isa_reg()  # src_off_reg
+                self.release_isa_reg()  # t_reg
+
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
+                A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                gpr_M_reg=self.gpr_seq_len)
+
+            # LLaMA: no post-attention norm; add residual directly to o_proj output.
+            # Per-row PBI loop (gpr_seq_len trips) — no URAM cap on prefill length.
+            self.eltwise_core_dram(
+                M=seq_len, N=self.vector_length,
+                dram_a=self.LAYER0_INPUT_DRAM,
+                dram_b=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
+                dram_out=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                mode=UE_MODE.ELTWISE_ADD,
+                gpr_M_reg=self.gpr_seq_len,
+            )
+
+            # LLaMA: post_attention_layernorm IS the pre-FFN norm
+            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                              OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off,
+                              gpr_M_reg=self.gpr_seq_len)
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+                A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True,
+                gpr_M_reg=self.gpr_seq_len)
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+                A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4,
+                gpr_M_reg=self.gpr_seq_len)
+            # gate × up — per-row PBI loop (gpr_seq_len trips); one row of mlp_elements per iter.
+            self.eltwise_core_dram(
+                M=seq_len, N=self.mlp_elements,
+                dram_a=self.LAYER0_MLP_GATE_DRAM,
+                dram_b=self.LAYER0_MLP_UP_DRAM,
+                dram_out=self.LAYER0_MLP_MULT_DRAM,
+                mode=UE_MODE.ELTWISE_MUL,
+                gpr_M_reg=self.gpr_seq_len,
+            )
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
+                A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4,
+                gpr_M_reg=self.gpr_seq_len)
+
+            # LLaMA: no post-FFN norm; add residual directly to down_proj output.
+            # Per-row PBI loop (gpr_seq_len trips) — layer_output = POST_ATTN_RESIDUAL + MLP_DOWN.
+            self.eltwise_core_dram(
+                M=seq_len, N=self.vector_length,
+                dram_a=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                dram_b=self.LAYER0_MLP_DOWN_DRAM,
+                dram_out=self.LAYER0_OUTPUT_DRAM,
+                mode=UE_MODE.ELTWISE_ADD,
+                gpr_M_reg=self.gpr_seq_len,
+            )
+        self.release_isa_reg()  # gpr_tmp
+        self.generate_instruction_halt()
+        prefill_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
+        _SILENT_MODE = False
+        return {"size_bytes": prefill_program_size, "flops": total_flops}
+
+    def _compile_decoder_program(self, layer_size: int) -> dict:
+        """Compile decoder into the active capture session.
+        Returns dict with ``program_size_bytes`` and ``total_flops``.
+        """
+        if not getattr(self, "is_capture_on", False):
+            raise RuntimeError("_compile_decoder_program() requires an active capture session")
+        count_at_start = self.capture_count
+        LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+        total_flops = 0
+
+        global _SILENT_MODE
+        _SILENT_MODE = True
+        for layer_idx in range(layer_size):
+                layer_off = layer_idx * LAYER_WEIGHT_SIZE
+                if layer_idx != 0:
+                    self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
+                    self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_INPUT_DRAM, element_size=self.vector_length)
+                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+                              OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim * self.group_size,
+                    A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
+                    A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
+                    A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+
+                # LLaMA 3B per-head GQA decoder: rope_hf_core_decode(N=128) per head on K and
+                # Q in-place (HF natural layout, no permutation), then scatter contiguous
+                # ahd-dim per-head slices to the KV cache (V_CACHE_SIZE_REG = decode position),
+                # then decoder_group_attention(head_dim=128) per KV head.
+                ROPE_WEIGHT_ADDR = self.DRAM_ADDR_ROPE_GLOBAL if layer_idx in self._rope_global_layers else self.DRAM_ADDR_ROPE_LOCAL
+                ahd      = self.actual_head_dim   # 128
+                nkvh     = self.num_kv_heads      # 8
+                nqh      = self.num_q_heads       # 24
+                qpkv     = self.group_size        # 3
+                bpe      = self.bytes_per_element
+                hd       = self.head_dim          # 1024
+
+                # Step 1: K per-head RoPE in-place (N=ahd=128 per head; ROPE_SIZE_REG = decode pos × rope_row)
+                for kv_h in range(nkvh):
+                    total_flops += self.rope_hf_core_decode(
+                        N=ahd,
+                        input_dram_addr=self.LAYER0_K_DRAM + kv_h * ahd * bpe,
+                        output_dram_addr=self.LAYER0_K_DRAM + kv_h * ahd * bpe,
+                        cos_dram_addr=ROPE_WEIGHT_ADDR,
+                        sin_dram_addr=ROPE_WEIGHT_ADDR + ahd * bpe,
+                        rope_size_reg=self.ROPE_SIZE_REG,
+                        tmp_reg=self.TMP_REG)
+
+                # Step 2: Q per-head RoPE in-place (N=ahd=128 per Q head; 24 heads)
+                for qh in range(nqh):
+                    total_flops += self.rope_hf_core_decode(
+                        N=ahd,
+                        input_dram_addr=self.LAYER0_Q_DRAM + qh * ahd * bpe,
+                        output_dram_addr=self.LAYER0_Q_DRAM + qh * ahd * bpe,
+                        cos_dram_addr=ROPE_WEIGHT_ADDR,
+                        sin_dram_addr=ROPE_WEIGHT_ADDR + ahd * bpe,
+                        rope_size_reg=self.ROPE_SIZE_REG,
+                        tmp_reg=self.TMP_REG)
+
+                # Step 3: Per-KV-head scatter K/V to cache (contiguous) + scatter Q → decoder_attention
+                for kv_h in range(nkvh):
+                    k_cache_base = (self.LAYER0_K_ROPE_DRAM
+                                    + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                                    + kv_h * self.MAX_CONTEXT_SIZE * ahd * bpe)
+                    v_cache_base = (self.LAYER0_V_DRAM
+                                    + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                                    + kv_h * self.MAX_CONTEXT_SIZE * ahd * bpe)
+
+                    # Scatter K head (contiguous ahd at kv_h*ahd) → KV cache at decode position
+                    self.accelerator_memory_to_sram(
+                        self.LAYER0_K_DRAM + kv_h * ahd * bpe, 0x10000, ahd)
+                    self.generate_instruction_add_imm(
+                        self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(k_cache_base), self.TMP_REG)
+                    self.sram_to_accelerator_memory(0x10000, 0, ahd)
+                    self.overwrite_instruction_with_general_register(self.TMP_REG)
+
+                    # Scatter V head (contiguous ahd) from FLASH_V[kv0..kv7] → V cache at decode position
+                    self.accelerator_memory_to_sram(
+                        self.LAYER0_FLASH_V_DRAM + kv_h * ahd * bpe, 0x20000, ahd)
+                    self.generate_instruction_add_imm(
+                        self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(v_cache_base), self.TMP_REG)
+                    self.sram_to_accelerator_memory(0x20000, 0, ahd)
+                    self.overwrite_instruction_with_general_register(self.TMP_REG)
+
+                    # Scatter this KV head's qpkv Q heads (contiguous ahd at (kv_h*qpkv+q)*ahd) → FLASH_Q
+                    for q in range(qpkv):
+                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe
+                        self.accelerator_memory_to_sram(
+                            self.LAYER0_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe, 0x30000, ahd)
+                        self.sram_to_accelerator_memory(0x30000, flash_q_addr, ahd)
+                    attn_flops = self.decoder_group_attention_core(
+                        group_size=qpkv,
+                        head_dim=ahd,
+                        seq_len=self.MAX_CONTEXT_SIZE,
+                        gpr_bucket_idx=self.gpr_bucket_idx,
+                        num_buckets=(self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE,
+                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM + kv_h * qpkv * ahd * bpe,
+                        K_DRAM_ADDR=k_cache_base,
+                        V_DRAM_ADDR=v_cache_base,
+                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe,
+                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                    )
+                    total_flops += attn_flops[-1]
+                total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
+                    A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+
+                # LLaMA: no post-attention norm; residual directly on o_proj output
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_INPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, sram_address=0x90000, element_size=self.vector_length)
+                self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
+                self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
+
+                # LLaMA: post_attention_layernorm IS the pre-FFN norm
+                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                              OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off)
+
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
+                    A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
+                    A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4)
+
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_GATE_DRAM, sram_address=0x10000, element_size=self.mlp_elements)
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
+                self.eltwise_mul_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.mlp_elements)
+                self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_MLP_MULT_DRAM, element_size=self.mlp_elements)
+
+                total_flops += self.quantized_matmat_core(M=1, K=self.mlp_elements, N=self.vector_length,
+                    A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4)
+
+                # LLaMA: no post-FFN norm; residual directly on down_proj output
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, sram_address=0x10000, element_size=self.vector_length)
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_DOWN_DRAM, sram_address=0x90000, element_size=self.vector_length)
+                self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
+                self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, element_size=self.vector_length)
+
+        if layer_size == self.LAYER_SIZE:
+            total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
+                OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
+            # LM head: in greedy mode the HW argmax register is populated as a
+            # pipeline side-effect, so skip the full vocab-logits writeback to DRAM
+            # (write_back_disable). For sampling (temperature > 0) writeback MUST be
+            # enabled so the host can DMA the logits row back for repetition-penalty /
+            # top-k / top-p / multinomial in sample_next_token(). This is a compile-time
+            # gate reading ue.temperature, which main() sets before compile_llama().
+            _greedy_lm_head = float(getattr(self, "temperature", 0.0)) <= 0
+            total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+                A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
+                write_back_disable=_greedy_lm_head)
+
+        self.generate_instruction_halt()
+        decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
+        _SILENT_MODE = False
+        return {"program_size_bytes": decoder_program_size, "total_flops": total_flops}
+
+    def compile_llama(self, layer_size: int | None = None) -> None:
+        """Compile prefill + decoder into a single combined instruction image.
+
+        Layout in program DRAM:  [prefill][decoder]
+
+        Prefill is compiled with a fixed template (UE_VECTOR_SIZE) — all runtime
+        loop counts are driven by GPRs primed by the preamble, so the same bin
+        works for any seq_len. If both bin and meta already exist, this is a no-op.
+
+        Writes:
+          - paths.instruction_bin  : combined raw instruction stream
+          - paths.instruction_meta : per-stage start addresses, sizes, FLOPs
+        """
+        if layer_size is None:
+            layer_size = self.LAYER_SIZE
+        paths_cfg = self._cfg.get("paths", {})
+        instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_3b_bin/llama_instruction.bin"))
+        instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
+        if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
+            print(f"Reusing existing instruction image at {instruction_bin_path}")
+            print(f"  delete {instruction_bin_path} to force recompile.")
+            return
+
+        # Compile the prefill template at PREFILL_CONTEXT_SIZE (the max prompt length).
+        # All loop counts are GPR-driven (gpr_seq_len), so the single cached program
+        # handles any actual prompt length <= PREFILL_CONTEXT_SIZE; template_seq_len is
+        # used only for FLOPs accounting and the flash bucket count.
+        template_seq_len = self.PREFILL_CONTEXT_SIZE
+
+        self.clear_inst_id()
+        self.start_capture()
+
+        print(f"Compiling prefill (template_seq_len={template_seq_len})...")
+        t0 = time.perf_counter()
+        prefill_prog = self._compile_prefill_program(template_seq_len=template_seq_len, layer_size=layer_size)
+        print(f"  prefill compiled: {prefill_prog['size_bytes']} bytes, {time.perf_counter() - t0:.1f}s")
+
+        print("Compiling decoder...")
+        t0 = time.perf_counter()
+        decoder_prog = self._compile_decoder_program(layer_size=layer_size)
+        print(f"  decoder compiled: {decoder_prog['program_size_bytes']} bytes, {time.perf_counter() - t0:.1f}s")
+
+        self.stop_capture()
+
+        os.makedirs(os.path.dirname(instruction_bin_path), exist_ok=True)
+        instruction_bytes = bytearray()
+        for inst in self.capture_buffer:
+            instruction_bytes.extend(inst.get_bytes())
+        with open(instruction_bin_path, "wb") as f:
+            f.write(instruction_bytes)
+        self.clear_capture_buffer()
+
+        instruction_base_addr = self.get_program_dram_addr()
+        prefill_program_addr = instruction_base_addr
+        decoder_program_addr = instruction_base_addr + prefill_prog["size_bytes"]
+
+        metadata = {
+            "instruction_bin": os.path.relpath(instruction_bin_path, self.script_dir),
+            "instruction_base_addr": f"0x{instruction_base_addr:X}",
+            "instruction_total_size": len(instruction_bytes),
+            "prefill_template_seq_len": template_seq_len,
+            "prefill_program_start_addr": f"0x{prefill_program_addr:X}",
+            "prefill_program_size": prefill_prog["size_bytes"],
+            "prefill_template_flops": prefill_prog["flops"],
+            "decoder_program_start_addr": f"0x{decoder_program_addr:X}",
+            "decoder_program_size": decoder_prog["program_size_bytes"],
+            "decoder_total_flops": decoder_prog["total_flops"],
+        }
+        with open(instruction_meta_path, "w") as f:
+            json.dump(metadata, f, indent=2)
+        print(f"Combined instruction image written to {instruction_bin_path} ({len(instruction_bytes)} bytes)")
+        print(f"Metadata written to {instruction_meta_path}")
+
+    def _structural_token_ids(self) -> set:
+        """Token ids that must NEVER be repetition-penalized: punctuation, whitespace,
+        newline, and special tokens. Precomputed once from the tokenizer vocab and cached.
+
+        These 'glue' tokens recur constantly in any text; penalizing them over a long
+        generation is what starves a small model of grammatical structure and produces
+        word-salad. Exempting them lets the repetition penalty target only content tokens.
+        """
+        cached = getattr(self, "_struct_ids_cache", None)
+        if cached is not None:
+            return cached
+        import string
+        allowed = set(string.punctuation) | set(string.whitespace) | set("—–’‘“”…·•‹›«»¡¿")
+        ids = set(int(i) for i in (getattr(self.tokenizer, "all_special_ids", []) or []))
+        for i in range(self.EMBEDDING_ELEMENTS):
+            s = self.tokenizer.decode([i]).strip()
+            if s == "" or all(ch in allowed for ch in s):
+                ids.add(i)
+        self._struct_ids_cache = ids
+        return ids
+
+    def _structural_ids_tensor(self) -> torch.Tensor:
+        """1-D LongTensor of the structural/special token ids (cached) for vectorized
+        exemption in the repetition penalty."""
+        t = getattr(self, "_struct_ids_tensor_cache", None)
+        if t is None:
+            t = torch.tensor(sorted(self._structural_token_ids()), dtype=torch.long)
+            self._struct_ids_tensor_cache = t
+        return t
+
+    def sample_next_token(self, prev_tokens: list[int]) -> int:
+        """Read full logits from LOGITS_DRAM and sample the next token using the
+        engine's configured ``temperature`` / ``top_k`` / ``top_p`` /
+        ``repetition_penalty`` (mechanism mirrors qwen3_1.7b). Greedy fast path
+        (HW argmax register) is used when ``temperature <= 0`` — the caller
+        dispatches, this method assumes sampling is enabled.
+
+        prev_tokens: token ids already in the sequence (prompt + decoded), used
+                     by the repetition penalty to down-weight repeats.
+
+        Requires the decoder bin to have been compiled with LM-head writeback
+        ENABLED (i.e. temperature > 0 at compile time), so LOGITS_DRAM holds the
+        full vocab row rather than only the HW argmax index.
+        """
+        vocab = self.EMBEDDING_ELEMENTS
+        bpe = self.bytes_per_element
+        # DMA logits row to host. ~256 KB for the Llama vocab; negligible vs decode latency.
+        buf = torch.empty(vocab, dtype=torch.bfloat16)
+        self.dma_read(DMA_DEVICE_C2H, self.LOGITS_DRAM, buf, vocab * bpe)
+        logits = buf.float()
+        # Repetition penalty — recency-decayed frequency form (not flat binary).
+        # For each token in the last ``rep_window`` tokens, accumulate a weight
+        #   w[t] = sum over its occurrences of  rep_decay ** age   (age 0 = most recent),
+        # then scale logits by  rep_pen ** w[t]  (divide positives / multiply negatives).
+        # So a token used ONCE a while ago gets w≈small → factor≈1 (barely touched), while
+        # a token looped several times very recently gets a large w → strong suppression.
+        # This fixes two failure modes of the old flat penalty: (1) it no longer flips
+        # intentionally-repeated scaffolding (e.g. "Chapter" reused a paragraph later is
+        # only mildly nudged), and (2) it still crushes genuine short-range loops.
+        # Structural "glue" tokens (punctuation/whitespace/newline/special) stay exempt.
+        rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        if rep_pen != 1.0 and prev_tokens:
+            rep_window = int(getattr(self, "rep_window", 256))
+            rep_decay = float(getattr(self, "rep_decay", 0.97))
+            window = torch.tensor(prev_tokens[-rep_window:], dtype=torch.long)
+            L = window.numel()
+            ages = torch.arange(L - 1, -1, -1, dtype=torch.float32)   # oldest=L-1 ... newest=0
+            contrib = rep_decay ** ages
+            weight = torch.zeros(vocab, dtype=torch.float32)
+            weight.index_add_(0, window, contrib)                     # recency-weighted count per id
+            weight[self._structural_ids_tensor()] = 0.0               # never penalize glue/special
+            nz = weight > 0
+            if bool(nz.any()):
+                factor = rep_pen ** weight[nz]                        # >= 1, grows with recency*count
+                v = logits[nz]
+                logits[nz] = torch.where(v > 0, v / factor, v * factor)
+        # Temperature
+        temp = float(getattr(self, "temperature", 1.0))
+        if temp <= 0:
+            return int(logits.argmax().item())
+        logits = logits / temp
+        # Top-k
+        top_k = int(getattr(self, "top_k", 0) or 0)
+        if top_k > 0 and top_k < vocab:
+            kth = torch.topk(logits, top_k).values[-1]
+            logits[logits < kth] = float("-inf")
+        # Top-p (nucleus)
+        top_p = float(getattr(self, "top_p", 1.0))
+        if 0.0 < top_p < 1.0:
+            sorted_logits, sorted_idx = torch.sort(logits, descending=True)
+            probs = torch.softmax(sorted_logits, dim=-1)
+            cumprob = torch.cumsum(probs, dim=-1)
+            # mask tokens whose cumulative prob > top_p (keep at least 1)
+            keep = cumprob <= top_p
+            keep[0] = True
+            drop_idx = sorted_idx[~keep]
+            logits[drop_idx] = float("-inf")
+        probs = torch.softmax(logits, dim=-1)
+        return int(torch.multinomial(probs, num_samples=1).item())
+
+    def run_llama(self) -> None:
+        """Load the unified instruction image and run prefill + decoder loop.
+
+        Primes GPRs via a small captured preamble that jumps into the cached
+        prefill or decoder program at runtime.
+        """
+        paths_cfg = self._cfg.get("paths", {})
+        meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
+        with open(meta_path, "r") as f:
+            meta = json.load(f)
+
+        self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))
+        preamble_addr = self.get_program_dram_addr()
+
+        prefill_program_addr = int(meta["prefill_program_start_addr"], 16)
+        decoder_program_addr = int(meta["decoder_program_start_addr"], 16)
+        template_seq_len = int(meta["prefill_template_seq_len"])
+        flops_prefill_template = meta["prefill_template_flops"]
+        decoder_flops_per_token = meta["decoder_total_flops"]
+        _max_gpr_bucket = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
+        _kv_stride = self.actual_head_dim * self.bytes_per_element       # per-head KV cache stride (256 B)
+        _rope_row  = 2 * self.actual_head_dim * self.bytes_per_element    # per-head rope table row (512 B)
+
+        prefill_seq = self.prefill_seq
+        if prefill_seq is None:
+            prefill_seq = tuple(self._cfg["default_prefill_tokens"])
+        if len(prefill_seq) < 2:
+            raise ValueError("Prefill sequence must have at least 2 tokens.")
+        prefill_seq = prefill_seq[:-1]  # last token starts the decoder
+        prefill_seq_len = len(prefill_seq)
+        self.seq_len = prefill_seq_len
+
+        q_seq_len = prefill_seq_len * self.group_size
+        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
+        flops_prefill = flops_prefill_template * prefill_seq_len // max(template_seq_len, 1)
+
+        # Prefill preamble: prime gpr_seq_len + gpr_bucket_idx, then jump into cached prefill.
+        self.clear_inst_id()
+        self.start_capture()
+        self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
+        self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
+        self.stop_capture()
+        self.write_captured_instructions_to_dram(preamble_addr)
+        self.allocate_program_dram(self.get_capture_instruction_size_bytes())
+        self.clear_capture_buffer()
+
+        embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        rows = torch.arange(aligned_seq_len).unsqueeze(1)
+        cols = torch.arange(aligned_seq_len).unsqueeze(0)
+        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        bias_one_group.masked_fill_(valid_mask, 0.0)
+        bias_one_group[:, q_seq_len:] = float("-inf")
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
+
+        print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
+        print(f"Prompt ({len(self.prefill_seq)}) tokens: {self.prefill_seq}")
+        timer = time.perf_counter()
+        self.program_execute(preamble_addr, flops=flops_prefill)
+        latency_prefill = time.perf_counter() - timer
+        print(f"Prefill done in {latency_prefill:.2f}s\n")
+
+        print("--- Starting decoder ---")
+        timer = time.perf_counter()
+        token_id = self.prefill_seq[-1]
+        _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
+        global _SILENT_MODE
+
+        # Sampling state: repetition penalty in sample_next_token() considers every
+        # token seen so far (prompt + decoded), seeded by main() with the prompt ids.
+        # Falls back to the full prompt when run without main() (e.g. run_from_bin).
+        if not hasattr(self, "_generated_tokens"):
+            self._generated_tokens = list(self.prefill_seq)
+        _sampling = float(getattr(self, "temperature", 0.0)) > 0
+
+        # Two-region live counter: pin the bottom terminal row as a status line via
+        # an ANSI scroll region; tokens stream in the area above it and the counter
+        # refreshes in place. Only when stdout is a real TTY (skip when piped/redirected).
+        import shutil
+        _use_status = sys.stdout.isatty()
+        def _status_setup():
+            rows = shutil.get_terminal_size().lines
+            sys.stdout.write(f"\033[1;{rows - 1}r")   # scroll region = rows 1..rows-1
+            sys.stdout.write(f"\033[{rows - 1};1H")   # park cursor at bottom of region
+            sys.stdout.flush()
+        def _status_update():
+            rows = shutil.get_terminal_size().lines
+            n = self.seq_len - prefill_seq_len
+            elapsed = time.perf_counter() - timer
+            rate = n / elapsed if elapsed > 0 else 0.0
+            sys.stdout.write("\0337")                 # save cursor
+            sys.stdout.write(f"\033[{rows};1H\033[2K") # bottom row, clear it
+            sys.stdout.write(f" decoding… {n} tokens  (pos {self.seq_len}/{self.MAX_CONTEXT_SIZE})  "
+                             f"{elapsed:.1f}s  {rate:.1f} tok/s")
+            sys.stdout.write("\0338")                 # restore cursor
+            sys.stdout.flush()
+        def _status_teardown():
+            rows = shutil.get_terminal_size().lines
+            sys.stdout.write("\033[r")                # reset scroll region
+            sys.stdout.write(f"\033[{rows};1H\033[2K") # clear the status row
+            sys.stdout.flush()
+        if _use_status:
+            _status_setup()
+
+        while self.seq_len < self.MAX_CONTEXT_SIZE:
+            _SILENT_MODE = True
+            self.seq_len += 1
+            aligned_seq_len = ((self.seq_len + 63) // 64) * 64
+            bucket_idx = min((self.seq_len + 63) // 64, _max_gpr_bucket)
+            decode_pos = self.seq_len - 1
+
+            embedding_tensor = self.get_embedding_for_tokens([token_id])
+            self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+            bias_host = torch.full((1, aligned_seq_len), -1e36, dtype=torch.bfloat16)
+            bias_host[0, :self.seq_len] = 0.0
+            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host)
+
+            # Decoder preamble: prime 3 position GPRs + bucket, then jump into cached decoder.
+            self.clear_inst_id()
+            self.start_capture()
+            self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+            self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
+            self.generate_instruction_add_set(self.ROPE_SIZE_REG,    ue_35bit_addr_shifter(decode_pos * _rope_row))
+            self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
+            self.stop_capture()
+            self.write_captured_instructions_to_dram(preamble_addr)
+            self.clear_capture_buffer()
+
+            self.program_execute(preamble_addr, flops=decoder_flops_per_token)
+            # Sampling reads the full logits row (writeback enabled at compile time);
+            # greedy uses the HW argmax register (no host readback).
+            if _sampling:
+                token_id = self.sample_next_token(self._generated_tokens)
+            else:
+                token_id = self.get_arg_max_index(rank=1)
+            self._generated_tokens.append(token_id)
+            token_char = self.tokenizer.decode([token_id])
+            _SILENT_MODE = False
+            if token_id in _llama_stop_tokens:
+                if _use_status:
+                    _status_teardown()
+                print(f"\nStop token {token_id} reached.")
+                break
+            print(token_char, end="", flush=True)
+            if _use_status:
+                _status_update()
+        else:
+            if _use_status:
+                _status_teardown()
+
+        latency_decoder = time.perf_counter() - timer
+        tokens_decoded = self.seq_len - prefill_seq_len
+        print(f"\nDecoder done in {latency_prefill + latency_decoder:.2f}s, "
+              f"speed: {tokens_decoded / latency_decoder:.2f} tokens/s, "
+              f"total {self.seq_len} tokens.")
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Llama-3.2-3B prefill + decode on accelerator.")
+    parser.add_argument("--prompt", type=str, default=None, help="Text prompt")
+    parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_3b_bin/full_model_weights.bin")
+    parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
+    parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
+    # Sampling DEFAULTS tuned for the quantized FPGA model (temp 0.6 / top-p 0.9 /
+    # rep-penalty 1.2, recency-decayed + structural-exempt). Two findings drive this:
+    #   - Greedy (temp 0) loops on the FPGA: its reduced-precision arithmetic perturbs
+    #     the logits enough that argmax falls into repetition (greedy is fine on a clean
+    #     int4 GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
+    #     => need temperature > 0 to escape the loops.
+    #   - High temp (0.7) samples from the int4-noisy tail and drifts. => keep it modest.
+    # 0.6 is the compromise: enough randomness (with the repetition penalty) to escape
+    # the arithmetic-induced loops, low enough to stay near the robust argmax region.
+    # Pass --temperature 0 for deterministic greedy (HW argmax, no logit readback).
+    parser.add_argument('--temperature', type=float, default=0.6,
+                        help='Sampling temperature (0=greedy via HW argmax; >0 enables SW sampling). Default 0.6.')
+    parser.add_argument('--top-k', type=int, default=0,
+                        help='Top-k filter (0=disabled). Active only when --temperature > 0. Default 0.')
+    parser.add_argument('--top-p', type=float, default=0.9,
+                        help='Top-p (nucleus) filter, 0<p<1 keeps the smallest set with cumulative prob >= p. Default 0.9.')
+    parser.add_argument('--repetition-penalty', type=float, default=1.2,
+                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Default 1.2.')
+    parser.add_argument('--rep-window', type=int, default=256,
+                        help='Repetition penalty considers only the last N tokens (and never penalizes '
+                             'punctuation/whitespace/special tokens). Smaller = less structural starvation '
+                             'on long generations. Default 256.')
+    parser.add_argument('--rep-decay', type=float, default=0.97,
+                        help='Recency decay for the repetition penalty (per-token, age-based): a repeat '
+                             'k tokens ago contributes rep_decay**k to its penalty weight. 1.0 = pure '
+                             'frequency (no decay); lower = only very recent repeats matter. Default 0.97 '
+                             '(half-life ~23 tokens).')
+    parser.add_argument('--seed', type=int, default=None,
+                        help='RNG seed for reproducible sampling (only when --temperature > 0).')
+    args = parser.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if args.local_weights:
+        weights_bin_rel = "llama3.2_3b_bin/full_model_weights.bin"
+    else:
+        weights_bin_rel = "llama3.2_3b_bin/weights_llama3.2_3b_hf.bin"
+        weights_bin_full = os.path.join(script_dir, weights_bin_rel)
+        if not os.path.exists(weights_bin_full):
+            weight_bin_generate(script_dir=script_dir, output_path=weights_bin_full)
+
+    set_dma_device(args.dev)
+    global DMA_DEVICE_H2C, DMA_DEVICE_C2H, DMA_DEVICE_USER
+    DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
+    DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
+    DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
+    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    print(f"Using DMA device: {args.dev}, CLOCK_CYCLE_TIME_NS={user_dma_core.CLOCK_CYCLE_TIME_NS}")
+
+    ue = Llama32_3b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
+    cfg = _load_config(script_dir)
+
+    if args.prompt is not None:
+        tok_path = os.path.join(script_dir, cfg["paths"]["hf_model_dir"])
+        tokenizer = AutoTokenizer.from_pretrained(tok_path, trust_remote_code=True)
+        conversation = [{"role": "user", "content": args.prompt}]
+        prompt_with_template = tokenizer.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)
+        prefill_seq = tuple(tokenizer.encode(prompt_with_template, add_special_tokens=False))
+        print(f"Prefill from prompt ({len(prefill_seq)} tokens): {args.prompt!r}")
+    else:
+        prefill_seq = tuple(cfg["default_prefill_tokens"])
+
+    max_prefill = ue.PREFILL_CONTEXT_SIZE
+    if len(prefill_seq) < 2 or len(prefill_seq) > max_prefill + 1:
+        print(f"WARNING: prompt length {len(prefill_seq)} out of range [2, {max_prefill + 1}], falling back to default.")
+        prefill_seq = tuple(cfg["default_prefill_tokens"])
+
+    ue.prefill_seq = prefill_seq
+
+    # Sampling config (consumed by sample_next_token / the LM-head writeback gate).
+    # Must be set BEFORE compile_llama() so the decoder bin is compiled with logits
+    # writeback ON when temperature > 0. Mirrors qwen3_1.7b.
+    ue.temperature = float(args.temperature)
+    ue.top_k = int(args.top_k)
+    ue.top_p = float(args.top_p)
+    ue.repetition_penalty = float(args.repetition_penalty)
+    ue.rep_window = int(args.rep_window)
+    ue.rep_decay = float(args.rep_decay)
+    ue._generated_tokens = list(prefill_seq)   # seed repetition penalty with the prompt
+    if args.seed is not None and ue.temperature > 0:
+        torch.manual_seed(args.seed)
+    if ue.temperature > 0:
+        print(f"Sampling: temperature={ue.temperature}  top_k={ue.top_k}  "
+              f"top_p={ue.top_p}  repetition_penalty={ue.repetition_penalty}  "
+              f"rep_window={ue.rep_window}  rep_decay={ue.rep_decay}  seed={args.seed}")
+        # Precompute the structural-token exemption set upfront (one vocab scan) so it
+        # doesn't stall the first decode step.
+        if ue.repetition_penalty != 1.0:
+            _n = len(ue._structural_token_ids())
+            print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+
+    print("\n--- Compiling ---")
+    timer = time.perf_counter()
+    ue.compile_llama()
+    print(f"Compile done in {time.perf_counter() - timer:.2f}s")
+
+    print("\n--- Running ---")
+    ue.run_llama()
+    ue.clear_dram()
+    print("Llama-3.2-3B test ends.")
+
+if __name__ == "__main__":
+    main()

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -45,6 +45,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(SCRIPT_DIR)))
 import user_dma_core
 from user_dma_core import DMA_DEVICE_H2C, TYPE, UE_MODE, UE_FMAX_CONTEXT_SIZE, UE_VECTOR_SIZE, URAM_NEAR_FULL_ELEMENTS, URAM_FULL_ELEMENTS, set_dma_device, ue_35bit_addr_shifter, INSTRUCTION_SIZE_BYTES
 from user_dma_core import UnifiedEngine
+# Canonical, HW-aligned 4-bit codec shared across all model templates.
+from quant_lib import quantize_if4
+
+# Map the config's quantization variant string to quantize_if4's int_variant arg.
+# "int" → pure INT4, "fp" → pure FP4, "mix"/"mixmse" → per-block min-MSE (INT4 or FP4).
+_IF4_VARIANT = {"int": True, "fp": False, "mix": None, "mixmse": None}
 
 # --- BROAD PRINT SUPPRESSION FOR LIBRARIES ---
 import builtins
@@ -67,25 +73,6 @@ def _parse_offset(val) -> int:
         return int(val, 0)
     return int(val)
 
-def _quantize_bf16_to_int4_packed(weight_bf16: torch.Tensor, block_size: int = 64) -> tuple[bytes, bytes]:
-    """Quantize bf16 weight (N_w, K_w) to INT4 packed + scale per block of 64 along K. Returns (data_bytes, scale_bytes)."""
-    w = weight_bf16.detach().cpu().float().reshape(-1)
-    N_w, K_w = weight_bf16.shape
-    assert K_w % block_size == 0
-    w_blocks = w.reshape(N_w, K_w // block_size, block_size)
-    scale = w_blocks.abs().amax(dim=-1).clamp(min=1e-8) / 7.0
-    # IF4 dispatches INT4 vs FP4 by bf16 scale sign (negative=INT4 codebook).
-    scale_bf16 = (-scale).to(torch.bfloat16)
-    w_int8 = (w_blocks / scale.unsqueeze(-1)).round().clamp(-8, 7).to(torch.int8)
-    w_nibbles = w_int8.numpy().astype(np.int16) & 0x0F
-    low = w_nibbles[:, :, 0::2].reshape(N_w, -1)
-    high = w_nibbles[:, :, 1::2].reshape(N_w, -1)
-    packed = (high << 4) | low
-    data_bytes = packed.astype(np.uint8).tobytes()
-    scale_bytes = scale_bf16.contiguous().view(torch.uint8).numpy().tobytes()
-    return (data_bytes, scale_bytes)
-
-
 def weight_bin_generate(script_dir: str | None = None, output_path: str | None = None) -> str:
     """Generate weights_llama3.2_3b_hf.bin from HuggingFace model per llama3.2_3b_config.json layout.
     Returns the path to the written file."""
@@ -95,6 +82,10 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
     paths = cfg["paths"]
     paths_full = os.path.join(script_dir, paths["weights_bin"])
     out_path = output_path or paths_full
+
+    _q = cfg["special"]["quantization"]
+    block_size = _q.get("block_size", 64)
+    if4_variant = _IF4_VARIANT[_q.get("if4_variant", "int")]   # quantize_if4 int_variant
 
     model, model_dir = _ensure_hf_model(script_dir, cfg)
     gamma_offset = cfg["special"]["rms_norm"]["gamma_offset"]  # 0.0 for LLaMA
@@ -162,17 +153,17 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
 
         region_writes = [
             (gamma_in, "bf16"),
-            (q_w, "int4"),
-            (k_w, "int4"),
-            (v_w, "int4"),
+            (q_w, "if4"),
+            (k_w, "if4"),
+            (v_w, "if4"),
             (gamma_q, "bf16"),
             (gamma_k, "bf16"),
-            (o_w, "int4"),
+            (o_w, "if4"),
             (gamma_post, "bf16"),
             (gamma_ffn, "bf16"),
-            (up_w, "int4"),
-            (gate_w, "int4"),
-            (down_w, "int4"),
+            (up_w, "if4"),
+            (gate_w, "if4"),
+            (down_w, "if4"),
             (gamma_post_ffn, "bf16"),
         ]
         j = 0
@@ -184,10 +175,10 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
             sz = weight_defs[sz_key]
             file_off = off + layer_idx * LAYER_WEIGHT_SIZE
             tensor, kind = region_writes[j]
-            if kind == "int4":
+            if kind == "if4":
                 next_key = blk0_structure[i + 1]["key"]
                 data_sz = weight_defs[f"{next_key}_SIZE"]
-                data_bytes, scale_bytes = _quantize_bf16_to_int4_packed(tensor)
+                data_bytes, scale_bytes = quantize_if4(tensor, block_size=block_size, int_variant=if4_variant)
                 scale_padded = (scale_bytes + b"\x00" * sz)[:sz]
                 data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
                 write_at(file_off, scale_padded)
@@ -236,7 +227,7 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
     lm_head_w = model.get_input_embeddings().weight.detach().cpu().to(torch.bfloat16)
     scale_sz = weight_defs["LM_HEAD_WEIGHT_SCALE_SIZE"]
     data_sz = weight_defs["LM_HEAD_WEIGHT_DATA_SIZE"]
-    data_bytes, scale_bytes = _quantize_bf16_to_int4_packed(lm_head_w)
+    data_bytes, scale_bytes = quantize_if4(lm_head_w, block_size=block_size, int_variant=if4_variant)
     scale_padded = (scale_bytes + b"\x00" * scale_sz)[:scale_sz]
     data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
     write_at(weight_defs["LM_HEAD_WEIGHT_SCALE"], scale_padded)
@@ -1270,9 +1261,9 @@ def main():
     # rep-penalty 1.2, recency-decayed + structural-exempt). Two findings drive this:
     #   - Greedy (temp 0) loops on the FPGA: its reduced-precision arithmetic perturbs
     #     the logits enough that argmax falls into repetition (greedy is fine on a clean
-    #     int4 GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
+    #     4-bit GPU run, so this is a hardware-arithmetic effect, not the 4-bit weights).
     #     => need temperature > 0 to escape the loops.
-    #   - High temp (0.7) samples from the int4-noisy tail and drifts. => keep it modest.
+    #   - High temp (0.7) samples from the 4-bit-noisy tail and drifts. => keep it modest.
     # 0.6 is the compromise: enough randomness (with the repetition penalty) to escape
     # the arithmetic-induced loops, low enough to stay near the robust argmax region.
     # Pass --temperature 0 for deterministic greedy (HW argmax, no logit readback).


### PR DESCRIPTION
1. Instruction bin size (single unified bin = prefill + decoder)

| Model | Prefill | Decoder | Total bin |
| :--- | :--- | :--- | :--- |
| Llama-3.2-1B | 4.7 MB | 27.3 MB | 32.0 MB |
| Llama-3.2-3B | 6.2 MB | 50.9 MB | 57.1 MB |

2. Decode speed (tokens/s)

| Model | Peak (greedy, short ctx) | Penalized regime (after 512 tok / readback) |
| :--- | :--- | :--- |
| Llama-3.2-1B | 6.55 tok/s | ~5.1 tok/s |
| Llama-3.2-3B | 2.75 tok/s | ~2.5 tok/s |