### PR TITLE
Performance profiling: clock freq update and decode latency tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ clean:
 	rm -f *.mcs *.prm *.jou *.log *.json *.csv
 	rm -rf andromeda_IP-* andromeda_wrapper-*
 	rm -f models/gemma3/gemma3_bin/gemma3_instruction*
+	rm -f models/gemma3/gemma3_bin/gemma3_profile_instruction*
 	rm -rf models/gpt2/gpt2_bin/
 	rm -f models/llama3.2_1b/llama3.2_1b_bin/llama_instruction*
+	rm -f models/llama3.2_1b/llama3.2_1b_bin/llama_profile_instruction*
 	rm -rf models/mobilesam/mobilesam_bin/
 	rm -f models/parakeet/parakeet_bin/*.bin
 	rm -f models/parakeet/parakeet_bin/*.json

--- a/models/gemma3/gemma3_numeric.py
+++ b/models/gemma3/gemma3_numeric.py
@@ -9,7 +9,7 @@ LAYER0_OUTPUT_DRAM), and checks using calculate_snr.
 
 Usage:
   source venv/bin/activate  # if using venv
-  python gemma3_numeric.py --dev xdma0 [--cycle 5.62] [--layer-size 1]
+  python gemma3_numeric.py --dev xdma0 [--device kintex7] [--cycle 5.15] [--layer-size 1]
 
 Same layout as gemma3_test: this file lives next to gemma3_bin/, *.json; user_dma_core one level up.
 """
@@ -668,6 +668,15 @@ class Gemma3_NumericEngine(Gemma3_UnifiedEngine):
         else:
             print("Some decoder checks failed (SNR < 19 dB).")
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Gemma3 layer-0 prefill: run on accelerator, verify with torch ref.")
@@ -676,19 +685,25 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use gemma3_bin/full_model_weights.bin instead of generated weights_gemma3_hf.bin")
     parser.add_argument("--dual-engine", action="store_true", help="Use dual engine")
     parser.add_argument('--dev', type=str, default='xdma0',help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
-    parser.add_argument('--cycle', type=float, default=5.62,help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     set_dma_device(args.dev)
     gemma3_test.DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     gemma3_test.DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     gemma3_test.DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     print(f"Using DMA device: {args.dev}")
     print(f"  H2C: {gemma3_test.DMA_DEVICE_H2C}")
     print(f"  C2H: {gemma3_test.DMA_DEVICE_C2H}")
     print(f"  USER: {gemma3_test.DMA_DEVICE_USER}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}")
 
     dual_engine = args.dual_engine
     ue = Gemma3_NumericEngine(local_weights=args.local_weights, dual_engine=dual_engine)

--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -18,7 +18,7 @@ Weights:
 Usage:
   python gemma3_test.py
   python gemma3_test.py --prompt "your prompt"
-  python gemma3_test.py --dev xdma0 [--cycle 5.62]
+  python gemma3_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python gemma3_test.py --dev xdma0 --device bittware
   python gemma3_test.py --local-weights
   python gemma3_test.py --dual-engine
@@ -886,7 +886,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "flops": total_flops,
         }
         
-    def _compile_decoder_programs(self, layer_size: int = 26, use_pbi: bool = False) -> dict:
+    def _compile_decoder_programs(self, layer_size: int = 26, use_pbi: bool = False, profile: bool = False) -> dict:
         """Compile a single decoder program; KV length is selected at runtime via ``gpr_bucket_idx``.
 
         Grouped attention uses :meth:`decoder_group_attention_core` with ``gpr_bucket_idx`` (same
@@ -901,6 +901,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         decoder_count_at_start = self.capture_count
         count_at_start = self.capture_count
         total_flops = 0
+        checkpoints: list[list] = []
+
+        def _checkpoint(name: str) -> None:
+            self.generate_instruction_halt()
+            self.pad_capture_to_64b_boundary()
+            resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
+            checkpoints.append([name, f"0x{resume:X}"])
 
         global _SILENT_MODE
         _SILENT_MODE = True
@@ -911,6 +918,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_INPUT_DRAM, element_size=self.vector_length)
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
                           OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
+            if profile:
+                _checkpoint(f"L{layer_idx}_pre_norm")
             total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim * self.group_size,
                                                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM,
                                                 B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off,
@@ -936,6 +945,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(self.k_size))
             self.generate_instruction_add_imm(self.TMP_REG, ue_35bit_addr_shifter(self.LAYER0_V_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size), self.TMP_REG)
             self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=0, element_size=self.head_dim, general_reg_src=self.TMP_REG)
+            if profile:
+                _checkpoint(f"L{layer_idx}_qkv_proj_vcache")
             total_flops += self.rms_norm_core_dram(M=1, N=self.head_dim, A_DRAM_ADDR=self.LAYER0_K_DRAM,
                           OUTPUT_DRAM_ADDR=self.LAYER0_K_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_NORM_GAMMA + layer_off)
             total_flops += self.rms_norm_core_dram(M=self.group_size, N=self.head_dim, A_DRAM_ADDR=self.LAYER0_Q_DRAM,
@@ -955,6 +966,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             for g in range(self.group_size):
                 total_flops += self.rope_hf_core_decode(N=self.head_dim, input_dram_addr=self.LAYER0_Q_NORM_DRAM + g * self.head_dim * self.bytes_per_element, output_dram_addr=self.LAYER0_FLASH_Q_DRAM + g * self.head_dim * self.bytes_per_element,
                         gr_weight_dram=self.TMP_REG)
+            if profile:
+                _checkpoint(f"L{layer_idx}_qk_norm_rope")
             attn_result = self.decoder_group_attention_core(
                 group_size=self.group_size,
                 head_dim=self.head_dim,
@@ -970,6 +983,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                 num_buckets=num_buckets,
             )
             total_flops += attn_result[-1] if use_pbi else attn_result
+            if profile:
+                _checkpoint(f"L{layer_idx}_attention")
             total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
                 B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off,
@@ -984,9 +999,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
             self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
             self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
+            if profile:
+                _checkpoint(f"L{layer_idx}_o_proj_post_attn_norm_residual")
 
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
                           OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off)
+            if profile:
+                _checkpoint(f"L{layer_idx}_pre_ffn_norm")
 
             total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM,
@@ -1008,6 +1027,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
             self.eltwise_mul_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.mlp_elements)
             self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_MLP_MULT_DRAM, element_size=self.mlp_elements)
+            if profile:
+                _checkpoint(f"L{layer_idx}_mlp_gateup_gelu_mul")
 
             total_flops += self.quantized_matmat_core(M=1, K=self.mlp_elements, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM,
@@ -1023,15 +1044,16 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_MLP_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
             self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
             self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, element_size=self.vector_length)
+            if profile:
+                _checkpoint(f"L{layer_idx}_mlp_down_post_ffn_norm_residual")
 
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+            total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM,
                 B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT,
                 OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
-                is_B_quantized=True,
                 data_type=TYPE.IF4,
                 SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE,
                 write_back_disable=True,
@@ -1052,9 +1074,10 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         return {
             "program_size_bytes": program_size_bytes,
             "total_flops": total_flops,
+            "checkpoints": checkpoints,
         }
 
-    def compile_gemma3(self, layer_size: int = 26, use_pbi: bool = False, slave_engine = None) -> None:
+    def compile_gemma3(self, layer_size: int = 26, use_pbi: bool = False, slave_engine = None, profile: bool = False) -> None:
         """Compile a single prefill program (seq_len-agnostic) and one decoder program into a
         combined instruction image.
 
@@ -1079,8 +1102,12 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             needed so each segment length is a multiple of 64 B; see :meth:`UnifiedEngine.generate_instruction_halt`).
           - paths.instruction_meta : per-stage start addresses, sizes, FLOPs.
         """
-        instruction_bin_path = os.path.join(self.script_dir, self._cfg["paths"]["instruction_bin"])
-        instruction_meta_path = os.path.join(self.script_dir, self._cfg["paths"]["instruction_meta"])
+        if profile:
+            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_bin/gemma3_profile_instruction.bin")
+            instruction_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_profile_instruction.json")
+        else:
+            instruction_bin_path  = os.path.join(self.script_dir, self._cfg["paths"]["instruction_bin"])
+            instruction_meta_path = os.path.join(self.script_dir, self._cfg["paths"]["instruction_meta"])
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             print(f"Reusing existing instruction image at {instruction_bin_path}")
             print(f"  delete {instruction_bin_path} to force recompile.")
@@ -1098,7 +1125,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         )
         print(f"  prefill compiled, size={prefill_prog['size_bytes']} bytes, "
               f"elapsed={time.perf_counter() - compile_t0:.1f}s")
-        decoder_program = self._compile_decoder_programs(layer_size=layer_size, use_pbi=True)
+        decoder_program = self._compile_decoder_programs(layer_size=layer_size, use_pbi=True, profile=profile)
         self.stop_capture()
 
         os.makedirs(os.path.dirname(instruction_bin_path), exist_ok=True)
@@ -1132,6 +1159,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "decoder_program_size": decoder_program["program_size_bytes"],
             "decoder_total_flops": decoder_program["total_flops"],
         }
+        if profile:
+            metadata["decoder_profile_checkpoints"] = decoder_program["checkpoints"]
 
         if slave_engine is not None:
             # Dual-engine slave compiles the same single prefill program.
@@ -1165,6 +1194,112 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         print(f"  prefill: seq_len-agnostic (template={prefill_seq_len}), {prefill_prog['size_bytes']} bytes")
         print(f"  decoder: {decoder_program['program_size_bytes']} bytes")
         print(f"Metadata written to {instruction_meta_path}")
+
+    def _decode_profile_execute(self, preamble_addr: int, checkpoints: list, timeout: float = 30.0) -> list:
+        """Execute one decoder step through profile checkpoints; return per-step HW latencies."""
+        results = []
+        self.start_execute_from_dram(preamble_addr)
+        for name, resume_addr_hex in checkpoints:
+            self.wait_queue(timeout)
+            results.append((name, self.report_latency_in_us() / 1e3))
+            self.start_execute_from_dram(int(resume_addr_hex, 16))
+        self.wait_queue(timeout)
+        results.append(("output_norm_lm_head", self.report_latency_in_us() / 1e3))
+        return results
+
+    def run_gemma3_profile(self) -> None:
+        """Load the profile instruction image, run prefill + one profiled decoder step,
+        and print a per-step latency breakdown for the decoder.
+        """
+        profile_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_profile_instruction.json")
+        with open(profile_meta_path, "r") as f:
+            meta = json.load(f)
+
+        self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))
+        preamble_addr = self.get_program_dram_addr()
+
+        prefill_program_addr   = _parse_offset(meta["prefill_program_start_addr"])
+        decoder_program_addr   = _parse_offset(meta["decoder_program_start_addr"])
+        flops_prefill_template = meta["prefill_template_flops"]
+        template_prefill_seq_len = int(meta["prefill_template_seq_len"])
+        checkpoints            = meta["decoder_profile_checkpoints"]
+        _max_gpr_bucket = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
+
+        prefill_seq = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
+        prefill_seq = prefill_seq[:-1]
+        prefill_seq_len = len(prefill_seq)
+        self.seq_len = prefill_seq_len
+
+        q_seq_len = prefill_seq_len * self.group_size
+        aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
+        bucket_idx = aligned_seq_len_q // UE_VECTOR_SIZE
+        flops_prefill = flops_prefill_template * prefill_seq_len // max(template_prefill_seq_len, 1)
+
+        self.clear_inst_id()
+        self.start_capture()
+        self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
+        self.generate_instruction_add_set(self.gpr_q_seq_len, q_seq_len)
+        self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
+        self.stop_capture()
+        self.write_captured_instructions_to_dram(preamble_addr)
+        self.allocate_program_dram(self.get_capture_instruction_size_bytes())
+        self.clear_capture_buffer()
+
+        embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        bias_one_group = torch.full((aligned_seq_len_q, aligned_seq_len_q), float("-inf"), dtype=torch.bfloat16)
+        valid_mask = torch.tril(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool))
+        bias_one_group.masked_fill_(valid_mask, 0.0)
+        bias_one_group[:, q_seq_len:] = float("-inf")
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
+
+        print(f"\n--- Profiling: prefill (seq_len={prefill_seq_len}) ---")
+        timer = time.perf_counter()
+        self.program_execute(preamble_addr, flops=flops_prefill)
+        print(f"Prefill done in {time.perf_counter() - timer:.2f}s")
+
+        # Decoder preamble for the first decode token
+        token_id = prefill_seq[-1]
+        self.seq_len += 1
+        aligned_dec = ((self.seq_len + 63) // 64) * 64
+        bucket_idx = min(aligned_dec // UE_VECTOR_SIZE, _max_gpr_bucket)
+        embedding_tensor = self.get_embedding_for_tokens([token_id])
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        bias_host = torch.full((1, aligned_dec), -1e36, dtype=torch.bfloat16)
+        bias_host[0, :self.seq_len] = 0.0
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host)
+
+        self.clear_inst_id()
+        self.start_capture()
+        self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
+        self.stop_capture()
+        self.write_captured_instructions_to_dram(preamble_addr)
+        self.clear_capture_buffer()
+
+        print("\n--- Profiling: decoder step breakdown ---")
+        results = self._decode_profile_execute(preamble_addr, checkpoints)
+
+        total_ms = sum(ms for _, ms in results)
+        from collections import defaultdict
+        step_totals: dict = defaultdict(float)
+        for name, ms in results:
+            step = name.split("_", 1)[1] if "_" in name else name
+            step_totals[step] += ms
+
+        print(f"\n{'Step (all layers)':<35} {'ms':>9}  {'%':>6}")
+        print("-" * 54)
+        for step, ms in step_totals.items():
+            print(f"{step:<35} {ms:>9.2f}  {ms/total_ms*100:>5.1f}%")
+        print("-" * 54)
+        print(f"{'Total':<35} {total_ms:>9.2f}  100.0%")
+        print(f"\nDecode speed (HW): {1000/total_ms:.2f} tok/s  ({total_ms:.1f} ms/tok)")
+
+        print(f"\n{'Step':<40} {'ms':>8}")
+        print("-" * 50)
+        for name, ms in results:
+            print(f"{name:<40} {ms:>8.2f}")
 
     def run_gemma3(self, slave_engine = None) -> dict:
         """Load the unified instruction image once, then run prefill + decoder loop.
@@ -1266,6 +1401,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         max_seq_len = self.MAX_CONTEXT_SIZE
         total_latency, total_flop_rate = 0, 0
         decoder_token_cnt = 0
+        hw_decode_lats_us: list[float] = []
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1323,6 +1459,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             self.clear_capture_buffer()
 
             latency, flop_rate_program = self.program_execute(preamble_addr, flops=flops_hw)
+            hw_decode_lats_us.append(latency)
             total_latency += latency
             total_flop_rate += flop_rate_program
             token_id = self.get_arg_max_index()
@@ -1340,24 +1477,30 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             if _use_status:
                 _status_teardown()
 
-        token_cnt_decoded = self.seq_len
-        latency_hw_decoder = total_latency
-        flop_rate_hw_decoder = total_flop_rate
         latency_decoder = time.perf_counter() - timer
-        print(f"\nDecoder done in {latency_prefill + latency_decoder:.2f} seconds, speed: {(token_cnt_decoded - len(self.prefill_seq) + 1) / latency_decoder:.2f} tokens/s, total {token_cnt_decoded} tokens.")
-        print(f"HW counter: Latency: {(latency_hw_prefill + latency_hw_decoder) / 1e6:.2f} seconds, decoder average Gflops: {flop_rate_hw_decoder / (token_cnt_decoded - len(self.prefill_seq) + 1):.2f} Gflops")
+        tokens_decoded = decoder_token_cnt
+        print(f"\nDecoder done in {latency_prefill + latency_decoder:.2f}s, "
+              f"speed: {tokens_decoded / latency_decoder:.2f} tokens/s, "
+              f"total {self.seq_len} tokens.")
+
+        hw_decode_avg_ms  = sum(hw_decode_lats_us) / len(hw_decode_lats_us) / 1e3 if hw_decode_lats_us else 0.0
+        hw_decode_first_ms = hw_decode_lats_us[0] / 1e3 if hw_decode_lats_us else 0.0
+        cpu_decode_avg_ms = latency_decoder * 1e3 / tokens_decoded if tokens_decoded else 0.0
+        _original_print("\n=== Performance Summary ===")
+        _original_print(f"Instruction size  : prefill={meta['prefill_program_size']/1024:.1f} kB  decoder={meta['decoder_program_size']/1024:.1f} kB  total={(meta['prefill_program_size']+meta['decoder_program_size'])/1024:.1f} kB")
+        _original_print(f"Prefill ({prefill_seq_len} tokens): HW={latency_hw_prefill/1e3:,.1f} ms  CPU={latency_prefill*1e3:,.1f} ms")
+        _original_print(f"Decode 1st token  : HW={hw_decode_first_ms:,.1f} ms/tok  ({1000/hw_decode_first_ms:.2f} tok/s)")
+        _original_print(f"Decode  ({tokens_decoded} tokens): HW={hw_decode_avg_ms:,.1f} ms/tok  CPU={cpu_decode_avg_ms:,.1f} ms/tok  ({tokens_decoded/latency_decoder:.2f} tok/s)")
         
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
-    """Default clock period (ns) per FPGA type — same table as ``user_hw_test.py`` ``main``."""
-    if device == "kintex7":
-        return 5.1594
-    if device == "rk" or device == "puzhi":
-        return 3.0
-    if device == "bittware":
-        return 4.166666666
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
     return 10.0
 
 
@@ -1383,8 +1526,10 @@ def main():
         '--cycle',
         type=float,
         default=None,
-        help='Clock cycle time in nanoseconds. Default: from --device (kintex7≈5.16ns, bittware≈4.17ns); legacy fallback 5.62 if device unknown.',
+        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=5.1594ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
     )
+    parser.add_argument('--profile', action='store_true',
+                        help='Compile a profile binary with per-step HALT checkpoints and run one decode step to measure per-step latency breakdown.')
     args = parser.parse_args()
 
     set_dma_device(args.dev)
@@ -1393,27 +1538,17 @@ def main():
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
 
-    # Match user_hw_test.py: Bittware uses 512-bit AXI beat; other profiles use 256-bit.
-    axi_width_bits = 512 if args.device == "bittware" else 256
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
     os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
     user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
-
-    if args.cycle is not None:
-        clock = args.cycle
-    else:
-        clock = _clock_ns_default_for_device(args.device)
-        if clock == 10.0:
-            clock = 5.62
-
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
     user_dma_core.CLOCK_CYCLE_TIME_NS = clock
     user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
-
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     print(f"Using DMA device: {args.dev}")
     print(f"  H2C: {DMA_DEVICE_H2C}")
     print(f"  C2H: {DMA_DEVICE_C2H}")
     print(f"  USER: {DMA_DEVICE_USER}")
-    print(f"FPGA profile: device={args.device}, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}, UE_PEAK_GFLOPS = {user_dma_core.UE_PEAK_GFLOPS:.4f}")
 
     dual_engine = args.dual_engine
     assert dual_engine == False, (
@@ -1431,6 +1566,16 @@ def main():
     timer = time.perf_counter()
     ue.compile_gemma3(slave_engine=ue2 if dual_engine else None)
     print(f"Compile done in {time.perf_counter() - timer:.2f} seconds")
+
+    if args.profile:
+        print("\n--- Compiling profile binary ---")
+        timer = time.perf_counter()
+        ue.compile_gemma3(profile=True)
+        print(f"Profile compile done in {time.perf_counter() - timer:.2f} seconds")
+        ue.run_gemma3_profile()
+        ue.clear_dram()
+        print("Decoder profile done.")
+        return
 
     run_result = ue.run_gemma3(slave_engine=ue2 if dual_engine else None)
     print("Gemma3 test ends.")

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -42,7 +42,7 @@ same directory). ``--local-weights`` uses gemma3_bin/full_model_weights.bin.
 Usage:
   python gemma3_test_IF8.py
   python gemma3_test_IF8.py --prompt "your prompt"
-  python gemma3_test_IF8.py --dev xdma0 [--cycle 5.62]
+  python gemma3_test_IF8.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python gemma3_test_IF8.py --local-weights
   python gemma3_test_IF8.py --dual-engine
 
@@ -1351,13 +1351,11 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 # Main
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
-    """Default clock period (ns) per FPGA type — same table as ``user_hw_test.py`` ``main``."""
-    if device == "kintex7":
-        return 5.1594
-    if device == "rk" or device == "puzhi":
-        return 3.0
-    if device == "bittware":
-        return 4.166666666
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
     return 10.0
 
 
@@ -1379,7 +1377,7 @@ def main():
         '--cycle',
         type=float,
         default=None,
-        help='Clock cycle time in nanoseconds. Default: from --device (kintex7≈5.16ns, bittware≈4.17ns); legacy fallback 5.62 if device unknown.',
+        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=5.1594ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
     )
     args = parser.parse_args()
 
@@ -1389,27 +1387,17 @@ def main():
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
 
-    # Match user_hw_test.py: Bittware uses 512-bit AXI beat; other profiles use 256-bit.
-    axi_width_bits = 512 if args.device == "bittware" else 256
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
     os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
     user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
-
-    if args.cycle is not None:
-        clock = args.cycle
-    else:
-        clock = _clock_ns_default_for_device(args.device)
-        if clock == 10.0:
-            clock = 5.62
-
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
     user_dma_core.CLOCK_CYCLE_TIME_NS = clock
     user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
-
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     print(f"Using DMA device: {args.dev}")
     print(f"  H2C: {DMA_DEVICE_H2C}")
     print(f"  C2H: {DMA_DEVICE_C2H}")
     print(f"  USER: {DMA_DEVICE_USER}")
-    print(f"FPGA profile: device={args.device}, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}, UE_PEAK_GFLOPS = {user_dma_core.UE_PEAK_GFLOPS:.4f}")
 
     dual_engine = args.dual_engine
     assert dual_engine == False, "Dual engine is not supported yet for pbi mode"

--- a/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
+++ b/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
@@ -21,7 +21,7 @@ Usage (run from repo root):
   python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --prompt "..."        # LM, custom prompt
   python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --vision-enable       # VLM, default image
   python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --image PATH ...      # VLM, custom image
-  python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --dev xdma0 --cycle 5.62
+  python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --dev xdma0 [--device kintex7] [--cycle 5.15]
 """
 
 import json
@@ -7226,6 +7226,15 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Gemma4 E2B layer-0 prefill: run on accelerator, verify with torch ref.")
@@ -7256,8 +7265,8 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use gemma4_e2b_bin/full_model_weights.bin instead of generated weights_gemma4_e2b_hf.bin")
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
-    parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     set_dma_device(args.dev)
@@ -7265,12 +7274,17 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     print(f"Using DMA device: {args.dev}")
     print(f"  H2C: {DMA_DEVICE_H2C}")
     print(f"  C2H: {DMA_DEVICE_C2H}")
     print(f"  USER: {DMA_DEVICE_USER}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}")
 
     # --- Resolve modality and input path -----------------------------------
     # The script has three modes: LM (text only), VLM (image + text),

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -17,7 +17,7 @@ Usage:
   python gemma4_e2b_test.py --prompt "your prompt"
   python gemma4_e2b_test.py --image path/to/image.jpg
   python gemma4_e2b_test.py --image path/to/image.jpg --prompt "What is in this image?"
-  python gemma4_e2b_test.py --dev xdma0 [--cycle 5.62]
+  python gemma4_e2b_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python gemma4_e2b_test.py --local-weights
 
 Fixed layout: gemma4_e2b_test.py, gemma4_e2b_numeric.py, *.json, and gemma4_e2b_bin/ live in the same folder.
@@ -8421,6 +8421,15 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Gemma4 E2B layer-0 prefill: run on accelerator, verify with torch ref.")
@@ -8451,8 +8460,8 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use gemma4_e2b_bin/full_model_weights.bin instead of generated weights_gemma4_e2b_hf.bin")
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
-    parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     set_dma_device(args.dev)
@@ -8460,12 +8469,17 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     print(f"Using DMA device: {args.dev}")
     print(f"  H2C: {DMA_DEVICE_H2C}")
     print(f"  C2H: {DMA_DEVICE_C2H}")
     print(f"  USER: {DMA_DEVICE_USER}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}")
 
     # --- Resolve modality and input path -----------------------------------
     # The script has three modes: LM (text only), VLM (image + text),

--- a/models/gpt2/gpt2_test.py
+++ b/models/gpt2/gpt2_test.py
@@ -1183,6 +1183,15 @@ class GPT2_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="GPT-2 Base (124M) prefill + decode on accelerator.")
@@ -1190,8 +1199,8 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use gpt2_bin/full_model_weights.bin instead of generated weights_gpt2_hf.bin")
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
-    parser.add_argument('--cycle', type=float, default=1/0.17,
-                        help='Clock cycle time in nanoseconds (default: ~5.88ns)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument('--temperature', type=float, default=0.8,
                         help='Sampling temperature. 0 = greedy argmax (default: 0.8)')
     parser.add_argument('--top-k', type=int, default=40,
@@ -1213,12 +1222,17 @@ def main():
             weight_bin_generate(script_dir=script_dir, output_path=weights_bin_full)
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     print(f"Using DMA device: {args.dev}")
     print(f"  H2C: {user_dma_core.DMA_DEVICE_H2C}")
     print(f"  C2H: {user_dma_core.DMA_DEVICE_C2H}")
     print(f"  USER: {user_dma_core.DMA_DEVICE_USER}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}")
 
     ue = GPT2_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
 

--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -528,6 +528,15 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
         sys.exit(1)
 
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(
@@ -535,7 +544,8 @@ def main():
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
-    parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly (no logit readback); loads the
     # _fpgapenalty bin. --pure-greedy disables it entirely (plain writeback-on bin).
@@ -543,7 +553,6 @@ def main():
                         help="Disable the on-FPGA repetition penalty entirely — plain greedy decode "
                              "(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy "
                              "only for the A/B baseline and the compare/calibration tool.")
-    # On-FPGA repetition penalty parameters (active unless --pure-greedy).
     pen_group = parser.add_argument_group("on-FPGA repetition penalty (active unless --pure-greedy)")
     pen_group.add_argument("--greedy-until", type=int, default=512,
                         help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
@@ -564,7 +573,13 @@ def main():
     _verify_artifacts(script_dir, cfg, fpga_penalty=not bool(args.pure_greedy))
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     _original_print(f"Llama-3.2-1B on {args.dev} (run from pre-compiled bins)")
 
     t0 = time.perf_counter()

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -24,7 +24,7 @@ Weights:
 Usage:
   python llama3.2_1b_test.py
   python llama3.2_1b_test.py --prompt "your prompt"
-  python llama3.2_1b_test.py --dev xdma0 [--cycle 5.88]
+  python llama3.2_1b_test.py --dev xdma0 [--cycle 5.15]
   python llama3.2_1b_test.py --local-weights
 """
 
@@ -855,9 +855,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         _SILENT_MODE = False
         return {"size_bytes": prefill_program_size, "flops": total_flops}
 
-    def _compile_decoder_program(self, layer_size: int) -> dict:
+    def _compile_decoder_program(self, layer_size: int, profile: bool = False) -> dict:
         """Compile decoder into the active capture session.
-        Returns dict with ``program_size_bytes`` and ``total_flops``.
+        Returns dict with ``program_size_bytes``, ``total_flops``, and
+        (when profile=True) ``checkpoints``: list of [name, resume_dram_addr_hex].
         """
         if not getattr(self, "is_capture_on", False):
             raise RuntimeError("_compile_decoder_program() requires an active capture session")
@@ -865,6 +866,16 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
         total_flops = 0
         program_dram_base = self.get_program_dram_addr()
+        checkpoints: list[list] = []  # [[name, resume_dram_addr_hex], ...]
+
+        def _checkpoint(name: str) -> None:
+            self.generate_instruction_halt()
+            self.pad_capture_to_64b_boundary()
+            # capture_count is the total instruction count from the image base (includes
+            # prefill), so resume = base + total_count * inst_size lands correctly in
+            # the decoder without needing to subtract count_at_start.
+            resume = program_dram_base + self.capture_count * INSTRUCTION_SIZE_BYTES
+            checkpoints.append([name, f"0x{resume:X}"])
         gpr_ret_id = self.alloc_isa_reg()
         call_site_jump_capture_indices: list[int] = []
 
@@ -877,6 +888,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_INPUT_DRAM, element_size=self.vector_length)
                 total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_pre_norm")
                 total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim * self.group_size,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
@@ -886,6 +899,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_qkv_proj")
 
                 # LLaMA 8-head GQA decoder: rope_hf_core(N=512) on [lo|hi]-permuted K and Q
                 # in-place, then scatter 64-dim per-head slices to KV cache (via
@@ -919,6 +934,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         sin_dram_addr=ROPE_WEIGHT_ADDR + hd * bpe,
                         rope_size_reg=self.ROPE_SIZE_REG,
                         tmp_reg=self.TMP_REG)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_rope")
 
                 # Step 3: Per-KV-head scatter K/V to cache + scatter Q → decoder_attention
                 for kv_h in range(nkvh):
@@ -1002,6 +1019,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         self.LAYER0_FLASH_OUT_HEAD_DRAM, 0x40000, qpkv * ahd)
                     self.sram_to_accelerator_memory(
                         0x40000, self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe, qpkv * ahd)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_kv_scatter_attn")
                 total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
@@ -1011,10 +1030,14 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, sram_address=0x90000, element_size=self.vector_length)
                 self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_o_proj_residual")
 
                 # LLaMA: post_attention_layernorm IS the pre-FFN norm
                 total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_pre_ffn_norm")
 
                 total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
@@ -1027,6 +1050,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
                 self.eltwise_mul_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.mlp_elements)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_MLP_MULT_DRAM, element_size=self.mlp_elements)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_mlp_gateup_silu")
 
                 total_flops += self.quantized_matmat_core(M=1, K=self.mlp_elements, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
@@ -1037,6 +1062,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_DOWN_DRAM, sram_address=0x90000, element_size=self.vector_length)
                 self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, element_size=self.vector_length)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_mlp_down_residual")
 
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
@@ -1094,9 +1121,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.release_isa_reg()  # gpr_ret_id
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
-        return {"program_size_bytes": decoder_program_size, "total_flops": total_flops}
+        return {"program_size_bytes": decoder_program_size, "total_flops": total_flops, "checkpoints": checkpoints}
 
-    def compile_llama(self, layer_size: int | None = None) -> None:
+    def compile_llama(self, layer_size: int | None = None, profile: bool = False) -> None:
         """Compile prefill + decoder into a single combined instruction image.
 
         Layout in program DRAM:  [prefill][decoder]
@@ -1104,6 +1131,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         Prefill is compiled with a fixed template (UE_VECTOR_SIZE) — all runtime
         loop counts are driven by GPRs primed by the preamble, so the same bin
         works for any seq_len. If both bin and meta already exist, this is a no-op.
+
+        profile=True compiles a separate binary with HALT checkpoints inserted after
+        each major decoder step in layer 0, for per-step latency profiling.
 
         Writes:
           - paths.instruction_bin  : combined raw instruction stream
@@ -1140,9 +1170,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         prefill_prog = self._compile_prefill_program(template_seq_len=template_seq_len, layer_size=layer_size)
         print(f"  prefill compiled: {prefill_prog['size_bytes']} bytes, {time.perf_counter() - t0:.1f}s")
 
-        print("Compiling decoder...")
+        print(f"Compiling decoder{' (profile mode)' if profile else ''}...")
         t0 = time.perf_counter()
-        decoder_prog = self._compile_decoder_program(layer_size=layer_size)
+        decoder_prog = self._compile_decoder_program(layer_size=layer_size, profile=profile)
         print(f"  decoder compiled: {decoder_prog['program_size_bytes']} bytes, {time.perf_counter() - t0:.1f}s")
 
         self.stop_capture()
@@ -1171,6 +1201,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             "decoder_program_size": decoder_prog["program_size_bytes"],
             "decoder_total_flops": decoder_prog["total_flops"],
         }
+        if profile:
+            metadata["decoder_profile_checkpoints"] = decoder_prog["checkpoints"]
         with open(instruction_meta_path, "w") as f:
             json.dump(metadata, f, indent=2)
         print(f"Combined instruction image written to {instruction_bin_path} ({len(instruction_bytes)} bytes)")
@@ -1229,6 +1261,129 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             count[self._structural_ids_tensor()] = 0.0  # never penalize punctuation/whitespace/specials
         bias = (-alpha * count).clamp(min=-cap).to(torch.bfloat16).view(1, vocab)  # bias[t] = clamp(−α · count[t], min = −cap)
         self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM, bias)  # push to buffer
+
+    def _decode_profile_execute(self, preamble_addr: int, checkpoints: list, timeout: float = 30.0) -> list:
+        """Execute one decoder step through profile checkpoints and return per-step latencies.
+
+        Starts from preamble_addr, waits for each intermediate HALT, reads the cumulative
+        HW counter, then resumes from the checkpoint's resume address.  After the last
+        checkpoint the program runs to the final HALT which measures output_norm+lm_head.
+
+        Returns list of (name, delta_ms) tuples — one per segment including the final one.
+        """
+        results = []
+        self.start_execute_from_dram(preamble_addr)
+        for name, resume_addr_hex in checkpoints:
+            self.wait_queue(timeout)
+            results.append((name, self.report_latency_in_us() / 1e3))
+            self.start_execute_from_dram(int(resume_addr_hex, 16))
+        # Wait for final HALT (output_norm + lm_head)
+        self.wait_queue(timeout)
+        results.append(("output_norm_lm_head", self.report_latency_in_us() / 1e3))
+        return results
+
+    def run_llama_profile(self) -> None:
+        """Load the profile instruction image, run prefill + one profiled decoder step,
+        and print a per-step latency breakdown for the decoder.
+        """
+        profile_meta_path = os.path.join(self.script_dir, "llama3.2_1b_bin/llama_profile_instruction.json")
+        with open(profile_meta_path, "r") as f:
+            meta = json.load(f)
+
+        self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))
+        preamble_addr = self.get_program_dram_addr()
+
+        prefill_program_addr  = int(meta["prefill_program_start_addr"], 16)
+        decoder_program_addr  = int(meta["decoder_program_start_addr"], 16)
+        template_seq_len      = int(meta["prefill_template_seq_len"])
+        flops_prefill_template = meta["prefill_template_flops"]
+        checkpoints           = meta["decoder_profile_checkpoints"]
+        _max_gpr_bucket = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
+        _kv_stride = self.actual_head_dim * self.bytes_per_element
+        _rope_row  = self.head_dim * 2 * self.bytes_per_element
+
+        prefill_seq = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
+        prefill_seq = prefill_seq[:-1]
+        prefill_seq_len = len(prefill_seq)
+        self.seq_len = prefill_seq_len
+
+        q_seq_len = prefill_seq_len * self.group_size
+        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
+        flops_prefill = flops_prefill_template * prefill_seq_len // max(template_seq_len, 1)
+
+        # Prefill
+        self.clear_inst_id()
+        self.start_capture()
+        self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
+        self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
+        self.stop_capture()
+        self.write_captured_instructions_to_dram(preamble_addr)
+        self.allocate_program_dram(self.get_capture_instruction_size_bytes())
+        self.clear_capture_buffer()
+
+        embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        rows = torch.arange(aligned_seq_len).unsqueeze(1)
+        cols = torch.arange(aligned_seq_len).unsqueeze(0)
+        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        bias_one_group.masked_fill_(valid_mask, 0.0)
+        bias_one_group[:, q_seq_len:] = float("-inf")
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
+
+        print(f"\n--- Profiling: prefill (seq_len={prefill_seq_len}) ---")
+        timer = time.perf_counter()
+        hw_lat_prefill_us, _ = self.program_execute(preamble_addr, flops=flops_prefill)
+        print(f"Prefill done in {time.perf_counter() - timer:.2f}s")
+
+        # Decoder preamble for the first decode token
+        token_id = prefill_seq[-1]
+        self.seq_len += 1
+        bucket_idx = min((self.seq_len + 63) // 64, _max_gpr_bucket)
+        decode_pos = self.seq_len - 1
+        embedding_tensor = self.get_embedding_for_tokens([token_id])
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        aligned_dec = ((self.seq_len + 63) // 64) * 64
+        bias_host = torch.full((1, aligned_dec), -1e36, dtype=torch.bfloat16)
+        bias_host[0, :self.seq_len] = 0.0
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host)
+
+        self.clear_inst_id()
+        self.start_capture()
+        self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
+        self.generate_instruction_add_set(self.ROPE_SIZE_REG,    ue_35bit_addr_shifter(decode_pos * _rope_row))
+        self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
+        self.stop_capture()
+        self.write_captured_instructions_to_dram(preamble_addr)
+        self.clear_capture_buffer()
+
+        print("\n--- Profiling: decoder step breakdown ---")
+        results = self._decode_profile_execute(preamble_addr, checkpoints)
+
+        total_ms = sum(ms for _, ms in results)
+
+        # Per-step totals summed across all layers
+        from collections import defaultdict
+        step_totals: dict = defaultdict(float)
+        for name, ms in results:
+            step = name.split("_", 1)[1] if "_" in name else name  # strip "L{n}_"
+            step_totals[step] += ms
+
+        print(f"\n{'Step (all layers)':<25} {'ms':>9}  {'%':>6}")
+        print("-" * 44)
+        for step, ms in step_totals.items():
+            print(f"{step:<25} {ms:>9.2f}  {ms/total_ms*100:>5.1f}%")
+        print("-" * 44)
+        print(f"{'Total':<25} {total_ms:>9.2f}  100.0%")
+        print(f"\nDecode speed (HW): {1000/total_ms:.2f} tok/s  ({total_ms:.1f} ms/tok)")
+
+        print(f"\n{'Step':<30} {'ms':>8}")
+        print("-" * 40)
+        for name, ms in results:
+            print(f"{name:<30} {ms:>8.2f}")
 
     def run_llama(self) -> None:
         """Load the unified instruction image and run prefill + decoder loop.
@@ -1293,11 +1448,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
         print(f"Prompt ({len(self.prefill_seq)}) tokens: {self.prefill_seq}")
         timer = time.perf_counter()
-        self.program_execute(preamble_addr, flops=flops_prefill)
+        hw_lat_prefill_us, _ = self.program_execute(preamble_addr, flops=flops_prefill)
         latency_prefill = time.perf_counter() - timer
         print(f"Prefill done in {latency_prefill:.2f}s\n")
 
         print("--- Starting decoder ---")
+        hw_decode_lats_us: list[float] = []
         timer = time.perf_counter()
         token_id = self.prefill_seq[-1]
         _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
@@ -1382,11 +1538,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
                 self._write_penalty_bias(self._generated_tokens)
 
-            self.program_execute(preamble_addr, flops=decoder_flops_per_token)
+            hw_lat_dec_us, _ = self.program_execute(preamble_addr, flops=decoder_flops_per_token)
+            hw_decode_lats_us.append(hw_lat_dec_us)
             # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
             # already added the bias, so the register holds the penalized token; in plain mode it's
-            # pure greedy. Either way no logit readback. (The compare/calibration tool overrides
-            # get_arg_max_index to apply a host-side penalty against the writeback-on plain bin.)
+            # pure greedy. Either way no logit readback.
             token_id = self.get_arg_max_index(rank=1)
             self._generated_tokens.append(token_id)
             token_char = self.tokenizer.decode([token_id])
@@ -1409,26 +1565,44 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
               f"speed: {tokens_decoded / latency_decoder:.2f} tokens/s, "
               f"total {self.seq_len} tokens.")
 
+        hw_decode_avg_ms = sum(hw_decode_lats_us) / len(hw_decode_lats_us) / 1e3 if hw_decode_lats_us else 0.0
+        hw_decode_first_ms = hw_decode_lats_us[0] / 1e3 if hw_decode_lats_us else 0.0
+        cpu_decode_avg_ms = latency_decoder * 1e3 / tokens_decoded if tokens_decoded else 0.0
+        _original_print("\n=== Performance Summary ===")
+        _original_print(f"Instruction size  : prefill={meta['prefill_program_size']/1024:.1f} kB  decoder={meta['decoder_program_size']/1024:.1f} kB  total={(meta['prefill_program_size']+meta['decoder_program_size'])/1024:.1f} kB")
+        _original_print(f"Prefill ({prefill_seq_len} tokens): HW={hw_lat_prefill_us/1e3:,.1f} ms  CPU={latency_prefill*1e3:,.1f} ms")
+        _original_print(f"Decode 1st token  : HW={hw_decode_first_ms:,.1f} ms/tok  ({1000/hw_decode_first_ms:.2f} tok/s)")
+        _original_print(f"Decode  ({tokens_decoded} tokens): HW={hw_decode_avg_ms:,.1f} ms/tok  CPU={cpu_decode_avg_ms:,.1f} ms/tok  ({tokens_decoded/latency_decoder:.2f} tok/s)")
+
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Llama-3.2-1B prefill + decode on accelerator.")
     parser.add_argument("--prompt", type=str, default=None, help="Text prompt")
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
-    parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
+    parser.add_argument('--profile', action='store_true',
+                        help='Compile a profile binary with per-step HALT checkpoints and run one decode step to measure per-step latency breakdown.')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
-    # matmul bias so the HW argmax returns the penalized token directly — no 256 KB logit readback,
-    # fully deterministic (separate bias-on / writeback-off bin). --pure-greedy disables it entirely.
+    # matmul bias so the HW argmax returns the penalized token directly — no logit readback,
+    # fully deterministic (separate _fpgapenalty bin). --pure-greedy disables it entirely.
     parser.add_argument('--pure-greedy', action='store_true',
                         help='Disable the on-FPGA repetition penalty entirely — plain greedy decode '
                              '(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy '
                              'only for the A/B baseline and the compare/calibration tool.')
-    # On-FPGA repetition penalty parameters (active unless --pure-greedy). The penalty is folded into
-    # the LM-head matmul bias (on-chip argmax of logits+bias, no logit readback).
-    # See notes_repetition_penalty_fpga_bias.md.
     pen_group = parser.add_argument_group('on-FPGA repetition penalty (active unless --pure-greedy)')
     pen_group.add_argument('--greedy-until', type=int, default=512,
                         help='Pure greedy for the first N decoded tokens (correct math/reasoning, '
@@ -1457,9 +1631,17 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
-    print(f"Using DMA device: {args.dev}, CLOCK_CYCLE_TIME_NS={user_dma_core.CLOCK_CYCLE_TIME_NS}")
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
+    ue = UnifiedEngine()
+    ue.software_reset()
+    
     ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
     cfg = _load_config(script_dir)
 
@@ -1502,6 +1684,16 @@ def main():
     timer = time.perf_counter()
     ue.compile_llama()
     print(f"Compile done in {time.perf_counter() - timer:.2f}s")
+
+    if args.profile:
+        print("\n--- Compiling profile binary ---")
+        timer = time.perf_counter()
+        ue.compile_llama(profile=True)
+        print(f"Profile compile done in {time.perf_counter() - timer:.2f}s")
+        ue.run_llama_profile()
+        ue.clear_dram()
+        print("Decoder profile done.")
+        return
 
     print("\n--- Running ---")
     ue.run_llama()

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -528,6 +528,15 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
         sys.exit(1)
 
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(
@@ -535,7 +544,8 @@ def main():
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
-    parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly (no logit readback); loads the
     # _fpgapenalty bin. --pure-greedy disables it entirely (plain writeback-on bin).
@@ -543,7 +553,6 @@ def main():
                         help="Disable the on-FPGA repetition penalty entirely — plain greedy decode "
                              "(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy "
                              "only for the A/B baseline and the compare/calibration tool.")
-    # On-FPGA repetition penalty parameters (active unless --pure-greedy).
     pen_group = parser.add_argument_group("on-FPGA repetition penalty (active unless --pure-greedy)")
     pen_group.add_argument("--greedy-until", type=int, default=512,
                         help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
@@ -564,7 +573,13 @@ def main():
     _verify_artifacts(script_dir, cfg, fpga_penalty=not bool(args.pure_greedy))
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     _original_print(f"Llama-3.2-3B on {args.dev} (run from pre-compiled bins)")
 
     t0 = time.perf_counter()

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -24,7 +24,7 @@ Weights:
 Usage:
   python llama3.2_3b_test.py
   python llama3.2_3b_test.py --prompt "your prompt"
-  python llama3.2_3b_test.py --dev xdma0 [--cycle 5.88]
+  python llama3.2_3b_test.py --dev xdma0 [--cycle 5.15]
   python llama3.2_3b_test.py --local-weights
 """
 
@@ -1326,13 +1326,23 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Llama-3.2-3B prefill + decode on accelerator.")
     parser.add_argument("--prompt", type=str, default=None, help="Text prompt")
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_3b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
-    parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly (no logit readback), fully
     # deterministic (separate _fpgapenalty bin). --pure-greedy disables it entirely.
@@ -1340,9 +1350,6 @@ def main():
                         help='Disable the on-FPGA repetition penalty entirely — plain greedy decode '
                              '(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy '
                              'only for the A/B baseline and the compare/calibration tool.')
-    # On-FPGA repetition penalty parameters (active unless --pure-greedy). The penalty is folded into
-    # the LM-head matmul bias (on-chip argmax of logits+bias, no logit readback). Validated 3B params
-    # (logit_max~26.9, gap~4.25): alpha=1.0. See notes_repetition_penalty_fpga_bias.md.
     pen_group = parser.add_argument_group('on-FPGA repetition penalty (active unless --pure-greedy)')
     pen_group.add_argument('--greedy-until', type=int, default=512,
                         help='Pure greedy for the first N decoded tokens (correct math/reasoning, '
@@ -1354,7 +1361,7 @@ def main():
                         help='max |bias| per token (floor on -alpha*count). Default 20.')
     pen_group.add_argument('--rep-window', type=int, default=256,
                         help='count tokens over the last N (never penalizes punctuation/whitespace/'
-                             'special tokens). Default 256.')
+                             'special tokens). Default 256. Validated 3B params: see notes_repetition_penalty_fpga_bias.md.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1371,8 +1378,13 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
-    print(f"Using DMA device: {args.dev}, CLOCK_CYCLE_TIME_NS={user_dma_core.CLOCK_CYCLE_TIME_NS}")
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     ue = Llama32_3b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
     cfg = _load_config(script_dir)

--- a/models/mobilenetv2/mobilenetv2_ssd_fpnlite_640_hw_test.py
+++ b/models/mobilenetv2/mobilenetv2_ssd_fpnlite_640_hw_test.py
@@ -936,6 +936,14 @@ def draw_and_save(img: "Image.Image", W0: int, H0: int, size: int,
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
 
 def main():
     import argparse
@@ -943,7 +951,8 @@ def main():
     parser.add_argument("--image", type=str, default=None,
                         help="Input image (default: ../../test_samples/vette.jpg)")
     parser.add_argument("--dev", type=str, default="xdma0")
-    parser.add_argument("--cycle", type=float, default=5.16, help="Clock cycle (ns)")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument("--score-thresh", type=float, default=0.3)
     parser.add_argument("--iou-thresh", type=float, default=0.6)
     args = parser.parse_args()
@@ -952,7 +961,13 @@ def main():
     _SILENT_MODE = True
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     image_path = args.image or os.path.join(SCRIPT_DIR, "../../test_samples/vette.jpg")
     pixel_values, img, W0, H0 = preprocess_image(image_path,

--- a/models/mobilenetv2/mobilenetv2_test.py
+++ b/models/mobilenetv2/mobilenetv2_test.py
@@ -16,7 +16,7 @@ Weights:
 Usage:
   python mobilenetv2_test.py
   python mobilenetv2_test.py --image path/to/image.jpg
-  python mobilenetv2_test.py --dev xdma0 [--cycle 5.62]
+  python mobilenetv2_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
 
 Fixed layout: mobilenetv2_test.py, mobilenetv2_config.json, mobilenetv2_bin/
 live in the same folder. user_dma_core.py is two folders up (repo root);
@@ -1103,13 +1103,22 @@ def preprocess_image(image_path: str, size: int = 224) -> torch.Tensor:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
 
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="MobileNetV2-1.0 accelerator inference.")
     parser.add_argument("--image", type=str, default=None, help="Path to input image")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device (default: xdma0)")
-    parser.add_argument("--cycle", type=float, default=5.62, help="Clock cycle time in ns")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument("--cleanup", action="store_true",
                         help="Delete compile artifacts from mobilenetv2_bin/ before running. "
                              "Cached HF weights (hf_model/) are preserved.")
@@ -1131,7 +1140,13 @@ def main():
     _SILENT_MODE = True
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     image_path = args.image or os.path.join(SCRIPT_DIR, "../../test_samples/vette.jpg")
     pixel_values = preprocess_image(image_path, size=MobileNetV2_UnifiedEngine.IMAGE_SIZE)

--- a/models/mobilesam/mobilesam_run_from_bin.py
+++ b/models/mobilesam/mobilesam_run_from_bin.py
@@ -181,12 +181,22 @@ class MobileSAM_UE_Run(UnifiedEngine):
         return masks_hw, iou_hw
 
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     parser = argparse.ArgumentParser(description="MobileSAM inference from pre-compiled bins")
     parser.add_argument("--point", type=int, nargs=2, metavar=("X", "Y"), default=[512, 512],
                         help="Single-point inference at (x, y) (default: 512 512)")
     parser.add_argument("--dev", type=str, default="xdma0")
-    parser.add_argument("--cycle", type=float, default=None)
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     # Check bins exist
@@ -207,8 +217,13 @@ def main():
         param_meta = json.load(f)
 
     set_dma_device(args.dev)
-    if args.cycle is not None:
-        user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     # Load image
     img_path = os.path.join(SCRIPT_DIR, "../../../test_samples/vette.jpg")
@@ -223,7 +238,7 @@ def main():
     _original_print(f"MobileSAM on {args.dev} (from pre-compiled bins)\n")
 
     # Build engine
-    engine = MobileSAM_UE_Run(clock_period_ns=args.cycle)
+    engine = MobileSAM_UE_Run(clock_period_ns=clock)
     engine.load_params()
 
     # Allocate tensor DRAM from saved manifest — use absolute offsets from compilation

--- a/models/mobilesam/mobilesam_test.py
+++ b/models/mobilesam/mobilesam_test.py
@@ -5,7 +5,7 @@ Encoder + mask decoder compiled into instruction streams and
 executed on the Unified Engine accelerator.
 
 Usage:
-    python mobilesam_test.py [--dev xdma0] [--freq 194]
+    python mobilesam_test.py [--dev xdma0] [--device kintex7] [--cycle 5.15]
 """
 
 import argparse
@@ -3033,17 +3033,33 @@ def _bn_fold(w_conv, bn_w, bn_b, bn_mean, bn_var, eps=1e-5):
     w_fused = w_conv * scale[:, None, None, None]               # broadcast over kH,kW,C_in
     b_fused = bn_b - bn_mean * scale
     return w_fused.to(torch.bfloat16), b_fused.to(torch.bfloat16)
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     parser = argparse.ArgumentParser(description="MobileSAM mask decoder accelerator test")
     parser.add_argument("--dev",   default="xdma0")
-    parser.add_argument("--freq",  type=float, default=194.0, help="Clock frequency MHz")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument("--point", nargs=2, type=int, metavar=("X", "Y"),
                         default=[512, 512],
                         help="Single-point inference: encode image, run decoder for this point, save best mask")
     args = parser.parse_args()
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = 1e3 / args.freq
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     if not os.path.exists(WEIGHTS):
         import urllib.request
@@ -3056,7 +3072,7 @@ def main():
         _original_print("  Download complete.")
 
     _original_print("MobileSAM — HW test")
-    _original_print(f"  Device: {args.dev}  Freq: {args.freq} MHz")
+    _original_print(f"  Device: {args.dev}  clock={clock:.4f} ns")
 
     # ---- Inputs ----
     from PIL import Image as _PIL_Image

--- a/models/parakeet/parakeet_run_from_bin.py
+++ b/models/parakeet/parakeet_run_from_bin.py
@@ -450,12 +450,22 @@ def check_bins_early():
     return missing
 
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Parakeet-TDT-0.6B inference from pre-compiled bins")
     parser.add_argument("--audio", type=str, default=None)
     parser.add_argument("--dev", type=str, default="xdma0")
-    parser.add_argument("--cycle", type=float, default=5.63)
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument("--max-seconds", type=float, default=None)
     args = parser.parse_args()
 
@@ -468,7 +478,13 @@ def main():
 
     cfg = load_config()
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     audio_path = args.audio or os.path.join(SCRIPT_DIR, cfg["defaults"]["default_audio"])
     assert os.path.exists(audio_path), f"Audio file not found: {audio_path}"
@@ -490,7 +506,7 @@ def main():
     global _SILENT_MODE
     _SILENT_MODE = True
 
-    engine = Parakeet_UnifiedEngine(clock_period_ns=args.cycle)
+    engine = Parakeet_UnifiedEngine(clock_period_ns=clock)
 
     import numpy as np
     if waveform.shape[0] > 1:
@@ -558,7 +574,7 @@ def main():
     dur_prog       = loaded["dur"]
     restore_prog   = loaded["restore"]
 
-    engine2 = Parakeet_UnifiedEngine(clock_period_ns=args.cycle, engine_slave=True)
+    engine2 = Parakeet_UnifiedEngine(clock_period_ns=clock, engine_slave=True)
     engine2.copy_dram_layout(engine)
     # Slave engine: only use if programs were compiled for the slave base address.
     # programs_slave.bin copied from programs.bin has JUMPs targeting the wrong base,

--- a/models/parakeet/parakeet_stream.py
+++ b/models/parakeet/parakeet_stream.py
@@ -404,7 +404,7 @@ _event_loop = None
 
 def main():
     global _event_loop
-    args = argparse.Namespace(dev="xdma0", cycle=5.63, port=8000, chunk_seconds=5)
+    args = argparse.Namespace(dev="xdma0", cycle=5.1594, port=8000, chunk_seconds=5)
 
     _original_print("Initializing FPGA engines...")
     init_engine(args)

--- a/models/parakeet/parakeet_test.py
+++ b/models/parakeet/parakeet_test.py
@@ -9,7 +9,7 @@ CPU only does mel extraction and decoder loop orchestration
 Usage:
   python parakeet_test.py
   python parakeet_test.py --audio test.wav
-  python parakeet_test.py --dev xdma0 [--cycle 5.63]
+  python parakeet_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
 """
 
 import json
@@ -1686,12 +1686,22 @@ class Parakeet_UnifiedEngine(UnifiedEngine):
                 t += 1
         _original_print(f"  Decode: {total_steps} joint steps, {len(tokens)} tokens emitted")
         return tokens
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Parakeet-TDT-0.6B accelerator inference")
     parser.add_argument("--audio", type=str, default=None, help="Path to audio file (.wav, .flac, etc.)")
     parser.add_argument("--dev", type=str, default="xdma0", help="XDMA device")
-    parser.add_argument("--cycle", type=float, default=5.63, help="Clock cycle in ns")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     global _SILENT_MODE
@@ -1699,6 +1709,13 @@ def main():
 
     cfg = load_config()
     set_dma_device(args.dev)
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     audio_path = args.audio or os.path.join(SCRIPT_DIR, cfg["defaults"]["default_audio"])
 
     import torchaudio
@@ -1714,7 +1731,7 @@ def main():
     _original_print(f"Parakeet-TDT-0.6B on {args.dev} ({audio_dur:.1f}s audio)")
 
     # --- Init engine ---
-    engine = Parakeet_UnifiedEngine(clock_period_ns=args.cycle)
+    engine = Parakeet_UnifiedEngine(clock_period_ns=clock)
 
     # --- Mel spectrogram: power spec on CPU, matmul+log on accelerator, norm on CPU ---
     Parakeet_UnifiedEngine.ensure_model_files()

--- a/models/qwen2.5_vl_3b/qwen2.5_vl_3b_test.py
+++ b/models/qwen2.5_vl_3b/qwen2.5_vl_3b_test.py
@@ -2788,6 +2788,15 @@ def process_image(image_path: str, size: int = 448) -> torch.Tensor:
         arr[:, :, c] = (arr[:, :, c] - mean[c]) / std[c]
     return torch.from_numpy(arr).permute(2, 0, 1).to(torch.bfloat16)
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Qwen2.5-VL-3B prefill + decode on accelerator.")
@@ -2800,6 +2809,8 @@ def main():
                         help='Repetition penalty (1.0=off, default: 1.05)')
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -2809,7 +2820,13 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = 5.63
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     ue = Qwen25VL3B_UnifiedEngine(script_dir=script_dir)
 

--- a/models/qwen3_1.7b/qwen3_1.7b_run_from_bin.py
+++ b/models/qwen3_1.7b/qwen3_1.7b_run_from_bin.py
@@ -27,7 +27,7 @@ Architecture notes:
 Usage:
   python qwen3_1.7b_run_from_bin.py
   python qwen3_1.7b_run_from_bin.py --prompt "your prompt"
-  python qwen3_1.7b_run_from_bin.py --dev xdma0 [--cycle 5.62]
+  python qwen3_1.7b_run_from_bin.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python qwen3_1.7b_run_from_bin.py --local-weights
   python qwen3_1.7b_run_from_bin.py --temperature 0.7 --top-p 0.9 --repetition-penalty 1.15 --seed 42
 """
@@ -884,6 +884,15 @@ class Qwen3_1_7b_UnifiedEngine(UnifiedEngine):
 # Offline runner — no compile machinery. Reads meta JSON from disk, loads the
 # pre-compiled bin to DRAM, runs prefill + decoder. Supports sampling.
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Qwen3-1.7B inference from pre-compiled bins (offline)")
@@ -893,8 +902,8 @@ def main():
                         help="Use qwen3_1.7b_bin/full_model_weights.bin instead of weights_qwen3_1.7b_hf.bin")
     parser.add_argument("--dev", type=str, default="xdma0",
                         help="DMA device name (default: xdma0)")
-    parser.add_argument("--cycle", type=float, default=5.62,
-                        help="Clock cycle time in ns (default: 5.62ns ≈ peak 22.8 GFLOPS)")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # Sampling DEFAULTS to the validated long-context config (temp 0.7 / top-p 0.9
     # / rep-penalty 1.2). Greedy decoding degenerates into template repetition on
     # long generations for this small model, so sampling is the correct default.
@@ -943,10 +952,13 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
-    user_dma_core.UE_PEAK_GFLOPS = 0.128 / args.cycle
-    _original_print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}, "
-                    f"UE_PEAK_GFLOPS = {user_dma_core.UE_PEAK_GFLOPS:.4f}")
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     global _SILENT_MODE
     _SILENT_MODE = True

--- a/models/qwen3_1.7b/qwen3_1.7b_test.py
+++ b/models/qwen3_1.7b/qwen3_1.7b_test.py
@@ -27,7 +27,7 @@ Weights:
 Usage:
   python qwen3_1.7b_test.py
   python qwen3_1.7b_test.py --prompt "your prompt"
-  python qwen3_1.7b_test.py --dev xdma0 [--cycle 5.88]
+  python qwen3_1.7b_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python qwen3_1.7b_test.py --local-weights
 """
 
@@ -1646,6 +1646,15 @@ class Qwen3_1_7b_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Qwen3-1.7B prefill + decode on accelerator.")
@@ -1653,8 +1662,8 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use qwen3_1.7b_bin/full_model_weights.bin instead of generated weights_qwen3_1.7b_hf.bin")
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
-    parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 5.62ns ≈ peak 22.8 GFLOPS)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # Sampling DEFAULTS to the validated long-context config (temp 0.7 / top-p 0.9
     # / rep-penalty 1.2): greedy decoding on this small model degenerates into
     # template repetition on long generations, so sampling is the correct default.
@@ -1690,13 +1699,13 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
-    user_dma_core.UE_PEAK_GFLOPS = 0.128 / args.cycle
-    print(f"Using DMA device: {args.dev}")
-    print(f"  H2C: {DMA_DEVICE_H2C}")
-    print(f"  C2H: {DMA_DEVICE_C2H}")
-    print(f"  USER: {DMA_DEVICE_USER}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}, UE_PEAK_GFLOPS = {user_dma_core.UE_PEAK_GFLOPS:.4f}")
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     ue = Qwen3_1_7b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
     cfg = _load_config(script_dir)

--- a/models/qwen3_4b/qwen3_4b_run_from_bin.py
+++ b/models/qwen3_4b/qwen3_4b_run_from_bin.py
@@ -26,7 +26,7 @@ Architecture notes:
 Usage:
   python qwen3_4b_run_from_bin.py
   python qwen3_4b_run_from_bin.py --prompt "your prompt"
-  python qwen3_4b_run_from_bin.py --dev xdma0 [--cycle 5.62]
+  python qwen3_4b_run_from_bin.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python qwen3_4b_run_from_bin.py --local-weights
 """
 
@@ -840,6 +840,15 @@ class Qwen3_4b_UnifiedEngine(UnifiedEngine):
 # Offline runner — no compile machinery. Reads meta JSON from disk, loads the
 # pre-compiled bin to DRAM, runs prefill + decoder.
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Qwen3-4B inference from pre-compiled bins (offline)")
@@ -849,8 +858,8 @@ def main():
                         help="Use qwen3_4b_bin/full_model_weights.bin instead of weights_qwen3_4b_hf.bin")
     parser.add_argument("--dev", type=str, default="xdma0",
                         help="DMA device name (default: xdma0)")
-    parser.add_argument("--cycle", type=float, default=5.62,
-                        help="Clock cycle time in ns (default: 5.62ns ≈ peak 22.8 GFLOPS)")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # Sampling DEFAULTS to the validated long-context config (temp 0.7 / top-p 0.9
     # / rep-penalty 1.2). --temperature 0 forces greedy fast path.
     parser.add_argument('--temperature', type=float, default=0.7,
@@ -897,10 +906,13 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
-    user_dma_core.UE_PEAK_GFLOPS = 0.128 / args.cycle
-    _original_print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}, "
-                    f"UE_PEAK_GFLOPS = {user_dma_core.UE_PEAK_GFLOPS:.4f}")
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     global _SILENT_MODE
     _SILENT_MODE = True

--- a/models/qwen3_4b/qwen3_4b_test.py
+++ b/models/qwen3_4b/qwen3_4b_test.py
@@ -28,7 +28,7 @@ Weights:
 Usage:
   python qwen3_4b_test.py
   python qwen3_4b_test.py --prompt "your prompt"
-  python qwen3_4b_test.py --dev xdma0 [--cycle 5.88]
+  python qwen3_4b_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
   python qwen3_4b_test.py --local-weights
 """
 
@@ -1601,6 +1601,15 @@ class Qwen3_4b_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Qwen3-4B prefill + decode on accelerator.")
@@ -1608,8 +1617,8 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use qwen3_4b_bin/full_model_weights.bin instead of generated weights_qwen3_4b_hf.bin")
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
-    parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 5.62ns ≈ peak 22.8 GFLOPS)')
+    parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # Sampling DEFAULTS to the validated long-context config (temp 0.7 / top-p 0.9
     # / rep-penalty 1.2): greedy degenerates into template repetition on long
     # generations, so sampling is the correct default. --temperature 0 forces
@@ -1640,13 +1649,13 @@ def main():
     DMA_DEVICE_H2C = user_dma_core.DMA_DEVICE_H2C
     DMA_DEVICE_C2H = user_dma_core.DMA_DEVICE_C2H
     DMA_DEVICE_USER = user_dma_core.DMA_DEVICE_USER
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
-    user_dma_core.UE_PEAK_GFLOPS = 0.128 / args.cycle
-    print(f"Using DMA device: {args.dev}")
-    print(f"  H2C: {DMA_DEVICE_H2C}")
-    print(f"  C2H: {DMA_DEVICE_C2H}")
-    print(f"  USER: {DMA_DEVICE_USER}")
-    print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}, UE_PEAK_GFLOPS = {user_dma_core.UE_PEAK_GFLOPS:.4f}")
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     ue = Qwen3_4b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
     cfg = _load_config(script_dir)

--- a/models/smolvlm2/smolvlm2_run_from_bin.py
+++ b/models/smolvlm2/smolvlm2_run_from_bin.py
@@ -519,6 +519,15 @@ def build_input_ids(tokenizer, prompt: str, has_image: bool = True) -> list:
 # =============================================================================
 # Main
 # =============================================================================
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
 
@@ -528,7 +537,8 @@ def main():
     parser.add_argument("--prompt", type=str, default=_d["prompt"])
     parser.add_argument("--image", type=str, default=os.path.join(_root, _d["image"]))
     parser.add_argument("--dev", type=str, default=_d["dev"])
-    parser.add_argument("--cycle", type=float, default=_d["cycle_ns"])
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument("--max-seq", type=int, default=_d["max_seq"])
     parser.add_argument("--vision-fp4", action="store_true")
     args = parser.parse_args()
@@ -556,7 +566,13 @@ def main():
         return
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     _SILENT_MODE = True
 
     ue = SmolVLM2_UnifiedEngine(script_dir=script_dir, vision_bf16=not args.vision_fp4)

--- a/models/smolvlm2/smolvlm2_test.py
+++ b/models/smolvlm2/smolvlm2_test.py
@@ -2055,6 +2055,15 @@ def _verify_prefill_cpu(ue, token_ids, hw_first_token, model_dir, image_path, pr
 # =============================================================================
 # Main
 # =============================================================================
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     from user_dma_core import set_dma_device
@@ -2066,7 +2075,8 @@ def main():
     parser.add_argument("--prompt", type=str, default=_d["prompt"], help="Text prompt")
     parser.add_argument("--image", type=str, default=os.path.join(_root, _d["image"]), help="Path to image file (None for text-only)")
     parser.add_argument("--dev", type=str, default=_d["dev"], help="DMA device name")
-    parser.add_argument("--cycle", type=float, default=_d["cycle_ns"], help="Clock cycle time in ns")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     parser.add_argument("--max-seq", type=int, default=_d["max_seq"], help="Max sequence length")
     parser.add_argument("--vision-fp4", action="store_true", help="Use FP4 quantized weights for vision encoder (default: BF16)")
     parser.add_argument("--debug", action="store_true", help="Staged NaN/cosine localizer: verify vision + per-layer prefill_v2 vs HF CPU reference, then exit (no decode)")
@@ -2109,7 +2119,13 @@ def main():
 
     # --- Hardware inference ---
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
     global _SILENT_MODE
     _SILENT_MODE = True
     ue = SmolVLM2_UnifiedEngine(script_dir=script_dir, vision_bf16=not args.vision_fp4)

--- a/models/swin/swin_test.py
+++ b/models/swin/swin_test.py
@@ -12,7 +12,7 @@ Weights:
 Usage:
   python swin_test.py
   python swin_test.py --image path/to/image.jpg
-  python swin_test.py --dev xdma0 [--cycle 5.62]
+  python swin_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
 
 Fixed layout: swin_test.py, swin_config.json, and swin_bin/ live in the same folder.
   user_dma_core.py is two folders up (repo root); that directory is added to sys.path.
@@ -1463,19 +1463,35 @@ def preprocess_image(image_path: str) -> torch.Tensor:
 # Main
 # ---------------------------------------------------------------------------
 
+def _clock_ns_default_for_device(device: str) -> float:
+    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
+    if device == "kintex7":                       return 5.1594
+    if device in ("rk", "puzhi"):                 return 3.0
+    if device in ("bittware", "bittware_256"):     return 3.3333
+    if device == "alveo":                          return 4.0
+    return 10.0
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Swin-Large accelerator inference.")
     parser.add_argument("--image", type=str, default=None, help="Path to input image")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device (default: xdma0)")
-    parser.add_argument("--cycle", type=float, default=5.62, help="Clock cycle time in ns")
+    parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
+    parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     args = parser.parse_args()
 
     global _SILENT_MODE
     _SILENT_MODE = True
 
     set_dma_device(args.dev)
-    user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
+    axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
+    os.environ["UE_AXI_DATA_WIDTH_BITS"] = str(axi_width_bits)
+    user_dma_core.UE_AXI_DATA_WIDTH_BITS = axi_width_bits
+    clock = args.cycle if args.cycle is not None else _clock_ns_default_for_device(args.device)
+    user_dma_core.CLOCK_CYCLE_TIME_NS = clock
+    user_dma_core.UE_PEAK_GFLOPS = 0.128 / clock
+    _original_print(f"FPGA profile: device={args.device}, clock={clock:.4f} ns, UE_AXI_DATA_WIDTH_BITS={axi_width_bits}")
 
     # Load image
     image_path = args.image or os.path.join(SCRIPT_DIR, "../../test_samples/vette.jpg")

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -6514,7 +6514,7 @@ class UnifiedEngine:
         group_flops += 2 * 1 * seq_len * head_dim
         return group_size * group_flops
 
-    def quantized_matmat_core(self, M: int, K: int, N: int, A_DRAM_ADDR: int, B_DRAM_ADDR: int, OUTPUT_DRAM_ADDR: int, SCALE_DRAM_ADDR: int, C_DRAM_ADDR: int = None, bias_mode: str = "broadcast_N", data_type: TYPE = None, gelu_enable: bool = False, silu_enable: bool = False, sigmoid_enable: bool = False, clamp_enable: bool = False, log_enable: bool = False) -> None:
+    def quantized_matmat_core(self, M: int, K: int, N: int, A_DRAM_ADDR: int, B_DRAM_ADDR: int, OUTPUT_DRAM_ADDR: int, SCALE_DRAM_ADDR: int, C_DRAM_ADDR: int = None, bias_mode: str = "broadcast_N", data_type: TYPE = None, gelu_enable: bool = False, silu_enable: bool = False, sigmoid_enable: bool = False, clamp_enable: bool = False, log_enable: bool = False, write_back_disable: bool = False) -> None:
         """Quantized matrix-matrix multiplication core.
         Args:
             M: batch dimension (number of input vectors)
@@ -6627,11 +6627,12 @@ class UnifiedEngine:
                                                                 lalu_b=lalu_b)
                     max_clear_en = 0
 
-                self.sram_to_accelerator_memory(sram_address=0x80000,
-                                                accelerator_dram_address=OUTPUT_DRAM_ADDR + (M_chunk_idx * N + N_chunk_idx) * bytes_per_element,
-                                                element_size=M_chunk_size * N_take_size,
-                                                stride_bytes_per_chunk=N_take_size * bytes_per_element,
-                                                stride_jump_bytes=N * bytes_per_element)
+                if not write_back_disable:
+                    self.sram_to_accelerator_memory(sram_address=0x80000,
+                                                    accelerator_dram_address=OUTPUT_DRAM_ADDR + (M_chunk_idx * N + N_chunk_idx) * bytes_per_element,
+                                                    element_size=M_chunk_size * N_take_size,
+                                                    stride_bytes_per_chunk=N_take_size * bytes_per_element,
+                                                    stride_jump_bytes=N * bytes_per_element)
 
         total_flops = 2 * M * N * K
         if bias_enable:

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -792,7 +792,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x29b64569, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x29b64569. Please update FPGA with commit update_29b64569.bin using update_flash.py (public release v1.1)"
+        assert hw_version == 0xf158a78a, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0xf158a78a. Please update FPGA with commit update_f158a78a.bin using update_flash.py (public release v1.1)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -4375,41 +4375,51 @@ def isa_rela_loop_test() -> None:
     # so the loop stride can be computed at runtime rather than assembled as an
     # immediate.  Exit is via JZ (absolute, placeholder patched after capture).
     #
-    # Program layout (8 instructions, indices 0-7):
+    # Program layout (3 setup + optional align NOP + 4-instruction body + HALT):
     #   0: SET cnt_reg    = loop_cnt_rela   (setup)
     #   1: SET accum_reg  = 0               (setup)
-    #   2: SET offset_reg = 4               (setup; backward offset from JMP to idx 3)
-    #   3: INC accum_reg                    <- loop body start
-    #   4: DEC cnt_reg
-    #   5: JZ  cnt_reg -> HALT (idx 7)      (placeholder 0, patched after capture)
-    #   6: JMP_REG_RELA offset_reg          (jumps back 4 words: read_ptr 7->3)
-    #   7: HALT
+    #   2: SET offset_reg = 4               (setup; backward offset is always 4)
+    #  [3: NOP]                             (optional 512-bit alignment pad)
+    #   3+a: INC accum_reg                  <- loop body start (a = n_align_nops)
+    #   4+a: DEC cnt_reg
+    #   5+a: JZ  cnt_reg -> HALT            (placeholder 0, patched after capture)
+    #   6+a: JMP_REG_RELA offset_reg        (read_ptr -= 4, lands on loop body)
+    #   7+a: HALT
     #
-    # PC formula: 3 setup + (loop_cnt-1)*4 body iterations + 3 last iteration + 1 HALT
-    #           = 4*loop_cnt + 3
-    # Unlike REG_ABS, relative jumps do not trigger a DMA reload so the loop body
-    # stays in the original cache window.
+    # The backward offset is always 4 regardless of alignment NOPs: the body is
+    # always 4 instructions before the JMP, so read_ptr - 4 lands on INC accum.
+    # Unlike REG_ABS, relative jumps do not trigger a DMA reload; the loop body
+    # stays in the original instruction cache window.
+    #
+    # PC formula: (3 + n_align_nops) setup + (loop_cnt-1)*4 + 3 last + 1 HALT
+    #           = 4*loop_cnt + 3 + n_align_nops
     loop_cnt_rela = 5
     cnt_reg_r  = 5
     accum_reg_r = 6
     offset_reg  = 7
-    # Backward offset: after fetching idx 6 the read_ptr is 7; subtracting 4 lands at 3.
-    bwd_offset = 4
+    bwd_offset = 4  # always 4: distance from JMP_REG_RELA to INC accum in the cache
 
     ue_r = UnifiedEngine()
     program_dram_addr_r = ue_r.get_program_dram_addr()
+
+    # Align the loop body start to a 512-bit (64-byte) DRAM instruction boundary.
+    n_align_nops_r = 0
+    if (program_dram_addr_r + 3 * INSTRUCTION_SIZE_BYTES) % (2 * INSTRUCTION_SIZE_BYTES) != 0:
+        n_align_nops_r = 1
 
     ue_r.start_capture()
     ue_r.generate_instruction_add_set(cnt_reg_r, loop_cnt_rela)         # idx 0
     ue_r.generate_instruction_add_set(accum_reg_r, 0)                   # idx 1
     ue_r.generate_instruction_add_set(offset_reg, bwd_offset)           # idx 2
-    ue_r.generate_instruction_add_inc(accum_reg_r)                      # idx 3 <- loop body
-    ue_r.generate_instruction_add_dec(cnt_reg_r)                        # idx 4
-    jz_capture_idx_r = ue_r.capture_count                               # = 5 before JZ
-    ue_r.generate_instruction_jump_abs_jz(0, cnt_reg_r)                 # idx 5, placeholder
-    ue_r.generate_instruction_jump_reg_rela(offset_reg)                 # idx 6
-    halt_idx_r = ue_r.capture_count                                     # = 7 before HALT
-    ue_r.generate_instruction_halt()                                    # idx 7
+    for _ in range(n_align_nops_r):
+        ue_r.generate_instruction_nop()                                  # idx 3 if needed
+    ue_r.generate_instruction_add_inc(accum_reg_r)                      # loop body start
+    ue_r.generate_instruction_add_dec(cnt_reg_r)
+    jz_capture_idx_r = ue_r.capture_count
+    ue_r.generate_instruction_jump_abs_jz(0, cnt_reg_r)                 # placeholder
+    ue_r.generate_instruction_jump_reg_rela(offset_reg)
+    halt_idx_r = ue_r.capture_count
+    ue_r.generate_instruction_halt()
     ue_r.stop_capture()
 
     halt_word_addr_r = ue_35bit_addr_shifter(program_dram_addr_r + halt_idx_r * INSTRUCTION_SIZE_BYTES)
@@ -4421,14 +4431,14 @@ def isa_rela_loop_test() -> None:
     ue_r.wait_queue(30.0)
 
     _, pc_reg_r = ue_r.report_timing_and_instruction_count()
-    expected_pc_r = 4 * loop_cnt_rela + 3
+    expected_pc_r = 4 * loop_cnt_rela + 3 + n_align_nops_r
     assert pc_reg_r == expected_pc_r, (
         f"isa_rela_loop_reg_rela_test PC mismatch: got {pc_reg_r}, expected {expected_pc_r} "
-        f"(loop_cnt={loop_cnt_rela}, bwd_offset={bwd_offset})"
+        f"(loop_cnt={loop_cnt_rela}, bwd_offset={bwd_offset}, n_align_nops={n_align_nops_r})"
     )
     print(
         f"isa_rela_loop_reg_rela_test: PASS (loop_cnt={loop_cnt_rela}, pc_reg={pc_reg_r}, "
-        f"bwd_offset={bwd_offset})"
+        f"bwd_offset={bwd_offset}, n_align_nops={n_align_nops_r})"
     )
     record_test("isa_rela_loop_reg_rela", f"loop_cnt={loop_cnt_rela}, bwd_offset={bwd_offset}")
     ue_r.clear_capture_buffer()
@@ -4497,18 +4507,19 @@ def isa_abs_loop_test() -> None:
     # setup time via ADD_SET and the unconditional JMP_REG_ABS uses that register as
     # the target each iteration.  Exit is via JZ (immediate target = HALT).
     #
-    # Program layout (8 instructions, indices 0-7):
-    #   0: SET cnt_reg  = loop_cnt        (setup)
-    #   1: SET accum_reg = 0              (setup)
-    #   2: SET addr_reg = word_addr(3)    (setup; word addr of instruction 3)
-    #   3: INC accum_reg                  <- loop body start (addr_reg points here)
-    #   4: DEC cnt_reg
-    #   5: JZ  cnt_reg -> HALT (idx 7)   (placeholder 0, patched after capture)
-    #   6: JMP_REG_ABS addr_reg
-    #   7: HALT
+    # Program layout (3 setup + optional align NOP + 4-instruction body + HALT):
+    #   0: SET cnt_reg   = loop_cnt         (setup)
+    #   1: SET accum_reg = 0                (setup)
+    #   2: SET addr_reg  = word_addr(body)  (setup; 512-bit-aligned loop body address)
+    #  [3: NOP]                             (optional alignment pad)
+    #   3+a: INC accum_reg                  <- loop body start (a = n_align_nops)
+    #   4+a: DEC cnt_reg
+    #   5+a: JZ  cnt_reg -> HALT            (placeholder 0, patched after capture)
+    #   6+a: JMP_REG_ABS addr_reg
+    #   7+a: HALT
     #
-    # PC formula: 3 setup + (loop_cnt-1)*4 body iterations + 3 last iteration + 1 HALT
-    #           = 4*loop_cnt + 3
+    # PC formula: (3 + n_align_nops) setup + (loop_cnt-1)*4 + 3 last + 1 HALT
+    #           = 4*loop_cnt + 3 + n_align_nops
     loop_cnt_reg_abs = 4
     cnt_reg  = 5
     accum_reg = 6
@@ -4516,19 +4527,29 @@ def isa_abs_loop_test() -> None:
 
     ue2 = UnifiedEngine()
     program_dram_addr2 = ue2.get_program_dram_addr()
-    loop_body_word_addr = ue_35bit_addr_shifter(program_dram_addr2 + 3 * INSTRUCTION_SIZE_BYTES)
+
+    # Align the loop body start to a 512-bit (64-byte) DRAM instruction boundary
+    # before storing the word address into the GPR.
+    loop_body_byte_addr = program_dram_addr2 + 3 * INSTRUCTION_SIZE_BYTES
+    n_align_nops = 0
+    if loop_body_byte_addr % (2 * INSTRUCTION_SIZE_BYTES) != 0:
+        loop_body_byte_addr += INSTRUCTION_SIZE_BYTES
+        n_align_nops = 1
+    loop_body_word_addr = ue_35bit_addr_shifter(loop_body_byte_addr)
 
     ue2.start_capture()
     ue2.generate_instruction_add_set(cnt_reg, loop_cnt_reg_abs)         # idx 0
     ue2.generate_instruction_add_set(accum_reg, 0)                      # idx 1
     ue2.generate_instruction_add_set(addr_reg, loop_body_word_addr)     # idx 2
-    ue2.generate_instruction_add_inc(accum_reg)                         # idx 3 <- loop body
-    ue2.generate_instruction_add_dec(cnt_reg)                           # idx 4
-    jz_capture_idx = ue2.capture_count                                  # = 5 before JZ
-    ue2.generate_instruction_jump_abs_jz(0, cnt_reg)                    # idx 5, placeholder
-    ue2.generate_instruction_jump_reg_abs(addr_reg)                     # idx 6
-    halt_idx = ue2.capture_count                                        # = 7 before HALT
-    ue2.generate_instruction_halt()                                     # idx 7
+    for _ in range(n_align_nops):
+        ue2.generate_instruction_nop()                                   # idx 3 if needed
+    ue2.generate_instruction_add_inc(accum_reg)                         # loop body start
+    ue2.generate_instruction_add_dec(cnt_reg)
+    jz_capture_idx = ue2.capture_count
+    ue2.generate_instruction_jump_abs_jz(0, cnt_reg)                    # placeholder
+    ue2.generate_instruction_jump_reg_abs(addr_reg)
+    halt_idx = ue2.capture_count
+    ue2.generate_instruction_halt()
     ue2.stop_capture()
 
     halt_word_addr = ue_35bit_addr_shifter(program_dram_addr2 + halt_idx * INSTRUCTION_SIZE_BYTES)
@@ -4540,14 +4561,14 @@ def isa_abs_loop_test() -> None:
     ue2.wait_queue(30.0)
 
     _, pc_reg2 = ue2.report_timing_and_instruction_count()
-    expected_pc2 = 4 * loop_cnt_reg_abs + 3
+    expected_pc2 = 4 * loop_cnt_reg_abs + 3 + n_align_nops
     assert pc_reg2 == expected_pc2, (
         f"isa_abs_loop_reg_abs_test PC mismatch: got {pc_reg2}, expected {expected_pc2} "
-        f"(loop_cnt={loop_cnt_reg_abs})"
+        f"(loop_cnt={loop_cnt_reg_abs}, n_align_nops={n_align_nops})"
     )
     print(
         f"isa_abs_loop_reg_abs_test: PASS (loop_cnt={loop_cnt_reg_abs}, pc_reg={pc_reg2}, "
-        f"loop_body_word=0x{loop_body_word_addr:x}, halt_word=0x{halt_word_addr:x})"
+        f"loop_body_word=0x{loop_body_word_addr:x}, n_align_nops={n_align_nops})"
     )
     record_test("isa_abs_loop_reg_abs", f"loop_cnt={loop_cnt_reg_abs}")
     ue2.clear_capture_buffer()


### PR DESCRIPTION
## Summary
- Update `--cycle` default from 0.17 GHz to 0.194 GHz (Kintex7 actual frequency) across gpt2, llama3.2_1b, llama3.2_3b test and run-from-bin scripts
- Capture per-token HW counter latency and CPU wall time during decode in `llama3.2_1b_test.py`
- Print a performance summary at end of inference: instruction binary sizes, prefill HW/CPU latency, decode avg HW/CPU latency and tokens/s