### PR TITLE
Apply FPGA penalty to both 1b & 3b models

### DIFF
--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -24,7 +24,7 @@ See notes_repetition_penalty_fpga_bias.md.
 Usage:
   python llama3.2_1b_run_from_bin.py
   python llama3.2_1b_run_from_bin.py --prompt "your question"
-  python llama3.2_1b_run_from_bin.py --no-fpga-penalty --dev xdma0     # plain greedy (no penalty)
+  python llama3.2_1b_run_from_bin.py --pure-greedy --dev xdma0     # plain greedy (no penalty)
 """
 
 import json
@@ -349,7 +349,7 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
             if not os.path.exists(meta_path):
                 raise FileNotFoundError(
                     f"on-FPGA penalty bin meta not found: {meta_path}\n"
-                    f"  build it with:  python llama3.2_1b_test.py --fpga-penalty")
+                    f"  build it with:  python llama3.2_1b_test.py")
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -505,7 +505,7 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
     """Hard-fail before any FPGA touch if a required artifact is missing."""
     paths = cfg["paths"]
     inst_bin, inst_meta = paths["instruction_bin"], paths["instruction_meta"]
-    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py --fpga-penalty)
+    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py default)
         inst_bin = inst_bin.replace(".bin", "_fpgapenalty.bin")
         inst_meta = inst_meta.replace(".json", "_fpgapenalty.json")
     required = [
@@ -536,31 +536,32 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Decode is deterministic with the on-FPGA penalty only (no host penalty / sampling).
-    parser.add_argument("--greedy-until", type=int, default=512,
+    # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
+    # matmul bias so the HW argmax returns the penalized token directly (no logit readback); loads the
+    # _fpgapenalty bin. --pure-greedy disables it entirely (plain writeback-on bin).
+    parser.add_argument("--pure-greedy", action="store_true",
+                        help="Disable the on-FPGA repetition penalty entirely — plain greedy decode "
+                             "(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy "
+                             "only for the A/B baseline and the compare/calibration tool.")
+    # On-FPGA repetition penalty parameters (active unless --pure-greedy).
+    pen_group = parser.add_argument_group("on-FPGA repetition penalty (active unless --pure-greedy)")
+    pen_group.add_argument("--greedy-until", type=int, default=512,
                         help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
-                             "then the on-FPGA repetition penalty breaks long-context loops. "
+                             "then the penalty breaks long-context loops. "
                              "0 = penalty from the start. Default 512.")
-    # On-FPGA repetition penalty (DEFAULT): the penalty is folded into the LM-head matmul bias so the
-    # HW argmax returns the penalized token directly — no logit readback. Loads the _fpgapenalty bin.
-    parser.add_argument("--fpga-penalty", action=argparse.BooleanOptionalAction, default=True,
-                        help="Apply the repetition penalty on-FPGA via the LM-head matmul bias "
-                             "(argmax of logits+bias on chip, no logit readback). DEFAULT. "
-                             "--no-fpga-penalty = plain greedy (writeback-on bin, no penalty), for "
-                             "the A/B baseline and the compare/calibration tool.")
-    parser.add_argument("--pen-alpha", type=float, default=1.0,
-                        help="On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.")
-    parser.add_argument("--pen-cap", type=float, default=20.0,
-                        help="On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.")
-    parser.add_argument("--rep-window", type=int, default=256,
-                        help="On-FPGA penalty: count tokens over the last N. Default 256.")
+    pen_group.add_argument("--pen-alpha", type=float, default=1.0,
+                        help="bias[t] = -alpha*count[t] (logit units). Default 1.0.")
+    pen_group.add_argument("--pen-cap", type=float, default=20.0,
+                        help="max |bias| per token (floor on -alpha*count). Default 20.")
+    pen_group.add_argument("--rep-window", type=int, default=256,
+                        help="count tokens over the last N. Default 256.")
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     cfg = _load_config(script_dir)
 
     # Hard-fail BEFORE touching the FPGA if any artifact is missing.
-    _verify_artifacts(script_dir, cfg, fpga_penalty=bool(args.fpga_penalty))
+    _verify_artifacts(script_dir, cfg, fpga_penalty=not bool(args.pure_greedy))
 
     set_dma_device(args.dev)
     user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
@@ -590,7 +591,7 @@ def main():
     ue.prefill_seq = prefill_seq
     # Decode config — deterministic, on-FPGA penalty only (no host penalty / sampling).
     ue.greedy_until = int(args.greedy_until)
-    ue.fpga_penalty = bool(args.fpga_penalty)   # selects the _fpgapenalty bin + matmul-bias path
+    ue.fpga_penalty = not bool(args.pure_greedy)   # selects the _fpgapenalty bin + matmul-bias path
     ue.pen_alpha = float(args.pen_alpha)
     ue.pen_cap = float(args.pen_cap)
     ue.rep_window = int(args.rep_window)

--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -15,18 +15,16 @@ running ``llama3.2_1b_test.py`` once on a build machine that has HF access):
   * ``Llama-3.2-1B-Instruct/``       tokenizer files only (tokenizer.json /
                                      tokenizer_config.json). Model weights NOT needed.
 
-Design mirrors test.py §A–§D (see notes_llama3.2_1b.md): full-4 GB DRAM layout,
-dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
-and sampling decode (recency-decayed / windowed / structural-exempt repetition
-penalty). DECODE DEFAULT is a position-gated HYBRID (temp 0): pure greedy for the first
-greedy_until (512) tokens — correct math/reasoning — then repetition penalty 1.2 breaks
-long-context loops; deterministic, see notes §D. The shipped bin is compiled with LM-head
-writeback enabled, so sampling (temp>0), the hybrid, and pure greedy (rep-pen 1.0) all work.
+Design mirrors test.py (see notes_llama3.2_1b.md): full-4 GB DRAM layout, dynamic-PBI single
+bin (GPR-primed preamble + jump_abs), prefill_context_size=128. DECODE DEFAULT is deterministic:
+pure greedy for the first greedy_until (512) tokens — correct math/reasoning — then the on-FPGA
+repetition penalty (LM-head matmul bias) breaks long-context loops. No host penalty / sampling.
+See notes_repetition_penalty_fpga_bias.md.
 
 Usage:
   python llama3.2_1b_run_from_bin.py
   python llama3.2_1b_run_from_bin.py --prompt "your question"
-  python llama3.2_1b_run_from_bin.py --temperature 0 --dev xdma0     # greedy
+  python llama3.2_1b_run_from_bin.py --no-fpga-penalty --dev xdma0     # plain greedy (no penalty)
 """
 
 import json
@@ -286,6 +284,10 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
         self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
+        # On-FPGA repetition-penalty bias (the LM-head matmul's C term, bias_mode="broadcast_N").
+        # MUST be allocated here, immediately after LOGITS_DRAM and last — identical order/size to
+        # llama3.2_1b_test.py — so its baked address matches the fpga-penalty bin. all-zero = no penalty.
+        self.PENALTY_BIAS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
         _original_print(f"    Tensor dram end 0x{self.get_tensor_dram_addr():X}, usage {self.get_tensor_dram_usage()} bytes")
 
     # ---- sampling (identical mechanism to test.py §D) -----------------------
@@ -313,47 +315,24 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
             self._struct_ids_tensor_cache = t
         return t
 
-    def sample_next_token(self, prev_tokens) -> int:
-        """Read the full logits row from LOGITS_DRAM and sample with the configured
-        temperature / top_k / top_p / repetition_penalty (recency-decayed, windowed,
-        structural-exempt). Greedy (temperature<=0) is handled by the caller via the
-        HW argmax register, so this assumes sampling is on."""
+    def _write_penalty_bias(self, prev_tokens) -> None:
+        """On-FPGA repetition penalty: build the per-vocab additive bias from the windowed token
+        frequency and DMA it to PENALTY_BIAS_DRAM (the LM-head matmul's C term, bias_mode="broadcast_N").
+        bias[t] = clamp(-alpha*count[t], min=-cap); structural tokens stay 0. The HW argmax of
+        (logits + bias) then returns the penalized token id — no logit readback. Identical formula to
+        llama3.2_1b_test.py._write_penalty_bias (the bin compiled there bakes this contract)."""
         vocab = self.EMBEDDING_ELEMENTS
-        bpe = self.bytes_per_element
-        buf = torch.empty(vocab, dtype=torch.bfloat16)
-        self.dma_read(DMA_DEVICE_C2H, self.LOGITS_DRAM, buf, vocab * bpe)
-        logits = buf.float()
-        # Recency-decayed frequency repetition penalty over the last rep_window tokens,
-        # exempting structural/special tokens. See notes_llama3.2_1b.md §D.
-        rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        if rep_pen != 1.0 and prev_tokens:
-            rep_window = int(getattr(self, "rep_window", 256))
-            rep_decay = float(getattr(self, "rep_decay", 0.97))
-            window = torch.tensor(prev_tokens[-rep_window:], dtype=torch.long)
-            L = window.numel()
-            ages = torch.arange(L - 1, -1, -1, dtype=torch.float32)
-            contrib = rep_decay ** ages
-            weight = torch.zeros(vocab, dtype=torch.float32)
-            weight.index_add_(0, window, contrib)
-            weight[self._structural_ids_tensor()] = 0.0
-            nz = weight > 0
-            if bool(nz.any()):
-                factor = rep_pen ** weight[nz]
-                v = logits[nz]
-                logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        # Deterministic selection: argmax of the (penalty-adjusted) logits.
-        return int(logits.argmax().item())
-        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
-        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
-        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
-        # if top_k > 0 and top_k < vocab:
-        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
-        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
-        # if 0.0 < top_p < 1.0:
-        #     sl, si = torch.sort(logits, descending=True)
-        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
-        #     logits[si[~keep]] = float("-inf")
-        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
+        alpha = float(getattr(self, "pen_alpha", 1.0))
+        cap = float(getattr(self, "pen_cap", 20.0))
+        W = int(getattr(self, "rep_window", 256))
+        window = prev_tokens[-W:]
+        count = torch.zeros(vocab, dtype=torch.float32)
+        if window:
+            win = torch.tensor(window, dtype=torch.long)
+            count.index_add_(0, win, torch.ones(win.numel(), dtype=torch.float32))
+            count[self._structural_ids_tensor()] = 0.0
+        bias = (-alpha * count).clamp(min=-cap).to(torch.bfloat16).view(1, vocab)
+        self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM, bias)
 
     # ---- run path (dynamic-PBI single bin: preamble + jump_abs) -------------
     def run_llama(self) -> None:
@@ -363,6 +342,14 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         meta_path = os.path.join(self.script_dir,
                                  paths_cfg.get("instruction_meta", "llama3.2_1b_bin/llama_instruction.json"))
+        if bool(getattr(self, "fpga_penalty", False)):
+            # On-FPGA penalty uses a separate bin (LM-head matmul bias on / logit writeback off);
+            # its meta points to llama_instruction_fpgapenalty.bin. Compiled by llama3.2_1b_test.py.
+            meta_path = meta_path.replace(".json", "_fpgapenalty.json")
+            if not os.path.exists(meta_path):
+                raise FileNotFoundError(
+                    f"on-FPGA penalty bin meta not found: {meta_path}\n"
+                    f"  build it with:  python llama3.2_1b_test.py --fpga-penalty")
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -425,11 +412,16 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
 
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # Position-gated decode (deterministic): PURE greedy (HW argmax) for the first
         # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
-        # repetition penalty turns on to break long-context loops.
-        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        # on-FPGA repetition penalty turns on to break long-context loops.
         _greedy_until = int(getattr(self, "greedy_until", 0))
+        # On-FPGA penalty: the LM-head matmul adds PENALTY_BIAS_DRAM (its C bias) so the HW argmax
+        # already returns the penalized token. Zero the buffer first → pure greedy until the gate.
+        _fpga_penalty = bool(getattr(self, "fpga_penalty", False))
+        if _fpga_penalty:
+            self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM,
+                                           torch.zeros(1, self.EMBEDDING_ELEMENTS, dtype=torch.bfloat16))
 
         import shutil
         _use_status = sys.stdout.isatty()
@@ -475,14 +467,18 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
             self.write_captured_instructions_to_dram(preamble_addr)
             self.clear_capture_buffer()
 
+            # On-FPGA penalty: refresh the per-vocab bias (this step's LM-head matmul C term) from the
+            # windowed token frequency once past the gate, so the HW argmax of (logits + bias) returns
+            # the penalized token directly — no logit readback.
+            if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
+                self._write_penalty_bias(self._generated_tokens)
+
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
-            # repetition penalty (read logits, argmax of penalized logits).
-            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
-            if _penalty_active:
-                token_id = self.sample_next_token(self._generated_tokens)
-            else:
-                token_id = self.get_arg_max_index(rank=1)
+            # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
+            # already added the bias, so the register holds the penalized token; in plain mode it's
+            # pure greedy. No logit readback. (The compare/calibration tool overrides
+            # get_arg_max_index to apply a host-side penalty against the writeback-on plain bin.)
+            token_id = self.get_arg_max_index(rank=1)
             self._generated_tokens.append(token_id)
             token_char = self.tokenizer.decode([token_id])
             _SILENT_MODE = False
@@ -505,14 +501,18 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
                         f"total {self.seq_len} tokens.")
 
 
-def _verify_artifacts(script_dir: str, cfg: dict) -> None:
+def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) -> None:
     """Hard-fail before any FPGA touch if a required artifact is missing."""
     paths = cfg["paths"]
+    inst_bin, inst_meta = paths["instruction_bin"], paths["instruction_meta"]
+    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py --fpga-penalty)
+        inst_bin = inst_bin.replace(".bin", "_fpgapenalty.bin")
+        inst_meta = inst_meta.replace(".json", "_fpgapenalty.json")
     required = [
         ("llama3.2_1b_config.json", "model config"),
         (paths["weights_bin"], "weight bin"),
-        (paths["instruction_bin"], "unified instruction bin"),
-        (paths["instruction_meta"], "instruction bin meta"),
+        (inst_bin, "unified instruction bin"),
+        (inst_meta, "instruction bin meta"),
     ]
     tok_dir = os.path.join(script_dir, paths["hf_model_dir"])
     missing = [f"  {rel}   ({label})" for rel, label in required
@@ -536,31 +536,31 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Decode defaults match llama3.2_1b_test.py: deterministic hybrid (greedy 512 + rep-pen 1.2);
-    # see notes §D. (Sampling controls disabled below.)
-    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
-    #     sample_next_token() to re-enable stochastic sampling ---
-    # parser.add_argument("--temperature", type=float, default=0.0, help=">0 enables sampling.")
-    # parser.add_argument("--top-k", type=int, default=40, help="Top-k filter (sampling only).")
-    # parser.add_argument("--top-p", type=float, default=0.9, help="Top-p nucleus filter (sampling only).")
-    parser.add_argument("--repetition-penalty", type=float, default=1.2,
-                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
-    parser.add_argument("--rep-window", type=int, default=256,
-                        help="Repetition penalty look-back window in tokens. Default 256.")
-    parser.add_argument("--rep-decay", type=float, default=0.97,
-                        help="Recency decay for the repetition penalty (per-token age). Default 0.97.")
-    # parser.add_argument("--seed", type=int, default=None, help="RNG seed (sampling only).")
+    # Decode is deterministic with the on-FPGA penalty only (no host penalty / sampling).
     parser.add_argument("--greedy-until", type=int, default=512,
-                        help="Hybrid decode (temp 0): pure greedy for the first N decoded tokens "
-                             "(correct math/reasoning), then the repetition penalty breaks long-context "
-                             "loops. 0 = penalty from the start. Default 512.")
+                        help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
+                             "then the on-FPGA repetition penalty breaks long-context loops. "
+                             "0 = penalty from the start. Default 512.")
+    # On-FPGA repetition penalty (DEFAULT): the penalty is folded into the LM-head matmul bias so the
+    # HW argmax returns the penalized token directly — no logit readback. Loads the _fpgapenalty bin.
+    parser.add_argument("--fpga-penalty", action=argparse.BooleanOptionalAction, default=True,
+                        help="Apply the repetition penalty on-FPGA via the LM-head matmul bias "
+                             "(argmax of logits+bias on chip, no logit readback). DEFAULT. "
+                             "--no-fpga-penalty = plain greedy (writeback-on bin, no penalty), for "
+                             "the A/B baseline and the compare/calibration tool.")
+    parser.add_argument("--pen-alpha", type=float, default=1.0,
+                        help="On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.")
+    parser.add_argument("--pen-cap", type=float, default=20.0,
+                        help="On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.")
+    parser.add_argument("--rep-window", type=int, default=256,
+                        help="On-FPGA penalty: count tokens over the last N. Default 256.")
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     cfg = _load_config(script_dir)
 
     # Hard-fail BEFORE touching the FPGA if any artifact is missing.
-    _verify_artifacts(script_dir, cfg)
+    _verify_artifacts(script_dir, cfg, fpga_penalty=bool(args.fpga_penalty))
 
     set_dma_device(args.dev)
     user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
@@ -588,19 +588,20 @@ def main():
         prefill_seq = tuple(cfg["default_prefill_tokens"])
 
     ue.prefill_seq = prefill_seq
-    # Sampling controls (temperature/top_k/top_p/seed) disabled — decode is deterministic.
-    ue.repetition_penalty = float(args.repetition_penalty)
-    ue.rep_window = int(args.rep_window)
-    ue.rep_decay = float(args.rep_decay)
+    # Decode config — deterministic, on-FPGA penalty only (no host penalty / sampling).
     ue.greedy_until = int(args.greedy_until)
+    ue.fpga_penalty = bool(args.fpga_penalty)   # selects the _fpgapenalty bin + matmul-bias path
+    ue.pen_alpha = float(args.pen_alpha)
+    ue.pen_cap = float(args.pen_cap)
+    ue.rep_window = int(args.rep_window)
     ue._generated_tokens = list(prefill_seq)
-    _penalty_used = ue.repetition_penalty != 1.0
-    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
-             if _penalty_used else "no penalty")
-    _original_print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
-    if _penalty_used:
+    if ue.fpga_penalty:
+        _original_print(f"Decode: ON-FPGA penalty (bias in LM-head matmul) — pure greedy for "
+                        f"{ue.greedy_until} tokens, then alpha={ue.pen_alpha} cap={ue.pen_cap} window={ue.rep_window}")
         _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
-        _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
+        _original_print(f"  penalty exempts {_n} structural/special tokens")
+    else:
+        _original_print("Decode: plain greedy (deterministic) — no penalty (writeback-on bin)")
 
     ue.run_llama()
     ue.clear_dram()

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -535,7 +535,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
-        # Per-vocab additive repetition-penalty bias (on-FPGA penalty, --fpga-penalty). The LM-head
+        # Per-vocab additive repetition-penalty bias (on-FPGA penalty, the default). The LM-head
         # matmul reads this as its C bias (bias_mode="broadcast_N") so the on-chip argmax already
         # returns the penalized token id — no logit readback. Host maintains it with +/-alpha writes
         # (see notes_repetition_penalty_fpga_bias.md); all-zero = no penalty.
@@ -561,10 +561,26 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         global _SILENT_MODE
         _SILENT_MODE = True
         num_bucket = (self.PREFILL_CONTEXT_SIZE * self.group_size + 63) // 64
-        gpr_tmp = self.alloc_isa_reg()
-        self.generate_instruction_reg_mul_imm(gpr_tmp, self.gpr_seq_len, self.vector_length * self.bytes_per_element)
         total_flops = 0
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+
+        # Layer-invariant constants (hoisted so the flash subroutine can use them)
+        ahd         = self.actual_head_dim   # 64
+        nkvh        = self.num_kv_heads      # 8
+        qpkv        = self.group_size        # 4
+        bpe         = self.bytes_per_element
+        hd          = self.head_dim          # 512
+        total_q_dim = hd * qpkv             # 2048
+        half_ahd    = ahd // 2              # 32
+        rope_row    = hd * 2 * bpe          # bytes per rope table row
+
+        # flash_attention_core compiled once as a subroutine after the layer loop.
+        # Each call site sets gpr_ret_id to its return word address then jumps to the
+        # subroutine; flash_attention returns via JUMP_REG_ABS(gpr_ret_id).
+        program_dram_base = self.get_program_dram_addr()
+        gpr_ret_id = self.alloc_isa_reg()
+
+        call_site_jump_capture_indices: list[int] = []
         for layer_idx in range(layer_size):
             layer_off = layer_idx * LAYER_WEIGHT_SIZE
             if layer_idx != 0:
@@ -610,14 +626,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             # is scattered from non-contiguous positions in K_DRAM to contiguous 64-dim
             # slots in the KV cache and FLASH_K_DRAM.
             ROPE_WEIGHT_ADDR = self.DRAM_ADDR_ROPE_GLOBAL if layer_idx in self._rope_global_layers else self.DRAM_ADDR_ROPE_LOCAL
-            ahd      = self.actual_head_dim   # 64
-            nkvh     = self.num_kv_heads      # 8
-            qpkv     = self.group_size        # 4
-            bpe      = self.bytes_per_element
-            hd       = self.head_dim          # 512
-            total_q_dim = hd * qpkv           # 2048 (o_proj input width)
-            half_ahd = ahd // 2               # 32  (lo or hi slice width)
-            rope_row = hd * 2 * bpe           # 2048 bytes per rope table row (N=512)
 
             # Phase 1: K rope in-place on LAYER0_K_DRAM (N=512, [lo|hi] layout).
             # K layout = [seq_len, hd]. PBI: outer M loop driven by gpr_seq_len.
@@ -731,24 +739,15 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         template_seq_len=seq_len,
                     )
 
-                # Flash attention for this KV head (head_dim=64) — PBI bucket dispatcher;
-                # gpr_bucket_idx is primed at program start (ADD_SET above) so the dispatcher
-                # routes to the correct bucket body for the actual runtime seq_len.
-                flash_result = self.flash_attention_core(
-                    head_dim=ahd,
-                    seq_len=aligned_seq_len,
-                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
-                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
-                    gpr_bucket_idx=self.gpr_bucket_idx,
-                    num_buckets=num_bucket,
-                )
-                total_flops += flash_result[num_bucket - 1]
+                # Call flash attention subroutine (compiled after the layer loop).
+                # Pad so capture_count is even; return address = capture_count + 2
+                # (ADD_SET + JUMP_ABS), which is then also even = 512-bit aligned.
+                self.pad_capture_to_64b_boundary()
+                return_word_addr = ue_35bit_addr_shifter(
+                    program_dram_base + (self.capture_count + 2) * INSTRUCTION_SIZE_BYTES)
+                self.generate_instruction_add_set(gpr_ret_id, return_word_addr)
+                call_site_jump_capture_indices.append(self.capture_count)
+                self.generate_instruction_jump_abs(target_instruction_word_addr=0)
 
                 # Assemble output into LAYER0_FLASH_OUTPUT_DRAM
                 # Standard GQA layout per token: [kv0_q0(64), kv0_q1..q3, kv1_q0..q3, ...]
@@ -823,8 +822,35 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 mode=UE_MODE.ELTWISE_ADD,
                 gpr_M_reg=self.gpr_seq_len,
             )
-        self.release_isa_reg()  # gpr_tmp
+        # HALT ends the normal execution path; the flash_attention subroutine follows and
+        # is only reachable via the JUMP_ABS call sites within the layer loop above.
         self.generate_instruction_halt()
+
+        # Compile flash_attention subroutine after the HALT; bucket bodies return via
+        # JUMP_REG_ABS(gpr_ret_id), which each call site pre-loaded with its return address.
+        flash_sub_start_inst_dram_addr, flash_flops = self.flash_attention_core(
+            head_dim=ahd,
+            seq_len=aligned_seq_len,
+            Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+            K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+            V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
+            OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+            ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
+            gpr_bucket_idx=self.gpr_bucket_idx,
+            num_buckets=num_bucket,
+            gpr_ret_id=gpr_ret_id,
+        )
+        total_flops += flash_flops[num_bucket - 1] * layer_size * nkvh
+
+        # Patch all call-site JUMP_ABS placeholders to point at the flash subroutine.
+        for jump_idx in call_site_jump_capture_indices:
+            self._patch_jump_immediate(
+                jump_idx, ue_35bit_addr_shifter(flash_sub_start_inst_dram_addr))
+
+        self.release_isa_reg()  # gpr_ret_id
         prefill_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"size_bytes": prefill_program_size, "flops": total_flops}
@@ -838,6 +864,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         count_at_start = self.capture_count
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
         total_flops = 0
+        program_dram_base = self.get_program_dram_addr()
+        gpr_ret_id = self.alloc_isa_reg()
+        call_site_jump_capture_indices: list[int] = []
 
         global _SILENT_MODE
         _SILENT_MODE = True
@@ -916,6 +945,17 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(0x10080, 0, half_ahd)
                     self.overwrite_instruction_with_general_register(self.TMP_REG)
 
+                    # Copy valid K history → LAYER0_FLASH_K_DRAM; loop count = gpr_bucket_idx
+                    # so only current_seq_len tokens are copied, not the full MAX_CONTEXT_SIZE.
+                    self._emit_pbi_scatter_per_token(
+                        read_base=k_cache_base,
+                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_K_DRAM, UE_VECTOR_SIZE * ahd * bpe)],
+                        sram_byte_addr=0,
+                        element_count=UE_VECTOR_SIZE * ahd,
+                        gpr_seq_len=self.gpr_bucket_idx,
+                    )
+
                     # Scatter V_h (64-dim, standard layout) → V cache at decode position
                     # v_proj output at LAYER0_FLASH_V_DRAM: [V_KV0(64)..V_KV7(64)] = 512-dim
                     self.accelerator_memory_to_sram(
@@ -925,14 +965,25 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(0x20000, 0, ahd)
                     self.overwrite_instruction_with_general_register(self.TMP_REG)
 
-                    # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q → decoder_attn
+                    # Copy valid V history → LAYER0_FLASH_V_DRAM + k_size; same dynamic size.
+                    # Offset by k_size to avoid the v_proj output at [0..k_size-1].
+                    self._emit_pbi_scatter_per_token(
+                        read_base=v_cache_base,
+                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_V_DRAM + self.k_size, UE_VECTOR_SIZE * ahd * bpe)],
+                        sram_byte_addr=0,
+                        element_count=UE_VECTOR_SIZE * ahd,
+                        gpr_seq_len=self.gpr_bucket_idx,
+                    )
+
+                    # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q base (no kv_h offset)
                     # KV head kv_h → Q group g = kv_h//2; sub_idx = (kv_h%2)*qpkv + q
                     g_for_kv = kv_h // 2
                     local_kv = kv_h % 2
                     q_g_addr = self.LAYER0_Q_DRAM + g_for_kv * hd * bpe
                     for q in range(qpkv):
                         sub_idx = local_kv * qpkv + q
-                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe
+                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + q * ahd * bpe
                         self.accelerator_memory_to_sram(
                             q_g_addr + sub_idx * half_ahd * bpe, 0x30000, half_ahd)
                         self.accelerator_memory_to_sram(
@@ -940,21 +991,17 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                             0x30080, half_ahd)
                         self.sram_to_accelerator_memory(0x30000, flash_q_addr, half_ahd)
                         self.sram_to_accelerator_memory(0x30080, flash_q_addr + half_ahd * bpe, half_ahd)
-                    attn_flops = self.decoder_group_attention_core(
-                        group_size=qpkv,
-                        head_dim=ahd,
-                        seq_len=self.MAX_CONTEXT_SIZE,
-                        gpr_bucket_idx=self.gpr_bucket_idx,
-                        num_buckets=(self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE,
-                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM + kv_h * qpkv * ahd * bpe,
-                        K_DRAM_ADDR=k_cache_base,
-                        V_DRAM_ADDR=v_cache_base,
-                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe,
-                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    )
-                    total_flops += attn_flops[-1]
+                    self.pad_capture_to_64b_boundary()
+                    return_word_addr = ue_35bit_addr_shifter(
+                        program_dram_base + (self.capture_count + 2) * INSTRUCTION_SIZE_BYTES)
+                    self.generate_instruction_add_set(gpr_ret_id, return_word_addr)
+                    call_site_jump_capture_indices.append(self.capture_count)
+                    self.generate_instruction_jump_abs(target_instruction_word_addr=0)
+                    # Copy per-head output to its slot in FLASH_OUTPUT_DRAM.
+                    self.accelerator_memory_to_sram(
+                        self.LAYER0_FLASH_OUT_HEAD_DRAM, 0x40000, qpkv * ahd)
+                    self.sram_to_accelerator_memory(
+                        0x40000, self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe, qpkv * ahd)
                 total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
@@ -1006,7 +1053,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
                     write_back_disable=True)
             else:
-                # Plain bin (--no-fpga-penalty): no bias, full vocab-logits row written to DRAM
+                # Plain bin (--pure-greedy): no bias, full vocab-logits row written to DRAM
                 # (writeback ON). Used for the greedy A/B baseline and as the logit source for the
                 # compare/calibration tool (compare/compare_llama3.2_1b_penalty.py), which reads
                 # LOGITS_DRAM and applies the penalty on host. No host penalty runs in production.
@@ -1016,6 +1063,35 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     write_back_disable=False)
 
         self.generate_instruction_halt()
+        self.pad_capture_to_64b_boundary()
+
+        # Compile decoder_group_attention_core once as a subroutine after HALT.
+        num_buckets = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
+        ahd = self.actual_head_dim
+        bpe = self.bytes_per_element
+        qpkv = self.group_size
+        dec_sub_start_addr, dec_attn_flops = self.decoder_group_attention_core(
+            group_size=qpkv,
+            head_dim=ahd,
+            seq_len=self.MAX_CONTEXT_SIZE,
+            gpr_bucket_idx=self.gpr_bucket_idx,
+            num_buckets=num_buckets,
+            Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+            K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+            V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM + self.k_size,
+            OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+            gpr_ret_id=gpr_ret_id,
+        )
+        total_flops += dec_attn_flops[-1] * layer_size * self.num_kv_heads
+
+        for jump_idx in call_site_jump_capture_indices:
+            self._patch_jump_immediate(
+                jump_idx, ue_35bit_addr_shifter(dec_sub_start_addr))
+
+        self.release_isa_reg()  # gpr_ret_id
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"program_size_bytes": decoder_program_size, "total_flops": total_flops}
@@ -1131,7 +1207,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         return t
 
     def _write_penalty_bias(self, prev_tokens) -> None:
-        """On-FPGA repetition penalty (--fpga-penalty): build the per-vocab additive bias from the
+        """On-FPGA repetition penalty (the default): build the per-vocab additive bias from the
         windowed token frequency and DMA it to PENALTY_BIAS_DRAM (the LM-head matmul's C term,
         bias_mode="broadcast_N"). bias[t] = clamp(−alpha·count[t], min=−cap); structural tokens stay
         0. The HW argmax of (logits + bias) then returns the penalized token id — no logit readback.
@@ -1161,7 +1237,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         prefill or decoder program at runtime.
         """
         paths_cfg = self._cfg.get("paths", {})
-        # In --fpga-penalty mode use the penalty-specific bin/meta compile_llama produced.
+        # With the on-FPGA penalty (default) use the penalty-specific bin/meta compile_llama produced.
         meta_path = getattr(self, "_instruction_meta_path", None) or \
             os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/llama_instruction.json"))
         with open(meta_path, "r") as f:
@@ -1239,7 +1315,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         # On-FPGA penalty: the LM-head matmul adds PENALTY_BIAS_DRAM (its C bias) so the HW argmax
         # already returns the penalized token. Zero the buffer first → pure greedy until the gate,
         # then refresh the full bias each step past the gate (_write_penalty_bias). Plain mode
-        # (--no-fpga-penalty, writeback-on bin for compare/baseline) leaves the buffer untouched.
+        # (--pure-greedy, writeback-on bin for compare/baseline) leaves the buffer untouched.
         _fpga_penalty = bool(getattr(self, "fpga_penalty", False))
         if _fpga_penalty:
             self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM,
@@ -1343,29 +1419,28 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Decode is deterministic: pure greedy for the first `greedy_until` (512) decoded tokens —
-    # correct math/reasoning, which lands early — then the on-FPGA repetition penalty turns on to
-    # break long-context loops. The penalty runs entirely on the FPGA (LM-head matmul bias); there
-    # is no host-side penalty or sampling.
-    parser.add_argument('--greedy-until', type=int, default=512,
+    # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
+    # matmul bias so the HW argmax returns the penalized token directly — no 256 KB logit readback,
+    # fully deterministic (separate bias-on / writeback-off bin). --pure-greedy disables it entirely.
+    parser.add_argument('--pure-greedy', action='store_true',
+                        help='Disable the on-FPGA repetition penalty entirely — plain greedy decode '
+                             '(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy '
+                             'only for the A/B baseline and the compare/calibration tool.')
+    # On-FPGA repetition penalty parameters (active unless --pure-greedy). The penalty is folded into
+    # the LM-head matmul bias (on-chip argmax of logits+bias, no logit readback).
+    # See notes_repetition_penalty_fpga_bias.md.
+    pen_group = parser.add_argument_group('on-FPGA repetition penalty (active unless --pure-greedy)')
+    pen_group.add_argument('--greedy-until', type=int, default=512,
                         help='Pure greedy for the first N decoded tokens (correct math/reasoning, '
-                             'which lands early), then the on-FPGA repetition penalty turns on to '
-                             'break long-context loops. 0 = penalty from the start. Default 512.')
-    # On-FPGA repetition penalty (DEFAULT): fold the penalty into the LM-head matmul bias so the HW
-    # argmax returns the penalized token directly — no 256 KB logit readback, fully deterministic.
-    # Separate bin (bias on / writeback off). See notes_repetition_penalty_fpga_bias.md.
-    parser.add_argument('--fpga-penalty', action=argparse.BooleanOptionalAction, default=True,
-                        help='Apply the repetition penalty on-FPGA via the LM-head matmul bias '
-                             '(argmax of logits+bias on chip, no logit readback). DEFAULT. '
-                             '--no-fpga-penalty = plain greedy (writeback-on bin, no penalty) for the '
-                             'A/B baseline and the compare/calibration tool.')
-    parser.add_argument('--pen-alpha', type=float, default=1.0,
-                        help='On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.')
-    parser.add_argument('--pen-cap', type=float, default=20.0,
-                        help='On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.')
-    parser.add_argument('--rep-window', type=int, default=256,
-                        help='On-FPGA penalty: count tokens over the last N (never penalizes '
-                             'punctuation/whitespace/special tokens). Default 256.')
+                             'which lands early), then the penalty turns on to break long-context '
+                             'loops. 0 = penalty from the start. Default 512.')
+    pen_group.add_argument('--pen-alpha', type=float, default=1.0,
+                        help='bias[t] = -alpha*count[t] (logit units). Default 1.0.')
+    pen_group.add_argument('--pen-cap', type=float, default=20.0,
+                        help='max |bias| per token (floor on -alpha*count). Default 20.')
+    pen_group.add_argument('--rep-window', type=int, default=256,
+                        help='count tokens over the last N (never penalizes punctuation/whitespace/'
+                             'special tokens). Default 256.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1408,7 +1483,7 @@ def main():
     # Decode config — deterministic, on-FPGA penalty only. Must be set BEFORE compile_llama() since
     # fpga_penalty changes the compiled LM-head matmul (bias on / writeback off).
     ue.greedy_until = int(args.greedy_until)
-    ue.fpga_penalty = bool(args.fpga_penalty)
+    ue.fpga_penalty = not bool(args.pure_greedy)
     ue.pen_alpha = float(args.pen_alpha)
     ue.pen_cap = float(args.pen_cap)
     ue.rep_window = int(args.rep_window)

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -535,6 +535,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
+        # Per-vocab additive repetition-penalty bias (on-FPGA penalty, --fpga-penalty). The LM-head
+        # matmul reads this as its C bias (bias_mode="broadcast_N") so the on-chip argmax already
+        # returns the penalized token id — no logit readback. Host maintains it with +/-alpha writes
+        # (see notes_repetition_penalty_fpga_bias.md); all-zero = no penalty.
+        self.PENALTY_BIAS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
 
         print(f"    Allocate tensor dram end at DRAM address: 0x{self.get_tensor_dram_addr():X}, usage: {self.get_tensor_dram_usage()} bytes")
 
@@ -556,26 +561,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         global _SILENT_MODE
         _SILENT_MODE = True
         num_bucket = (self.PREFILL_CONTEXT_SIZE * self.group_size + 63) // 64
+        gpr_tmp = self.alloc_isa_reg()
+        self.generate_instruction_reg_mul_imm(gpr_tmp, self.gpr_seq_len, self.vector_length * self.bytes_per_element)
         total_flops = 0
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
-
-        # Layer-invariant constants (hoisted so the flash subroutine can use them)
-        ahd         = self.actual_head_dim   # 64
-        nkvh        = self.num_kv_heads      # 8
-        qpkv        = self.group_size        # 4
-        bpe         = self.bytes_per_element
-        hd          = self.head_dim          # 512
-        total_q_dim = hd * qpkv             # 2048
-        half_ahd    = ahd // 2              # 32
-        rope_row    = hd * 2 * bpe          # bytes per rope table row
-
-        # flash_attention_core compiled once as a subroutine after the layer loop.
-        # Each call site sets gpr_ret_id to its return word address then jumps to the
-        # subroutine; flash_attention returns via JUMP_REG_ABS(gpr_ret_id).
-        program_dram_base = self.get_program_dram_addr()
-        gpr_ret_id = self.alloc_isa_reg()
-
-        call_site_jump_capture_indices: list[int] = []
         for layer_idx in range(layer_size):
             layer_off = layer_idx * LAYER_WEIGHT_SIZE
             if layer_idx != 0:
@@ -621,6 +610,14 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             # is scattered from non-contiguous positions in K_DRAM to contiguous 64-dim
             # slots in the KV cache and FLASH_K_DRAM.
             ROPE_WEIGHT_ADDR = self.DRAM_ADDR_ROPE_GLOBAL if layer_idx in self._rope_global_layers else self.DRAM_ADDR_ROPE_LOCAL
+            ahd      = self.actual_head_dim   # 64
+            nkvh     = self.num_kv_heads      # 8
+            qpkv     = self.group_size        # 4
+            bpe      = self.bytes_per_element
+            hd       = self.head_dim          # 512
+            total_q_dim = hd * qpkv           # 2048 (o_proj input width)
+            half_ahd = ahd // 2               # 32  (lo or hi slice width)
+            rope_row = hd * 2 * bpe           # 2048 bytes per rope table row (N=512)
 
             # Phase 1: K rope in-place on LAYER0_K_DRAM (N=512, [lo|hi] layout).
             # K layout = [seq_len, hd]. PBI: outer M loop driven by gpr_seq_len.
@@ -734,15 +731,24 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         template_seq_len=seq_len,
                     )
 
-                # Call flash attention subroutine (compiled after the layer loop).
-                # Pad so capture_count is even; return address = capture_count + 2
-                # (ADD_SET + JUMP_ABS), which is then also even = 512-bit aligned.
-                self.pad_capture_to_64b_boundary()
-                return_word_addr = ue_35bit_addr_shifter(
-                    program_dram_base + (self.capture_count + 2) * INSTRUCTION_SIZE_BYTES)
-                self.generate_instruction_add_set(gpr_ret_id, return_word_addr)
-                call_site_jump_capture_indices.append(self.capture_count)
-                self.generate_instruction_jump_abs(target_instruction_word_addr=0)
+                # Flash attention for this KV head (head_dim=64) — PBI bucket dispatcher;
+                # gpr_bucket_idx is primed at program start (ADD_SET above) so the dispatcher
+                # routes to the correct bucket body for the actual runtime seq_len.
+                flash_result = self.flash_attention_core(
+                    head_dim=ahd,
+                    seq_len=aligned_seq_len,
+                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
+                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                    ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
+                    gpr_bucket_idx=self.gpr_bucket_idx,
+                    num_buckets=num_bucket,
+                )
+                total_flops += flash_result[num_bucket - 1]
 
                 # Assemble output into LAYER0_FLASH_OUTPUT_DRAM
                 # Standard GQA layout per token: [kv0_q0(64), kv0_q1..q3, kv1_q0..q3, ...]
@@ -817,35 +823,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 mode=UE_MODE.ELTWISE_ADD,
                 gpr_M_reg=self.gpr_seq_len,
             )
-        # HALT ends the normal execution path; the flash_attention subroutine follows and
-        # is only reachable via the JUMP_ABS call sites within the layer loop above.
+        self.release_isa_reg()  # gpr_tmp
         self.generate_instruction_halt()
-
-        # Compile flash_attention subroutine after the HALT; bucket bodies return via
-        # JUMP_REG_ABS(gpr_ret_id), which each call site pre-loaded with its return address.
-        flash_sub_start_inst_dram_addr, flash_flops = self.flash_attention_core(
-            head_dim=ahd,
-            seq_len=aligned_seq_len,
-            Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-            K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-            V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-            OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
-            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-            ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
-            gpr_bucket_idx=self.gpr_bucket_idx,
-            num_buckets=num_bucket,
-            gpr_ret_id=gpr_ret_id,
-        )
-        total_flops += flash_flops[num_bucket - 1] * layer_size * nkvh
-
-        # Patch all call-site JUMP_ABS placeholders to point at the flash subroutine.
-        for jump_idx in call_site_jump_capture_indices:
-            self._patch_jump_immediate(
-                jump_idx, ue_35bit_addr_shifter(flash_sub_start_inst_dram_addr))
-
-        self.release_isa_reg()  # gpr_ret_id
         prefill_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"size_bytes": prefill_program_size, "flops": total_flops}
@@ -859,9 +838,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         count_at_start = self.capture_count
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
         total_flops = 0
-        program_dram_base = self.get_program_dram_addr()
-        gpr_ret_id = self.alloc_isa_reg()
-        call_site_jump_capture_indices: list[int] = []
 
         global _SILENT_MODE
         _SILENT_MODE = True
@@ -940,17 +916,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(0x10080, 0, half_ahd)
                     self.overwrite_instruction_with_general_register(self.TMP_REG)
 
-                    # Copy valid K history → LAYER0_FLASH_K_DRAM; loop count = gpr_bucket_idx
-                    # so only current_seq_len tokens are copied, not the full MAX_CONTEXT_SIZE.
-                    self._emit_pbi_scatter_per_token(
-                        read_base=k_cache_base,
-                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
-                        write_specs=[(self.LAYER0_FLASH_K_DRAM, UE_VECTOR_SIZE * ahd * bpe)],
-                        sram_byte_addr=0,
-                        element_count=UE_VECTOR_SIZE * ahd,
-                        gpr_seq_len=self.gpr_bucket_idx,
-                    )
-
                     # Scatter V_h (64-dim, standard layout) → V cache at decode position
                     # v_proj output at LAYER0_FLASH_V_DRAM: [V_KV0(64)..V_KV7(64)] = 512-dim
                     self.accelerator_memory_to_sram(
@@ -960,25 +925,14 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(0x20000, 0, ahd)
                     self.overwrite_instruction_with_general_register(self.TMP_REG)
 
-                    # Copy valid V history → LAYER0_FLASH_V_DRAM + k_size; same dynamic size.
-                    # Offset by k_size to avoid the v_proj output at [0..k_size-1].
-                    self._emit_pbi_scatter_per_token(
-                        read_base=v_cache_base,
-                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
-                        write_specs=[(self.LAYER0_FLASH_V_DRAM + self.k_size, UE_VECTOR_SIZE * ahd * bpe)],
-                        sram_byte_addr=0,
-                        element_count=UE_VECTOR_SIZE * ahd,
-                        gpr_seq_len=self.gpr_bucket_idx,
-                    )
-
-                    # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q base (no kv_h offset)
+                    # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q → decoder_attn
                     # KV head kv_h → Q group g = kv_h//2; sub_idx = (kv_h%2)*qpkv + q
                     g_for_kv = kv_h // 2
                     local_kv = kv_h % 2
                     q_g_addr = self.LAYER0_Q_DRAM + g_for_kv * hd * bpe
                     for q in range(qpkv):
                         sub_idx = local_kv * qpkv + q
-                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + q * ahd * bpe
+                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe
                         self.accelerator_memory_to_sram(
                             q_g_addr + sub_idx * half_ahd * bpe, 0x30000, half_ahd)
                         self.accelerator_memory_to_sram(
@@ -986,17 +940,21 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                             0x30080, half_ahd)
                         self.sram_to_accelerator_memory(0x30000, flash_q_addr, half_ahd)
                         self.sram_to_accelerator_memory(0x30080, flash_q_addr + half_ahd * bpe, half_ahd)
-                    self.pad_capture_to_64b_boundary()
-                    return_word_addr = ue_35bit_addr_shifter(
-                        program_dram_base + (self.capture_count + 2) * INSTRUCTION_SIZE_BYTES)
-                    self.generate_instruction_add_set(gpr_ret_id, return_word_addr)
-                    call_site_jump_capture_indices.append(self.capture_count)
-                    self.generate_instruction_jump_abs(target_instruction_word_addr=0)
-                    # Copy per-head output to its slot in FLASH_OUTPUT_DRAM.
-                    self.accelerator_memory_to_sram(
-                        self.LAYER0_FLASH_OUT_HEAD_DRAM, 0x40000, qpkv * ahd)
-                    self.sram_to_accelerator_memory(
-                        0x40000, self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe, qpkv * ahd)
+                    attn_flops = self.decoder_group_attention_core(
+                        group_size=qpkv,
+                        head_dim=ahd,
+                        seq_len=self.MAX_CONTEXT_SIZE,
+                        gpr_bucket_idx=self.gpr_bucket_idx,
+                        num_buckets=(self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE,
+                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM + kv_h * qpkv * ahd * bpe,
+                        K_DRAM_ADDR=k_cache_base,
+                        V_DRAM_ADDR=v_cache_base,
+                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe,
+                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                    )
+                    total_flops += attn_flops[-1]
                 total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
@@ -1036,47 +994,28 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            # LM head: write the full vocab-logits row to DRAM only when the host reads it —
-            # i.e. when the repetition penalty is on (penalized greedy reads + argmaxes the
-            # penalty-adjusted logits). Pure unpenalized greedy (rep_pen 1.0) uses the HW argmax
-            # register, so writeback is disabled. This compile-time gate MUST match the decode
-            # readback condition; else the host reads a never-written LOGITS_DRAM → garbage ("!!!").
-            _need_logit_writeback = float(getattr(self, "repetition_penalty", 1.0)) != 1.0
-            total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
-                A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
-                write_back_disable=not _need_logit_writeback)
+            if bool(getattr(self, "fpga_penalty", False)):
+                # On-FPGA repetition penalty: feed the per-vocab penalty as the matmul C bias
+                # (bias_mode="broadcast_N" → bias[t] added to logit[t]) so the on-chip argmax
+                # returns the PENALIZED token id directly. No logit writeback (the host reads the
+                # argmax register, not the row). Host maintains PENALTY_BIAS_DRAM with +/-alpha
+                # writes. See notes_repetition_penalty_fpga_bias.md.
+                total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+                    A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
+                    C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N",
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
+                    write_back_disable=True)
+            else:
+                # Plain bin (--no-fpga-penalty): no bias, full vocab-logits row written to DRAM
+                # (writeback ON). Used for the greedy A/B baseline and as the logit source for the
+                # compare/calibration tool (compare/compare_llama3.2_1b_penalty.py), which reads
+                # LOGITS_DRAM and applies the penalty on host. No host penalty runs in production.
+                total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+                    A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
+                    write_back_disable=False)
 
         self.generate_instruction_halt()
-        self.pad_capture_to_64b_boundary()
-
-        # Compile decoder_group_attention_core once as a subroutine after HALT.
-        num_buckets = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
-        ahd = self.actual_head_dim
-        bpe = self.bytes_per_element
-        qpkv = self.group_size
-        dec_sub_start_addr, dec_attn_flops = self.decoder_group_attention_core(
-            group_size=qpkv,
-            head_dim=ahd,
-            seq_len=self.MAX_CONTEXT_SIZE,
-            gpr_bucket_idx=self.gpr_bucket_idx,
-            num_buckets=num_buckets,
-            Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-            K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-            V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM + self.k_size,
-            OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
-            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-            gpr_ret_id=gpr_ret_id,
-        )
-        total_flops += dec_attn_flops[-1] * layer_size * self.num_kv_heads
-
-        for jump_idx in call_site_jump_capture_indices:
-            self._patch_jump_immediate(
-                jump_idx, ue_35bit_addr_shifter(dec_sub_start_addr))
-
-        self.release_isa_reg()  # gpr_ret_id
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"program_size_bytes": decoder_program_size, "total_flops": total_flops}
@@ -1099,6 +1038,13 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_1b_bin/llama_instruction.bin"))
         instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/llama_instruction.json"))
+        if bool(getattr(self, "fpga_penalty", False)):
+            # On-FPGA penalty changes the LM-head matmul (bias on / writeback off) → a different
+            # bin. Use a separate cache file so it never clobbers the shipped host-path bin.
+            instruction_bin_path = instruction_bin_path.replace(".bin", "_fpgapenalty.bin")
+            instruction_meta_path = instruction_meta_path.replace(".json", "_fpgapenalty.json")
+            self._instruction_bin_path = instruction_bin_path
+            self._instruction_meta_path = instruction_meta_path
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             print(f"Reusing existing instruction image at {instruction_bin_path}")
             print(f"  delete {instruction_bin_path} to force recompile.")
@@ -1184,65 +1130,29 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             self._struct_ids_tensor_cache = t
         return t
 
-    def sample_next_token(self, prev_tokens: list[int]) -> int:
-        """Read full logits from LOGITS_DRAM and sample the next token using the
-        engine's configured ``temperature`` / ``top_k`` / ``top_p`` /
-        ``repetition_penalty`` (mechanism mirrors qwen3_1.7b). Greedy fast path
-        (HW argmax register) is used when ``temperature <= 0`` — the caller
-        dispatches, this method assumes sampling is enabled.
+    def _write_penalty_bias(self, prev_tokens) -> None:
+        """On-FPGA repetition penalty (--fpga-penalty): build the per-vocab additive bias from the
+        windowed token frequency and DMA it to PENALTY_BIAS_DRAM (the LM-head matmul's C term,
+        bias_mode="broadcast_N"). bias[t] = clamp(−alpha·count[t], min=−cap); structural tokens stay
+        0. The HW argmax of (logits + bias) then returns the penalized token id — no logit readback.
 
-        prev_tokens: token ids already in the sequence (prompt + decoded), used
-                     by the repetition penalty to down-weight repeats.
-
-        Requires the decoder bin to have been compiled with LM-head writeback
-        ENABLED (i.e. temperature > 0 at compile time), so LOGITS_DRAM holds the
-        full vocab row rather than only the HW argmax index.
+        A single full-buffer DMA per step (one device open/write). Exactly matches the SW golden
+        reference compare/compare_llama3.2_1b_penalty.py. Incremental ±alpha chunk writes were tried and measured both
+        SLOWER (2 per-step DMAs each pay os.open/os.close, which dominates the tiny transfer) and
+        lower quality (count-from-gate) — so the full rewrite is the production path.
         """
         vocab = self.EMBEDDING_ELEMENTS
-        bpe = self.bytes_per_element
-        # DMA logits row to host. ~256 KB for the Llama vocab; negligible vs decode latency.
-        buf = torch.empty(vocab, dtype=torch.bfloat16)
-        self.dma_read(DMA_DEVICE_C2H, self.LOGITS_DRAM, buf, vocab * bpe)
-        logits = buf.float()
-        # Repetition penalty — recency-decayed frequency form (not flat binary).
-        # For each token in the last ``rep_window`` tokens, accumulate a weight
-        #   w[t] = sum over its occurrences of  rep_decay ** age   (age 0 = most recent),
-        # then scale logits by  rep_pen ** w[t]  (divide positives / multiply negatives).
-        # So a token used ONCE a while ago gets w≈small → factor≈1 (barely touched), while
-        # a token looped several times very recently gets a large w → strong suppression.
-        # This fixes two failure modes of the old flat penalty: (1) it no longer flips
-        # intentionally-repeated scaffolding (e.g. "Chapter" reused a paragraph later is
-        # only mildly nudged), and (2) it still crushes genuine short-range loops.
-        # Structural "glue" tokens (punctuation/whitespace/newline/special) stay exempt.
-        rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        if rep_pen != 1.0 and prev_tokens:
-            rep_window = int(getattr(self, "rep_window", 256))
-            rep_decay = float(getattr(self, "rep_decay", 0.97))
-            window = torch.tensor(prev_tokens[-rep_window:], dtype=torch.long)
-            L = window.numel()
-            ages = torch.arange(L - 1, -1, -1, dtype=torch.float32)   # oldest=L-1 ... newest=0
-            contrib = rep_decay ** ages
-            weight = torch.zeros(vocab, dtype=torch.float32)
-            weight.index_add_(0, window, contrib)                     # recency-weighted count per id
-            weight[self._structural_ids_tensor()] = 0.0               # never penalize glue/special
-            nz = weight > 0
-            if bool(nz.any()):
-                factor = rep_pen ** weight[nz]                        # >= 1, grows with recency*count
-                v = logits[nz]
-                logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        # Deterministic selection: argmax of the (penalty-adjusted) logits.
-        return int(logits.argmax().item())
-        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
-        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
-        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
-        # if top_k > 0 and top_k < vocab:
-        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
-        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
-        # if 0.0 < top_p < 1.0:
-        #     sl, si = torch.sort(logits, descending=True)
-        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
-        #     logits[si[~keep]] = float("-inf")
-        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
+        alpha = float(getattr(self, "pen_alpha", 1.0))
+        cap = float(getattr(self, "pen_cap", 20.0))
+        W = int(getattr(self, "rep_window", 256))
+        window = prev_tokens[-W:]  # last W tokens
+        count = torch.zeros(vocab, dtype=torch.float32)
+        if window:
+            win = torch.tensor(window, dtype=torch.long)
+            count.index_add_(0, win, torch.ones(win.numel(), dtype=torch.float32))  # frequency of each token id
+            count[self._structural_ids_tensor()] = 0.0  # never penalize punctuation/whitespace/specials
+        bias = (-alpha * count).clamp(min=-cap).to(torch.bfloat16).view(1, vocab)  # bias[t] = clamp(−α · count[t], min = −cap)
+        self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM, bias)  # push to buffer
 
     def run_llama(self) -> None:
         """Load the unified instruction image and run prefill + decoder loop.
@@ -1251,7 +1161,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         prefill or decoder program at runtime.
         """
         paths_cfg = self._cfg.get("paths", {})
-        meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/llama_instruction.json"))
+        # In --fpga-penalty mode use the penalty-specific bin/meta compile_llama produced.
+        meta_path = getattr(self, "_instruction_meta_path", None) or \
+            os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/llama_instruction.json"))
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -1315,16 +1227,23 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
         global _SILENT_MODE
 
-        # Sampling state: repetition penalty in sample_next_token() considers every
-        # token seen so far (prompt + decoded), seeded by main() with the prompt ids.
-        # Falls back to the full prompt when run without main() (e.g. run_from_bin).
+        # Penalty window state: the on-FPGA penalty counts every token seen so far (prompt +
+        # decoded), seeded by main() with the prompt ids. Falls back to the full prompt when run
+        # without main().
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
         # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
         # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
-        # repetition penalty turns on to break long-context loops.
-        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        # on-FPGA repetition penalty turns on to break long-context loops.
         _greedy_until = int(getattr(self, "greedy_until", 0))
+        # On-FPGA penalty: the LM-head matmul adds PENALTY_BIAS_DRAM (its C bias) so the HW argmax
+        # already returns the penalized token. Zero the buffer first → pure greedy until the gate,
+        # then refresh the full bias each step past the gate (_write_penalty_bias). Plain mode
+        # (--no-fpga-penalty, writeback-on bin for compare/baseline) leaves the buffer untouched.
+        _fpga_penalty = bool(getattr(self, "fpga_penalty", False))
+        if _fpga_penalty:
+            self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM,
+                                           torch.zeros(1, self.EMBEDDING_ELEMENTS, dtype=torch.bfloat16))
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1379,14 +1298,20 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             self.write_captured_instructions_to_dram(preamble_addr)
             self.clear_capture_buffer()
 
+            # On-FPGA penalty: refresh the per-vocab bias (this step's LM-head matmul C term) from the
+            # windowed token frequency once past the gate, so the HW argmax of (logits + bias) returns
+            # the penalized token directly — no logit readback. A single full-buffer DMA per step;
+            # incremental ±α chunk writes were measured SLOWER (per-DMA device open/close dominates)
+            # and lower quality — see notes_repetition_penalty_fpga_bias.md.
+            if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
+                self._write_penalty_bias(self._generated_tokens)
+
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
-            # repetition penalty (read logits, argmax of penalized logits).
-            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
-            if _penalty_active:
-                token_id = self.sample_next_token(self._generated_tokens)
-            else:
-                token_id = self.get_arg_max_index(rank=1)
+            # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
+            # already added the bias, so the register holds the penalized token; in plain mode it's
+            # pure greedy. Either way no logit readback. (The compare/calibration tool overrides
+            # get_arg_max_index to apply a host-side penalty against the writeback-on plain bin.)
+            token_id = self.get_arg_max_index(rank=1)
             self._generated_tokens.append(token_id)
             token_char = self.tokenizer.decode([token_id])
             _SILENT_MODE = False
@@ -1418,30 +1343,29 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Decode is a position-gated hybrid (deterministic): PURE greedy for the first
-    # `greedy_until` (512) decoded tokens — correct math/reasoning, which lands early — then
-    # repetition penalty 1.2 to break long-context loops. Rationale: notes_llama3.2_1b.md §D.
-    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
-    #     sample_next_token() to re-enable stochastic sampling ---
-    # parser.add_argument('--temperature', type=float, default=0.0, help='>0 enables sampling.')
-    # parser.add_argument('--top-k', type=int, default=40, help='Top-k filter (sampling only).')
-    # parser.add_argument('--top-p', type=float, default=0.9, help='Top-p nucleus filter (sampling only).')
-    parser.add_argument('--repetition-penalty', type=float, default=1.2,
-                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Active after greedy_until in hybrid mode. Default 1.2.')
-    parser.add_argument('--rep-window', type=int, default=256,
-                        help='Repetition penalty considers only the last N tokens (and never penalizes '
-                             'punctuation/whitespace/special tokens). Smaller = less structural starvation '
-                             'on long generations. Default 256.')
-    parser.add_argument('--rep-decay', type=float, default=0.97,
-                        help='Recency decay for the repetition penalty (per-token, age-based): a repeat '
-                             'k tokens ago contributes rep_decay**k to its penalty weight. 1.0 = pure '
-                             'frequency (no decay); lower = only very recent repeats matter. Default 0.97 '
-                             '(half-life ~23 tokens).')
-    # parser.add_argument('--seed', type=int, default=None, help='RNG seed (sampling only).')
+    # Decode is deterministic: pure greedy for the first `greedy_until` (512) decoded tokens —
+    # correct math/reasoning, which lands early — then the on-FPGA repetition penalty turns on to
+    # break long-context loops. The penalty runs entirely on the FPGA (LM-head matmul bias); there
+    # is no host-side penalty or sampling.
     parser.add_argument('--greedy-until', type=int, default=512,
-                        help='Hybrid decode (temp 0 only): pure greedy for the first N decoded tokens '
-                             '(correct math/reasoning, which lands early), then the repetition penalty '
-                             'turns on to break long-context loops. 0 = penalty from the start. Default 512.')
+                        help='Pure greedy for the first N decoded tokens (correct math/reasoning, '
+                             'which lands early), then the on-FPGA repetition penalty turns on to '
+                             'break long-context loops. 0 = penalty from the start. Default 512.')
+    # On-FPGA repetition penalty (DEFAULT): fold the penalty into the LM-head matmul bias so the HW
+    # argmax returns the penalized token directly — no 256 KB logit readback, fully deterministic.
+    # Separate bin (bias on / writeback off). See notes_repetition_penalty_fpga_bias.md.
+    parser.add_argument('--fpga-penalty', action=argparse.BooleanOptionalAction, default=True,
+                        help='Apply the repetition penalty on-FPGA via the LM-head matmul bias '
+                             '(argmax of logits+bias on chip, no logit readback). DEFAULT. '
+                             '--no-fpga-penalty = plain greedy (writeback-on bin, no penalty) for the '
+                             'A/B baseline and the compare/calibration tool.')
+    parser.add_argument('--pen-alpha', type=float, default=1.0,
+                        help='On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.')
+    parser.add_argument('--pen-cap', type=float, default=20.0,
+                        help='On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.')
+    parser.add_argument('--rep-window', type=int, default=256,
+                        help='On-FPGA penalty: count tokens over the last N (never penalizes '
+                             'punctuation/whitespace/special tokens). Default 256.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1481,24 +1405,23 @@ def main():
 
     ue.prefill_seq = prefill_seq
 
-    # Decode config (consumed by the decode loop / repetition penalty / LM-head writeback
-    # gate). Must be set BEFORE compile_llama() so the bin is compiled with logits writeback
-    # ON when a repetition penalty is used. Sampling controls (temperature/top_k/top_p/seed)
-    # are disabled — decode is deterministic.
-    ue.repetition_penalty = float(args.repetition_penalty)
-    ue.rep_window = int(args.rep_window)
-    ue.rep_decay = float(args.rep_decay)
+    # Decode config — deterministic, on-FPGA penalty only. Must be set BEFORE compile_llama() since
+    # fpga_penalty changes the compiled LM-head matmul (bias on / writeback off).
     ue.greedy_until = int(args.greedy_until)
-    ue._generated_tokens = list(prefill_seq)   # seed repetition penalty with the prompt
-    _penalty_used = ue.repetition_penalty != 1.0
-    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
-             if _penalty_used else "no penalty")
-    print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
-    # Precompute the structural-token exemption set upfront (one vocab scan) so it
-    # doesn't stall the first decode step where the penalty turns on.
-    if _penalty_used:
+    ue.fpga_penalty = bool(args.fpga_penalty)
+    ue.pen_alpha = float(args.pen_alpha)
+    ue.pen_cap = float(args.pen_cap)
+    ue.rep_window = int(args.rep_window)
+    ue._generated_tokens = list(prefill_seq)   # seed the penalty window with the prompt
+    if ue.fpga_penalty:
+        print(f"Decode: ON-FPGA penalty (bias in LM-head matmul) — pure greedy for {ue.greedy_until} "
+              f"tokens, then alpha={ue.pen_alpha} cap={ue.pen_cap} window={ue.rep_window}")
+        # Precompute the structural-exemption set upfront (one vocab scan) so it doesn't stall the
+        # first penalized decode step.
         _n = len(ue._structural_token_ids())
-        print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+        print(f"  penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+    else:
+        print("Decode: plain greedy (deterministic) — no penalty (writeback-on bin)")
 
     print("\n--- Compiling ---")
     timer = time.perf_counter()

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -24,7 +24,7 @@ See notes_repetition_penalty_fpga_bias.md.
 Usage:
   python llama3.2_3b_run_from_bin.py
   python llama3.2_3b_run_from_bin.py --prompt "your question"
-  python llama3.2_3b_run_from_bin.py --no-fpga-penalty --dev xdma0     # plain greedy (no penalty)
+  python llama3.2_3b_run_from_bin.py --pure-greedy --dev xdma0     # plain greedy (no penalty)
 """
 
 import json
@@ -344,12 +344,12 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
                                  paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
         if bool(getattr(self, "fpga_penalty", False)):
             # On-FPGA penalty uses a separate bin (LM-head matmul bias on / logit writeback off);
-            # its meta points to the _fpgapenalty bin. Compiled by llama3.2_3b_test.py --fpga-penalty.
+            # its meta points to the _fpgapenalty bin. Compiled by llama3.2_3b_test.py (default).
             meta_path = meta_path.replace(".json", "_fpgapenalty.json")
             if not os.path.exists(meta_path):
                 raise FileNotFoundError(
                     f"on-FPGA penalty bin meta not found: {meta_path}\n"
-                    f"  build it with:  python llama3.2_3b_test.py --fpga-penalty")
+                    f"  build it with:  python llama3.2_3b_test.py")
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -505,7 +505,7 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
     """Hard-fail before any FPGA touch if a required artifact is missing."""
     paths = cfg["paths"]
     inst_bin, inst_meta = paths["instruction_bin"], paths["instruction_meta"]
-    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py --fpga-penalty)
+    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py default)
         inst_bin = inst_bin.replace(".bin", "_fpgapenalty.bin")
         inst_meta = inst_meta.replace(".json", "_fpgapenalty.json")
     required = [
@@ -536,31 +536,32 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Decode is deterministic with the on-FPGA penalty only (no host penalty / sampling).
-    parser.add_argument("--greedy-until", type=int, default=512,
+    # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
+    # matmul bias so the HW argmax returns the penalized token directly (no logit readback); loads the
+    # _fpgapenalty bin. --pure-greedy disables it entirely (plain writeback-on bin).
+    parser.add_argument("--pure-greedy", action="store_true",
+                        help="Disable the on-FPGA repetition penalty entirely — plain greedy decode "
+                             "(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy "
+                             "only for the A/B baseline and the compare/calibration tool.")
+    # On-FPGA repetition penalty parameters (active unless --pure-greedy).
+    pen_group = parser.add_argument_group("on-FPGA repetition penalty (active unless --pure-greedy)")
+    pen_group.add_argument("--greedy-until", type=int, default=512,
                         help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
-                             "then the on-FPGA repetition penalty breaks long-context loops. "
+                             "then the penalty breaks long-context loops. "
                              "0 = penalty from the start. Default 512.")
-    # On-FPGA repetition penalty (DEFAULT): the penalty is folded into the LM-head matmul bias so the
-    # HW argmax returns the penalized token directly — no logit readback. Loads the _fpgapenalty bin.
-    parser.add_argument("--fpga-penalty", action=argparse.BooleanOptionalAction, default=True,
-                        help="Apply the repetition penalty on-FPGA via the LM-head matmul bias "
-                             "(argmax of logits+bias on chip, no logit readback). DEFAULT. "
-                             "--no-fpga-penalty = plain greedy (writeback-on bin, no penalty), for "
-                             "the A/B baseline and the compare/calibration tool.")
-    parser.add_argument("--pen-alpha", type=float, default=1.0,
-                        help="On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.")
-    parser.add_argument("--pen-cap", type=float, default=20.0,
-                        help="On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.")
-    parser.add_argument("--rep-window", type=int, default=256,
-                        help="On-FPGA penalty: count tokens over the last N. Default 256.")
+    pen_group.add_argument("--pen-alpha", type=float, default=1.0,
+                        help="bias[t] = -alpha*count[t] (logit units). Default 1.0.")
+    pen_group.add_argument("--pen-cap", type=float, default=20.0,
+                        help="max |bias| per token (floor on -alpha*count). Default 20.")
+    pen_group.add_argument("--rep-window", type=int, default=256,
+                        help="count tokens over the last N. Default 256.")
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     cfg = _load_config(script_dir)
 
     # Hard-fail BEFORE touching the FPGA if any artifact is missing.
-    _verify_artifacts(script_dir, cfg, fpga_penalty=bool(args.fpga_penalty))
+    _verify_artifacts(script_dir, cfg, fpga_penalty=not bool(args.pure_greedy))
 
     set_dma_device(args.dev)
     user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
@@ -590,7 +591,7 @@ def main():
     ue.prefill_seq = prefill_seq
     # Decode config — deterministic, on-FPGA penalty only (no host penalty / sampling).
     ue.greedy_until = int(args.greedy_until)
-    ue.fpga_penalty = bool(args.fpga_penalty)   # selects the _fpgapenalty bin + matmul-bias path
+    ue.fpga_penalty = not bool(args.pure_greedy)   # selects the _fpgapenalty bin + matmul-bias path
     ue.pen_alpha = float(args.pen_alpha)
     ue.pen_cap = float(args.pen_cap)
     ue.rep_window = int(args.rep_window)

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -15,18 +15,16 @@ running ``llama3.2_3b_test.py`` once on a build machine that has HF access):
   * ``Llama-3.2-3B-Instruct/``       tokenizer files only (tokenizer.json /
                                      tokenizer_config.json). Model weights NOT needed.
 
-Design mirrors test.py §A–§D (see notes_llama3.2_3b.md): full-4 GB DRAM layout,
-dynamic-PBI single bin (GPR-primed preamble + jump_abs), prefill_context_size=128,
-and sampling decode (recency-decayed / windowed / structural-exempt repetition
-penalty). DECODE DEFAULT is a position-gated HYBRID (temp 0): pure greedy for the first
-greedy_until (512) tokens — correct math/reasoning — then repetition penalty 1.2 breaks
-long-context loops; deterministic, see notes §D. The shipped bin is compiled with LM-head
-writeback enabled, so sampling (temp>0), the hybrid, and pure greedy (rep-pen 1.0) all work.
+Design mirrors test.py (see notes_llama3.2_3b.md): full-4 GB DRAM layout, dynamic-PBI single
+bin (GPR-primed preamble + jump_abs), prefill_context_size=128. DECODE DEFAULT is deterministic:
+pure greedy for the first greedy_until (512) tokens — correct math/reasoning — then the on-FPGA
+repetition penalty (LM-head matmul bias) breaks long-context loops. No host penalty / sampling.
+See notes_repetition_penalty_fpga_bias.md.
 
 Usage:
   python llama3.2_3b_run_from_bin.py
   python llama3.2_3b_run_from_bin.py --prompt "your question"
-  python llama3.2_3b_run_from_bin.py --temperature 0 --dev xdma0     # greedy
+  python llama3.2_3b_run_from_bin.py --no-fpga-penalty --dev xdma0     # plain greedy (no penalty)
 """
 
 import json
@@ -286,6 +284,10 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
         self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
+        # On-FPGA repetition-penalty bias (the LM-head matmul's C term, bias_mode="broadcast_N").
+        # MUST be allocated here, immediately after LOGITS_DRAM and last — identical order/size to
+        # llama3.2_3b_test.py — so its baked address matches the fpga-penalty bin. all-zero = no penalty.
+        self.PENALTY_BIAS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
         _original_print(f"    Tensor dram end 0x{self.get_tensor_dram_addr():X}, usage {self.get_tensor_dram_usage()} bytes")
 
     # ---- sampling (identical mechanism to test.py §D) -----------------------
@@ -313,47 +315,24 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
             self._struct_ids_tensor_cache = t
         return t
 
-    def sample_next_token(self, prev_tokens) -> int:
-        """Read the full logits row from LOGITS_DRAM and sample with the configured
-        temperature / top_k / top_p / repetition_penalty (recency-decayed, windowed,
-        structural-exempt). Greedy (temperature<=0) is handled by the caller via the
-        HW argmax register, so this assumes sampling is on."""
+    def _write_penalty_bias(self, prev_tokens) -> None:
+        """On-FPGA repetition penalty: build the per-vocab additive bias from the windowed token
+        frequency and DMA it to PENALTY_BIAS_DRAM (the LM-head matmul's C term, bias_mode="broadcast_N").
+        bias[t] = clamp(-alpha*count[t], min=-cap); structural tokens stay 0. The HW argmax of
+        (logits + bias) then returns the penalized token id — no logit readback. Identical formula to
+        llama3.2_3b_test.py._write_penalty_bias (the bin compiled there bakes this contract)."""
         vocab = self.EMBEDDING_ELEMENTS
-        bpe = self.bytes_per_element
-        buf = torch.empty(vocab, dtype=torch.bfloat16)
-        self.dma_read(DMA_DEVICE_C2H, self.LOGITS_DRAM, buf, vocab * bpe)
-        logits = buf.float()
-        # Recency-decayed frequency repetition penalty over the last rep_window tokens,
-        # exempting structural/special tokens. See notes_llama3.2_3b.md §D.
-        rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        if rep_pen != 1.0 and prev_tokens:
-            rep_window = int(getattr(self, "rep_window", 256))
-            rep_decay = float(getattr(self, "rep_decay", 0.97))
-            window = torch.tensor(prev_tokens[-rep_window:], dtype=torch.long)
-            L = window.numel()
-            ages = torch.arange(L - 1, -1, -1, dtype=torch.float32)
-            contrib = rep_decay ** ages
-            weight = torch.zeros(vocab, dtype=torch.float32)
-            weight.index_add_(0, window, contrib)
-            weight[self._structural_ids_tensor()] = 0.0
-            nz = weight > 0
-            if bool(nz.any()):
-                factor = rep_pen ** weight[nz]
-                v = logits[nz]
-                logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        # Deterministic selection: argmax of the (penalty-adjusted) logits.
-        return int(logits.argmax().item())
-        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
-        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
-        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
-        # if top_k > 0 and top_k < vocab:
-        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
-        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
-        # if 0.0 < top_p < 1.0:
-        #     sl, si = torch.sort(logits, descending=True)
-        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
-        #     logits[si[~keep]] = float("-inf")
-        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
+        alpha = float(getattr(self, "pen_alpha", 1.0))
+        cap = float(getattr(self, "pen_cap", 20.0))
+        W = int(getattr(self, "rep_window", 256))
+        window = prev_tokens[-W:]
+        count = torch.zeros(vocab, dtype=torch.float32)
+        if window:
+            win = torch.tensor(window, dtype=torch.long)
+            count.index_add_(0, win, torch.ones(win.numel(), dtype=torch.float32))
+            count[self._structural_ids_tensor()] = 0.0
+        bias = (-alpha * count).clamp(min=-cap).to(torch.bfloat16).view(1, vocab)
+        self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM, bias)
 
     # ---- run path (dynamic-PBI single bin: preamble + jump_abs) -------------
     def run_llama(self) -> None:
@@ -363,6 +342,14 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         meta_path = os.path.join(self.script_dir,
                                  paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
+        if bool(getattr(self, "fpga_penalty", False)):
+            # On-FPGA penalty uses a separate bin (LM-head matmul bias on / logit writeback off);
+            # its meta points to the _fpgapenalty bin. Compiled by llama3.2_3b_test.py --fpga-penalty.
+            meta_path = meta_path.replace(".json", "_fpgapenalty.json")
+            if not os.path.exists(meta_path):
+                raise FileNotFoundError(
+                    f"on-FPGA penalty bin meta not found: {meta_path}\n"
+                    f"  build it with:  python llama3.2_3b_test.py --fpga-penalty")
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -425,11 +412,16 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
 
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # Position-gated decode (deterministic): PURE greedy (HW argmax) for the first
         # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
-        # repetition penalty turns on to break long-context loops.
-        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        # on-FPGA repetition penalty turns on to break long-context loops.
         _greedy_until = int(getattr(self, "greedy_until", 0))
+        # On-FPGA penalty: the LM-head matmul adds PENALTY_BIAS_DRAM (its C bias) so the HW argmax
+        # already returns the penalized token. Zero the buffer first → pure greedy until the gate.
+        _fpga_penalty = bool(getattr(self, "fpga_penalty", False))
+        if _fpga_penalty:
+            self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM,
+                                           torch.zeros(1, self.EMBEDDING_ELEMENTS, dtype=torch.bfloat16))
 
         import shutil
         _use_status = sys.stdout.isatty()
@@ -475,14 +467,18 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
             self.write_captured_instructions_to_dram(preamble_addr)
             self.clear_capture_buffer()
 
+            # On-FPGA penalty: refresh the per-vocab bias (this step's LM-head matmul C term) from the
+            # windowed token frequency once past the gate, so the HW argmax of (logits + bias) returns
+            # the penalized token directly — no logit readback.
+            if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
+                self._write_penalty_bias(self._generated_tokens)
+
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
-            # repetition penalty (read logits, argmax of penalized logits).
-            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
-            if _penalty_active:
-                token_id = self.sample_next_token(self._generated_tokens)
-            else:
-                token_id = self.get_arg_max_index(rank=1)
+            # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
+            # already added the bias, so the register holds the penalized token; in plain mode it's
+            # pure greedy. No logit readback. (The compare/calibration tool overrides
+            # get_arg_max_index to apply a host-side penalty against the writeback-on plain bin.)
+            token_id = self.get_arg_max_index(rank=1)
             self._generated_tokens.append(token_id)
             token_char = self.tokenizer.decode([token_id])
             _SILENT_MODE = False
@@ -505,14 +501,18 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
                         f"total {self.seq_len} tokens.")
 
 
-def _verify_artifacts(script_dir: str, cfg: dict) -> None:
+def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) -> None:
     """Hard-fail before any FPGA touch if a required artifact is missing."""
     paths = cfg["paths"]
+    inst_bin, inst_meta = paths["instruction_bin"], paths["instruction_meta"]
+    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py --fpga-penalty)
+        inst_bin = inst_bin.replace(".bin", "_fpgapenalty.bin")
+        inst_meta = inst_meta.replace(".json", "_fpgapenalty.json")
     required = [
         ("llama3.2_3b_config.json", "model config"),
         (paths["weights_bin"], "weight bin"),
-        (paths["instruction_bin"], "unified instruction bin"),
-        (paths["instruction_meta"], "instruction bin meta"),
+        (inst_bin, "unified instruction bin"),
+        (inst_meta, "instruction bin meta"),
     ]
     tok_dir = os.path.join(script_dir, paths["hf_model_dir"])
     missing = [f"  {rel}   ({label})" for rel, label in required
@@ -536,30 +536,31 @@ def main():
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=1 / 0.17, help="Clock cycle time in ns. Default ~5.88.")
-    # Decode — defaults match llama3.2_3b_test.py: hybrid (temp 0: greedy then rep-pen 1.2); see notes §D.
-    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
-    #     sample_next_token() to re-enable stochastic sampling ---
-    # parser.add_argument("--temperature", type=float, default=0.0, help=">0 enables sampling.")
-    # parser.add_argument("--top-k", type=int, default=40, help="Top-k filter (sampling only).")
-    # parser.add_argument("--top-p", type=float, default=0.9, help="Top-p nucleus filter (sampling only).")
-    parser.add_argument("--repetition-penalty", type=float, default=1.2,
-                        help="Recency-decayed repetition penalty (>1 down-weights repeats). Default 1.2.")
-    parser.add_argument("--rep-window", type=int, default=256,
-                        help="Repetition penalty look-back window in tokens. Default 256.")
-    parser.add_argument("--rep-decay", type=float, default=0.97,
-                        help="Recency decay for the repetition penalty (per-token age). Default 0.97.")
-    # parser.add_argument("--seed", type=int, default=None, help="RNG seed (sampling only).")
+    # Decode is deterministic with the on-FPGA penalty only (no host penalty / sampling).
     parser.add_argument("--greedy-until", type=int, default=512,
-                        help="Hybrid decode (temp 0): pure greedy for the first N decoded tokens "
-                             "(correct math/reasoning), then the repetition penalty breaks long-context "
-                             "loops. 0 = penalty from the start. Default 512.")
+                        help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
+                             "then the on-FPGA repetition penalty breaks long-context loops. "
+                             "0 = penalty from the start. Default 512.")
+    # On-FPGA repetition penalty (DEFAULT): the penalty is folded into the LM-head matmul bias so the
+    # HW argmax returns the penalized token directly — no logit readback. Loads the _fpgapenalty bin.
+    parser.add_argument("--fpga-penalty", action=argparse.BooleanOptionalAction, default=True,
+                        help="Apply the repetition penalty on-FPGA via the LM-head matmul bias "
+                             "(argmax of logits+bias on chip, no logit readback). DEFAULT. "
+                             "--no-fpga-penalty = plain greedy (writeback-on bin, no penalty), for "
+                             "the A/B baseline and the compare/calibration tool.")
+    parser.add_argument("--pen-alpha", type=float, default=1.0,
+                        help="On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.")
+    parser.add_argument("--pen-cap", type=float, default=20.0,
+                        help="On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.")
+    parser.add_argument("--rep-window", type=int, default=256,
+                        help="On-FPGA penalty: count tokens over the last N. Default 256.")
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     cfg = _load_config(script_dir)
 
     # Hard-fail BEFORE touching the FPGA if any artifact is missing.
-    _verify_artifacts(script_dir, cfg)
+    _verify_artifacts(script_dir, cfg, fpga_penalty=bool(args.fpga_penalty))
 
     set_dma_device(args.dev)
     user_dma_core.CLOCK_CYCLE_TIME_NS = args.cycle
@@ -587,19 +588,20 @@ def main():
         prefill_seq = tuple(cfg["default_prefill_tokens"])
 
     ue.prefill_seq = prefill_seq
-    # Sampling controls (temperature/top_k/top_p/seed) disabled — decode is deterministic.
-    ue.repetition_penalty = float(args.repetition_penalty)
-    ue.rep_window = int(args.rep_window)
-    ue.rep_decay = float(args.rep_decay)
+    # Decode config — deterministic, on-FPGA penalty only (no host penalty / sampling).
     ue.greedy_until = int(args.greedy_until)
+    ue.fpga_penalty = bool(args.fpga_penalty)   # selects the _fpgapenalty bin + matmul-bias path
+    ue.pen_alpha = float(args.pen_alpha)
+    ue.pen_cap = float(args.pen_cap)
+    ue.rep_window = int(args.rep_window)
     ue._generated_tokens = list(prefill_seq)
-    _penalty_used = ue.repetition_penalty != 1.0
-    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
-             if _penalty_used else "no penalty")
-    _original_print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
-    if _penalty_used:
+    if ue.fpga_penalty:
+        _original_print(f"Decode: ON-FPGA penalty (bias in LM-head matmul) — pure greedy for "
+                        f"{ue.greedy_until} tokens, then alpha={ue.pen_alpha} cap={ue.pen_cap} window={ue.rep_window}")
         _n = len(ue._structural_token_ids())  # precompute upfront (no mid-decode stall)
-        _original_print(f"  repetition penalty exempts {_n} structural/special tokens")
+        _original_print(f"  penalty exempts {_n} structural/special tokens")
+    else:
+        _original_print("Decode: plain greedy (deterministic) — no penalty (writeback-on bin)")
 
     ue.run_llama()
     ue.clear_dram()

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -507,6 +507,11 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
+        # Per-vocab additive repetition-penalty bias (on-FPGA penalty, --fpga-penalty). The LM-head
+        # matmul reads this as its C bias (bias_mode="broadcast_N") so the on-chip argmax already
+        # returns the penalized token id — no logit readback. MUST be last (after LOGITS_DRAM), same
+        # order/size as run_from_bin, so the baked address matches. all-zero = no penalty.
+        self.PENALTY_BIAS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
 
         print(f"    Allocate tensor dram end at DRAM address: 0x{self.get_tensor_dram_addr():X}, usage: {self.get_tensor_dram_usage()} bytes")
 
@@ -898,18 +903,26 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            # LM head: the full vocab-logits writeback to DRAM is needed whenever the host
-            # reads logits — sampling (temp>0) OR penalized greedy (temp 0 + rep_pen!=1, which
-            # argmaxes the penalty-adjusted logits). Disable it ONLY for pure unpenalized greedy
-            # (temp 0 + rep_pen 1.0), where the HW argmax register suffices. This compile-time
-            # gate MUST match the decode readback condition (temp>0 or penalty active); else the host reads a
-            # never-written LOGITS_DRAM → NaN/garbage ("!!!"). main() sets both before compile.
-            _need_logit_writeback = (float(getattr(self, "temperature", 0.0)) > 0
-                                     or float(getattr(self, "repetition_penalty", 1.0)) != 1.0)
-            total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
-                A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
-                write_back_disable=not _need_logit_writeback)
+            if bool(getattr(self, "fpga_penalty", False)):
+                # On-FPGA repetition penalty: feed the per-vocab penalty as the matmul C bias
+                # (bias_mode="broadcast_N" → bias[t] added to logit[t]) so the on-chip argmax
+                # returns the PENALIZED token id directly. No logit writeback (the host reads the
+                # argmax register, not the row). Host maintains PENALTY_BIAS_DRAM each step.
+                # See notes_repetition_penalty_fpga_bias.md.
+                total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+                    A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
+                    C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N",
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
+                    write_back_disable=True)
+            else:
+                # Plain bin (--no-fpga-penalty): no bias, full vocab-logits row written to DRAM
+                # (writeback ON). Used for the greedy A/B baseline and as the logit source for the
+                # compare/calibration tool (compare/compare_llama3.2_3b_penalty.py), which reads
+                # LOGITS_DRAM and applies the penalty on host. No host penalty runs in production.
+                total_flops += self.matmat_mul_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+                    A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
+                    write_back_disable=False)
 
         self.generate_instruction_halt()
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
@@ -934,6 +947,13 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_3b_bin/llama_instruction.bin"))
         instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
+        if bool(getattr(self, "fpga_penalty", False)):
+            # On-FPGA penalty changes the LM-head matmul (bias on / writeback off) → a different bin.
+            # Separate cache file so it never clobbers the host-path bin. run_from_bin loads the same.
+            instruction_bin_path = instruction_bin_path.replace(".bin", "_fpgapenalty.bin")
+            instruction_meta_path = instruction_meta_path.replace(".json", "_fpgapenalty.json")
+            self._instruction_bin_path = instruction_bin_path
+            self._instruction_meta_path = instruction_meta_path
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             print(f"Reusing existing instruction image at {instruction_bin_path}")
             print(f"  delete {instruction_bin_path} to force recompile.")
@@ -1019,65 +1039,24 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
             self._struct_ids_tensor_cache = t
         return t
 
-    def sample_next_token(self, prev_tokens: list[int]) -> int:
-        """Read full logits from LOGITS_DRAM and sample the next token using the
-        engine's configured ``temperature`` / ``top_k`` / ``top_p`` /
-        ``repetition_penalty`` (mechanism mirrors qwen3_1.7b). Greedy fast path
-        (HW argmax register) is used when ``temperature <= 0`` — the caller
-        dispatches, this method assumes sampling is enabled.
-
-        prev_tokens: token ids already in the sequence (prompt + decoded), used
-                     by the repetition penalty to down-weight repeats.
-
-        Requires the decoder bin to have been compiled with LM-head writeback
-        ENABLED (i.e. temperature > 0 at compile time), so LOGITS_DRAM holds the
-        full vocab row rather than only the HW argmax index.
-        """
+    def _write_penalty_bias(self, prev_tokens) -> None:
+        """On-FPGA repetition penalty (--fpga-penalty): build the per-vocab additive bias from the
+        windowed token frequency and DMA it to PENALTY_BIAS_DRAM (the LM-head matmul's C term,
+        bias_mode="broadcast_N"). bias[t] = clamp(-alpha*count[t], min=-cap); structural tokens stay
+        0. The HW argmax of (logits + bias) then returns the penalized token id — no logit readback.
+        Identical formula to the 1B path and to run_from_bin (the bin bakes this contract)."""
         vocab = self.EMBEDDING_ELEMENTS
-        bpe = self.bytes_per_element
-        # DMA logits row to host. ~256 KB for the Llama vocab; negligible vs decode latency.
-        buf = torch.empty(vocab, dtype=torch.bfloat16)
-        self.dma_read(DMA_DEVICE_C2H, self.LOGITS_DRAM, buf, vocab * bpe)
-        logits = buf.float()
-        # Repetition penalty — recency-decayed frequency form (not flat binary).
-        # For each token in the last ``rep_window`` tokens, accumulate a weight
-        #   w[t] = sum over its occurrences of  rep_decay ** age   (age 0 = most recent),
-        # then scale logits by  rep_pen ** w[t]  (divide positives / multiply negatives).
-        # So a token used ONCE a while ago gets w≈small → factor≈1 (barely touched), while
-        # a token looped several times very recently gets a large w → strong suppression.
-        # This fixes two failure modes of the old flat penalty: (1) it no longer flips
-        # intentionally-repeated scaffolding (e.g. "Chapter" reused a paragraph later is
-        # only mildly nudged), and (2) it still crushes genuine short-range loops.
-        # Structural "glue" tokens (punctuation/whitespace/newline/special) stay exempt.
-        rep_pen = float(getattr(self, "repetition_penalty", 1.0))
-        if rep_pen != 1.0 and prev_tokens:
-            rep_window = int(getattr(self, "rep_window", 256))
-            rep_decay = float(getattr(self, "rep_decay", 0.97))
-            window = torch.tensor(prev_tokens[-rep_window:], dtype=torch.long)
-            L = window.numel()
-            ages = torch.arange(L - 1, -1, -1, dtype=torch.float32)   # oldest=L-1 ... newest=0
-            contrib = rep_decay ** ages
-            weight = torch.zeros(vocab, dtype=torch.float32)
-            weight.index_add_(0, window, contrib)                     # recency-weighted count per id
-            weight[self._structural_ids_tensor()] = 0.0               # never penalize glue/special
-            nz = weight > 0
-            if bool(nz.any()):
-                factor = rep_pen ** weight[nz]                        # >= 1, grows with recency*count
-                v = logits[nz]
-                logits[nz] = torch.where(v > 0, v / factor, v * factor)
-        # Deterministic selection: argmax of the (penalty-adjusted) logits.
-        return int(logits.argmax().item())
-        # --- Sampling mechanism (DISABLED) — uncomment + set temperature>0 to re-enable ---
-        # logits = logits / float(getattr(self, "temperature", 1.0))            # temperature
-        # top_k = int(getattr(self, "top_k", 0) or 0)                           # top-k filter
-        # if top_k > 0 and top_k < vocab:
-        #     logits[logits < torch.topk(logits, top_k).values[-1]] = float("-inf")
-        # top_p = float(getattr(self, "top_p", 1.0))                            # top-p (nucleus)
-        # if 0.0 < top_p < 1.0:
-        #     sl, si = torch.sort(logits, descending=True)
-        #     keep = torch.cumsum(torch.softmax(sl, -1), -1) <= top_p; keep[0] = True
-        #     logits[si[~keep]] = float("-inf")
-        # return int(torch.multinomial(torch.softmax(logits, -1), 1).item())    # sample
+        alpha = float(getattr(self, "pen_alpha", 1.0))
+        cap = float(getattr(self, "pen_cap", 20.0))
+        W = int(getattr(self, "rep_window", 256))
+        window = prev_tokens[-W:]
+        count = torch.zeros(vocab, dtype=torch.float32)
+        if window:
+            win = torch.tensor(window, dtype=torch.long)
+            count.index_add_(0, win, torch.ones(win.numel(), dtype=torch.float32))
+            count[self._structural_ids_tensor()] = 0.0
+        bias = (-alpha * count).clamp(min=-cap).to(torch.bfloat16).view(1, vocab)
+        self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM, bias)
 
     def run_llama(self) -> None:
         """Load the unified instruction image and run prefill + decoder loop.
@@ -1086,7 +1065,10 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         prefill or decoder program at runtime.
         """
         paths_cfg = self._cfg.get("paths", {})
-        meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
+        # When fpga_penalty, compile_llama set _instruction_meta_path to the _fpgapenalty meta — use
+        # it so we load the bias bin (whose meta's instruction_bin points to the _fpgapenalty bin).
+        meta_path = getattr(self, "_instruction_meta_path", None) or \
+            os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/llama_instruction.json"))
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -1150,16 +1132,21 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
         global _SILENT_MODE
 
-        # Sampling state: repetition penalty in sample_next_token() considers every
-        # token seen so far (prompt + decoded), seeded by main() with the prompt ids.
-        # Falls back to the full prompt when run without main() (e.g. run_from_bin).
+        # Penalty window state: the on-FPGA penalty counts every token seen so far (prompt +
+        # decoded), seeded by main() with the prompt ids. Falls back to the full prompt when run
+        # without main().
         if not hasattr(self, "_generated_tokens"):
             self._generated_tokens = list(self.prefill_seq)
-        # Position-gated hybrid decode (deterministic): PURE greedy (HW argmax) for the first
+        # Position-gated decode (deterministic): PURE greedy (HW argmax) for the first
         # `greedy_until` decoded tokens — correct math/reasoning, which lands early — then the
-        # repetition penalty turns on to break long-context loops.
-        _rep_pen = float(getattr(self, "repetition_penalty", 1.0))
+        # on-FPGA repetition penalty turns on to break long-context loops.
         _greedy_until = int(getattr(self, "greedy_until", 0))
+        # On-FPGA penalty: the LM-head matmul adds PENALTY_BIAS_DRAM (its C bias) so the HW argmax
+        # already returns the penalized token. Zero the buffer first → pure greedy until the gate.
+        _fpga_penalty = bool(getattr(self, "fpga_penalty", False))
+        if _fpga_penalty:
+            self.dma_to_accelerator_memory(self.PENALTY_BIAS_DRAM,
+                                           torch.zeros(1, self.EMBEDDING_ELEMENTS, dtype=torch.bfloat16))
 
         # Two-region live counter: pin the bottom terminal row as a status line via
         # an ANSI scroll region; tokens stream in the area above it and the counter
@@ -1214,14 +1201,18 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
             self.write_captured_instructions_to_dram(preamble_addr)
             self.clear_capture_buffer()
 
+            # On-FPGA penalty: refresh the per-vocab bias (this step's LM-head matmul C term) from the
+            # windowed token frequency once past the gate, so the HW argmax of (logits + bias) returns
+            # the penalized token directly — no logit readback.
+            if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
+                self._write_penalty_bias(self._generated_tokens)
+
             self.program_execute(preamble_addr, flops=decoder_flops_per_token)
-            # Hybrid gate: pure HW argmax for the first `greedy_until` decoded tokens, then the
-            # repetition penalty (read logits, argmax of penalized logits).
-            _penalty_active = _rep_pen != 1.0 and (self.seq_len - prefill_seq_len) > _greedy_until
-            if _penalty_active:
-                token_id = self.sample_next_token(self._generated_tokens)
-            else:
-                token_id = self.get_arg_max_index(rank=1)
+            # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
+            # already added the bias, so the register holds the penalized token; in plain mode it's
+            # pure greedy. No logit readback. (The compare/calibration tool overrides
+            # get_arg_max_index to apply a host-side penalty against the writeback-on plain bin.)
+            token_id = self.get_arg_max_index(rank=1)
             self._generated_tokens.append(token_id)
             token_char = self.tokenizer.decode([token_id])
             _SILENT_MODE = False
@@ -1253,30 +1244,28 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_3b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Decode is a position-gated hybrid (deterministic): PURE greedy for the first
-    # `greedy_until` (512) decoded tokens — correct math/reasoning, which lands early — then
-    # repetition penalty 1.2 to break long-context loops. Rationale: notes_llama3.2_1b.md §D.
-    # --- Sampling controls (DISABLED) — uncomment + restore the sampling block in
-    #     sample_next_token() to re-enable stochastic sampling ---
-    # parser.add_argument('--temperature', type=float, default=0.0, help='>0 enables sampling.')
-    # parser.add_argument('--top-k', type=int, default=40, help='Top-k filter (sampling only).')
-    # parser.add_argument('--top-p', type=float, default=0.9, help='Top-p nucleus filter (sampling only).')
-    parser.add_argument('--repetition-penalty', type=float, default=1.2,
-                        help='HF-style repetition penalty (>1 down-weights repeated tokens). Active after greedy_until in hybrid mode. Default 1.2.')
-    parser.add_argument('--rep-window', type=int, default=256,
-                        help='Repetition penalty considers only the last N tokens (and never penalizes '
-                             'punctuation/whitespace/special tokens). Smaller = less structural starvation '
-                             'on long generations. Default 256.')
-    parser.add_argument('--rep-decay', type=float, default=0.97,
-                        help='Recency decay for the repetition penalty (per-token, age-based): a repeat '
-                             'k tokens ago contributes rep_decay**k to its penalty weight. 1.0 = pure '
-                             'frequency (no decay); lower = only very recent repeats matter. Default 0.97 '
-                             '(half-life ~23 tokens).')
-    # parser.add_argument('--seed', type=int, default=None, help='RNG seed (sampling only).')
+    # Decode is deterministic: pure greedy for the first `greedy_until` (512) decoded tokens —
+    # correct math/reasoning, which lands early — then the on-FPGA repetition penalty turns on to
+    # break long-context loops. The penalty runs entirely on the FPGA; no host penalty or sampling.
     parser.add_argument('--greedy-until', type=int, default=512,
-                        help='Hybrid decode (temp 0 only): pure greedy for the first N decoded tokens '
-                             '(correct math/reasoning, which lands early), then the repetition penalty '
-                             'turns on to break long-context loops. 0 = penalty from the start. Default 512.')
+                        help='Pure greedy for the first N decoded tokens (correct math/reasoning, '
+                             'which lands early), then the on-FPGA repetition penalty turns on to '
+                             'break long-context loops. 0 = penalty from the start. Default 512.')
+    # On-FPGA repetition penalty (DEFAULT): fold the penalty into the LM-head matmul bias so the HW
+    # argmax returns the penalized token (no logit readback). Separate _fpgapenalty bin. Validated
+    # params for 3B (logit_max~26.9, gap~4.25): alpha=1.0. See notes_repetition_penalty_fpga_bias.md.
+    parser.add_argument('--fpga-penalty', action=argparse.BooleanOptionalAction, default=True,
+                        help='Apply the repetition penalty on-FPGA via the LM-head matmul bias '
+                             '(argmax of logits+bias on chip, no logit readback). DEFAULT. '
+                             '--no-fpga-penalty = plain greedy (writeback-on bin, no penalty), for '
+                             'the A/B baseline and the compare/calibration tool.')
+    parser.add_argument('--pen-alpha', type=float, default=1.0,
+                        help='On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.')
+    parser.add_argument('--pen-cap', type=float, default=20.0,
+                        help='On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.')
+    parser.add_argument('--rep-window', type=int, default=256,
+                        help='On-FPGA penalty: count tokens over the last N (never penalizes '
+                             'punctuation/whitespace/special tokens). Default 256.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1316,24 +1305,23 @@ def main():
 
     ue.prefill_seq = prefill_seq
 
-    # Decode config (consumed by the decode loop / repetition penalty / LM-head writeback
-    # gate). Must be set BEFORE compile_llama() so the bin is compiled with logits writeback
-    # ON when a repetition penalty is used. Sampling controls (temperature/top_k/top_p/seed)
-    # are disabled — decode is deterministic.
-    ue.repetition_penalty = float(args.repetition_penalty)
-    ue.rep_window = int(args.rep_window)
-    ue.rep_decay = float(args.rep_decay)
+    # Decode config — deterministic, on-FPGA penalty only. Must be set BEFORE compile_llama() since
+    # fpga_penalty changes the compiled LM-head matmul (bias on / writeback off).
     ue.greedy_until = int(args.greedy_until)
-    ue._generated_tokens = list(prefill_seq)   # seed repetition penalty with the prompt
-    _penalty_used = ue.repetition_penalty != 1.0
-    _tail = (f"penalty (rep_pen={ue.repetition_penalty}) after {ue.greedy_until} tokens"
-             if _penalty_used else "no penalty")
-    print(f"Decode: greedy (deterministic) — pure greedy then {_tail}")
-    # Precompute the structural-token exemption set upfront (one vocab scan) so it
-    # doesn't stall the first decode step where the penalty turns on.
-    if _penalty_used:
+    ue.fpga_penalty = bool(args.fpga_penalty)
+    ue.pen_alpha = float(args.pen_alpha)
+    ue.pen_cap = float(args.pen_cap)
+    ue.rep_window = int(args.rep_window)
+    ue._generated_tokens = list(prefill_seq)   # seed the penalty window with the prompt
+    if ue.fpga_penalty:
+        print(f"Decode: ON-FPGA penalty (bias in LM-head matmul) — pure greedy for {ue.greedy_until} "
+              f"tokens, then alpha={ue.pen_alpha} cap={ue.pen_cap} window={ue.rep_window}")
+        # Precompute the structural-exemption set upfront (one vocab scan) so it doesn't stall the
+        # first penalized decode step.
         _n = len(ue._structural_token_ids())
-        print(f"  repetition penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+        print(f"  penalty exempts {_n} structural/special tokens (punctuation/whitespace/newline)")
+    else:
+        print("Decode: plain greedy (deterministic) — no penalty (writeback-on bin)")
 
     print("\n--- Compiling ---")
     timer = time.perf_counter()

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -507,7 +507,7 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
-        # Per-vocab additive repetition-penalty bias (on-FPGA penalty, --fpga-penalty). The LM-head
+        # Per-vocab additive repetition-penalty bias (on-FPGA penalty, the default). The LM-head
         # matmul reads this as its C bias (bias_mode="broadcast_N") so the on-chip argmax already
         # returns the penalized token id — no logit readback. MUST be last (after LOGITS_DRAM), same
         # order/size as run_from_bin, so the baked address matches. all-zero = no penalty.
@@ -533,10 +533,20 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         global _SILENT_MODE
         _SILENT_MODE = True
         num_bucket = (self.PREFILL_CONTEXT_SIZE * self.group_size + 63) // 64
-        gpr_tmp = self.alloc_isa_reg()
-        self.generate_instruction_reg_mul_imm(gpr_tmp, self.gpr_seq_len, self.vector_length * self.bytes_per_element)
         total_flops = 0
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+
+        # Layer-invariant constants the flash subroutine needs after the layer loop.
+        ahd  = self.actual_head_dim   # 128
+        nkvh = self.num_kv_heads      # 8
+
+        # flash_attention_core is compiled once as a subroutine after the layer loop; each
+        # call site primes gpr_ret_id with its return word address then jumps to the
+        # subroutine, which returns via JUMP_REG_ABS(gpr_ret_id). All KV-head/layer attentions
+        # share one instruction body, shrinking the program image dramatically.
+        program_dram_base = self.get_program_dram_addr()
+        gpr_ret_id = self.alloc_isa_reg()
+        call_site_jump_capture_indices: list[int] = []
         for layer_idx in range(layer_size):
             layer_off = layer_idx * LAYER_WEIGHT_SIZE
             if layer_idx != 0:
@@ -657,24 +667,15 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                         template_seq_len=seq_len,
                     )
 
-                # Flash attention for this KV head (head_dim=64) — PBI bucket dispatcher;
-                # gpr_bucket_idx is primed at program start (ADD_SET above) so the dispatcher
-                # routes to the correct bucket body for the actual runtime seq_len.
-                flash_result = self.flash_attention_core(
-                    head_dim=ahd,
-                    seq_len=aligned_seq_len,
-                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
-                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
-                    gpr_bucket_idx=self.gpr_bucket_idx,
-                    num_buckets=num_bucket,
-                )
-                total_flops += flash_result[num_bucket - 1]
+                # Call the flash-attention subroutine (compiled once after the layer loop).
+                # Pad so capture_count is even; return address = capture_count + 2
+                # (ADD_SET + JUMP_ABS), which is then also even = 512-bit aligned.
+                self.pad_capture_to_64b_boundary()
+                return_word_addr = ue_35bit_addr_shifter(
+                    program_dram_base + (self.capture_count + 2) * INSTRUCTION_SIZE_BYTES)
+                self.generate_instruction_add_set(gpr_ret_id, return_word_addr)
+                call_site_jump_capture_indices.append(self.capture_count)
+                self.generate_instruction_jump_abs(target_instruction_word_addr=0)
 
                 # Assemble output into LAYER0_FLASH_OUTPUT_DRAM
                 # Standard GQA layout per token: [kv0_q0(64), kv0_q1..q3, kv1_q0..q3, ...]
@@ -749,8 +750,35 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                 mode=UE_MODE.ELTWISE_ADD,
                 gpr_M_reg=self.gpr_seq_len,
             )
-        self.release_isa_reg()  # gpr_tmp
+        # HALT ends the normal execution path; the flash_attention subroutine follows and
+        # is only reachable via the JUMP_ABS call sites within the layer loop above.
         self.generate_instruction_halt()
+
+        # Compile the flash_attention subroutine after the HALT; bucket bodies return via
+        # JUMP_REG_ABS(gpr_ret_id), which each call site pre-loaded with its return address.
+        flash_sub_start_inst_dram_addr, flash_flops = self.flash_attention_core(
+            head_dim=ahd,
+            seq_len=aligned_seq_len,
+            Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+            K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+            V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
+            OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+            ATTN_P_DRAM_ADDR=self.LAYER0_FLASH_ATTN_P_DRAM,
+            gpr_bucket_idx=self.gpr_bucket_idx,
+            num_buckets=num_bucket,
+            gpr_ret_id=gpr_ret_id,
+        )
+        total_flops += flash_flops[num_bucket - 1] * layer_size * nkvh
+
+        # Patch all call-site JUMP_ABS placeholders to point at the flash subroutine.
+        for jump_idx in call_site_jump_capture_indices:
+            self._patch_jump_immediate(
+                jump_idx, ue_35bit_addr_shifter(flash_sub_start_inst_dram_addr))
+
+        self.release_isa_reg()  # gpr_ret_id
         prefill_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"size_bytes": prefill_program_size, "flops": total_flops}
@@ -764,6 +792,13 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         count_at_start = self.capture_count
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
         total_flops = 0
+
+        # decoder_group_attention_core compiled once as a subroutine after HALT; each call
+        # site primes gpr_ret_id then jumps in, and the bucket body returns via
+        # JUMP_REG_ABS(gpr_ret_id). One shared body for all KV-head/layer decode attentions.
+        program_dram_base = self.get_program_dram_addr()
+        gpr_ret_id = self.alloc_isa_reg()
+        call_site_jump_capture_indices: list[int] = []
 
         global _SILENT_MODE
         _SILENT_MODE = True
@@ -835,6 +870,18 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(0x10000, 0, ahd)
                     self.overwrite_instruction_with_general_register(self.TMP_REG)
 
+                    # Gather valid K history → LAYER0_FLASH_K_DRAM; loop count = gpr_bucket_idx
+                    # so only current_seq_len tokens are copied, not the full MAX_CONTEXT_SIZE.
+                    # The shared decode subroutine reads K from the fixed FLASH_K buffer.
+                    self._emit_pbi_scatter_per_token(
+                        read_base=k_cache_base,
+                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_K_DRAM, UE_VECTOR_SIZE * ahd * bpe)],
+                        sram_byte_addr=0,
+                        element_count=UE_VECTOR_SIZE * ahd,
+                        gpr_seq_len=self.gpr_bucket_idx,
+                    )
+
                     # Scatter V head (contiguous ahd) from FLASH_V[kv0..kv7] → V cache at decode position
                     self.accelerator_memory_to_sram(
                         self.LAYER0_FLASH_V_DRAM + kv_h * ahd * bpe, 0x20000, ahd)
@@ -843,27 +890,38 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                     self.sram_to_accelerator_memory(0x20000, 0, ahd)
                     self.overwrite_instruction_with_general_register(self.TMP_REG)
 
-                    # Scatter this KV head's qpkv Q heads (contiguous ahd at (kv_h*qpkv+q)*ahd) → FLASH_Q
+                    # Gather valid V history → LAYER0_FLASH_V_DRAM + k_size; same dynamic size.
+                    # Offset by k_size to avoid the v_proj output living at [0..k_size-1].
+                    self._emit_pbi_scatter_per_token(
+                        read_base=v_cache_base,
+                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_V_DRAM + self.k_size, UE_VECTOR_SIZE * ahd * bpe)],
+                        sram_byte_addr=0,
+                        element_count=UE_VECTOR_SIZE * ahd,
+                        gpr_seq_len=self.gpr_bucket_idx,
+                    )
+
+                    # Scatter this KV head's qpkv Q heads → FLASH_Q base (no kv_h offset; the shared
+                    # subroutine reads the group's Q from the FLASH_Q base).
                     for q in range(qpkv):
-                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe
+                        flash_q_addr = self.LAYER0_FLASH_Q_DRAM + q * ahd * bpe
                         self.accelerator_memory_to_sram(
                             self.LAYER0_Q_DRAM + (kv_h * qpkv + q) * ahd * bpe, 0x30000, ahd)
                         self.sram_to_accelerator_memory(0x30000, flash_q_addr, ahd)
-                    attn_flops = self.decoder_group_attention_core(
-                        group_size=qpkv,
-                        head_dim=ahd,
-                        seq_len=self.MAX_CONTEXT_SIZE,
-                        gpr_bucket_idx=self.gpr_bucket_idx,
-                        num_buckets=(self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE,
-                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM + kv_h * qpkv * ahd * bpe,
-                        K_DRAM_ADDR=k_cache_base,
-                        V_DRAM_ADDR=v_cache_base,
-                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe,
-                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    )
-                    total_flops += attn_flops[-1]
+
+                    # Call the decoder-attention subroutine (compiled once after HALT).
+                    self.pad_capture_to_64b_boundary()
+                    return_word_addr = ue_35bit_addr_shifter(
+                        program_dram_base + (self.capture_count + 2) * INSTRUCTION_SIZE_BYTES)
+                    self.generate_instruction_add_set(gpr_ret_id, return_word_addr)
+                    call_site_jump_capture_indices.append(self.capture_count)
+                    self.generate_instruction_jump_abs(target_instruction_word_addr=0)
+
+                    # Copy this head's output (qpkv*ahd) to its slot in FLASH_OUTPUT_DRAM.
+                    self.accelerator_memory_to_sram(
+                        self.LAYER0_FLASH_OUT_HEAD_DRAM, 0x40000, qpkv * ahd)
+                    self.sram_to_accelerator_memory(
+                        0x40000, self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe, qpkv * ahd)
                 total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
@@ -915,7 +973,7 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                     is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
                     write_back_disable=True)
             else:
-                # Plain bin (--no-fpga-penalty): no bias, full vocab-logits row written to DRAM
+                # Plain bin (--pure-greedy): no bias, full vocab-logits row written to DRAM
                 # (writeback ON). Used for the greedy A/B baseline and as the logit source for the
                 # compare/calibration tool (compare/compare_llama3.2_3b_penalty.py), which reads
                 # LOGITS_DRAM and applies the penalty on host. No host penalty runs in production.
@@ -925,6 +983,37 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
                     write_back_disable=False)
 
         self.generate_instruction_halt()
+        self.pad_capture_to_64b_boundary()
+
+        # Compile decoder_group_attention_core once as a subroutine after HALT; the bucket
+        # body returns via JUMP_REG_ABS(gpr_ret_id). Reads K/V from the fixed FLASH_K / FLASH_V
+        # buffers (gathered per call site) and Q from FLASH_Q base; writes FLASH_OUT_HEAD.
+        num_buckets = (self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE
+        ahd = self.actual_head_dim
+        bpe = self.bytes_per_element
+        qpkv = self.group_size
+        dec_sub_start_addr, dec_attn_flops = self.decoder_group_attention_core(
+            group_size=qpkv,
+            head_dim=ahd,
+            seq_len=self.MAX_CONTEXT_SIZE,
+            gpr_bucket_idx=self.gpr_bucket_idx,
+            num_buckets=num_buckets,
+            Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+            K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+            V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM + self.k_size,
+            OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+            gpr_ret_id=gpr_ret_id,
+        )
+        total_flops += dec_attn_flops[-1] * layer_size * self.num_kv_heads
+
+        for jump_idx in call_site_jump_capture_indices:
+            self._patch_jump_immediate(
+                jump_idx, ue_35bit_addr_shifter(dec_sub_start_addr))
+
+        self.release_isa_reg()  # gpr_ret_id
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"program_size_bytes": decoder_program_size, "total_flops": total_flops}
@@ -1040,7 +1129,7 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         return t
 
     def _write_penalty_bias(self, prev_tokens) -> None:
-        """On-FPGA repetition penalty (--fpga-penalty): build the per-vocab additive bias from the
+        """On-FPGA repetition penalty (the default): build the per-vocab additive bias from the
         windowed token frequency and DMA it to PENALTY_BIAS_DRAM (the LM-head matmul's C term,
         bias_mode="broadcast_N"). bias[t] = clamp(-alpha*count[t], min=-cap); structural tokens stay
         0. The HW argmax of (logits + bias) then returns the penalized token id — no logit readback.
@@ -1244,28 +1333,28 @@ def main():
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_3b_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=1/0.17, help='Clock cycle time in ns (default: ~5.88ns)')
-    # Decode is deterministic: pure greedy for the first `greedy_until` (512) decoded tokens —
-    # correct math/reasoning, which lands early — then the on-FPGA repetition penalty turns on to
-    # break long-context loops. The penalty runs entirely on the FPGA; no host penalty or sampling.
-    parser.add_argument('--greedy-until', type=int, default=512,
+    # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
+    # matmul bias so the HW argmax returns the penalized token directly (no logit readback), fully
+    # deterministic (separate _fpgapenalty bin). --pure-greedy disables it entirely.
+    parser.add_argument('--pure-greedy', action='store_true',
+                        help='Disable the on-FPGA repetition penalty entirely — plain greedy decode '
+                             '(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy '
+                             'only for the A/B baseline and the compare/calibration tool.')
+    # On-FPGA repetition penalty parameters (active unless --pure-greedy). The penalty is folded into
+    # the LM-head matmul bias (on-chip argmax of logits+bias, no logit readback). Validated 3B params
+    # (logit_max~26.9, gap~4.25): alpha=1.0. See notes_repetition_penalty_fpga_bias.md.
+    pen_group = parser.add_argument_group('on-FPGA repetition penalty (active unless --pure-greedy)')
+    pen_group.add_argument('--greedy-until', type=int, default=512,
                         help='Pure greedy for the first N decoded tokens (correct math/reasoning, '
-                             'which lands early), then the on-FPGA repetition penalty turns on to '
-                             'break long-context loops. 0 = penalty from the start. Default 512.')
-    # On-FPGA repetition penalty (DEFAULT): fold the penalty into the LM-head matmul bias so the HW
-    # argmax returns the penalized token (no logit readback). Separate _fpgapenalty bin. Validated
-    # params for 3B (logit_max~26.9, gap~4.25): alpha=1.0. See notes_repetition_penalty_fpga_bias.md.
-    parser.add_argument('--fpga-penalty', action=argparse.BooleanOptionalAction, default=True,
-                        help='Apply the repetition penalty on-FPGA via the LM-head matmul bias '
-                             '(argmax of logits+bias on chip, no logit readback). DEFAULT. '
-                             '--no-fpga-penalty = plain greedy (writeback-on bin, no penalty), for '
-                             'the A/B baseline and the compare/calibration tool.')
-    parser.add_argument('--pen-alpha', type=float, default=1.0,
-                        help='On-FPGA penalty: bias[t] = -alpha*count[t] (logit units). Default 1.0.')
-    parser.add_argument('--pen-cap', type=float, default=20.0,
-                        help='On-FPGA penalty: max |bias| per token (floor on -alpha*count). Default 20.')
-    parser.add_argument('--rep-window', type=int, default=256,
-                        help='On-FPGA penalty: count tokens over the last N (never penalizes '
-                             'punctuation/whitespace/special tokens). Default 256.')
+                             'which lands early), then the penalty turns on to break long-context '
+                             'loops. 0 = penalty from the start. Default 512.')
+    pen_group.add_argument('--pen-alpha', type=float, default=1.0,
+                        help='bias[t] = -alpha*count[t] (logit units). Default 1.0.')
+    pen_group.add_argument('--pen-cap', type=float, default=20.0,
+                        help='max |bias| per token (floor on -alpha*count). Default 20.')
+    pen_group.add_argument('--rep-window', type=int, default=256,
+                        help='count tokens over the last N (never penalizes punctuation/whitespace/'
+                             'special tokens). Default 256.')
     args = parser.parse_args()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -1308,7 +1397,7 @@ def main():
     # Decode config — deterministic, on-FPGA penalty only. Must be set BEFORE compile_llama() since
     # fpga_penalty changes the compiled LM-head matmul (bias on / writeback off).
     ue.greedy_until = int(args.greedy_until)
-    ue.fpga_penalty = bool(args.fpga_penalty)
+    ue.fpga_penalty = not bool(args.pure_greedy)
     ue.pen_alpha = float(args.pen_alpha)
     ue.pen_cap = float(args.pen_cap)
     ue.rep_window = int(args.rep_window)


### PR DESCRIPTION
| Model | Before (inline) | After (shared subroutine) | Reduction |
| :--- | :--- | :--- | :--- |
| Llama-3.2-1B | 30.55 MB | 1.67 MB (prefill 0.82 MB + decoder 0.85 MB) | 18.3× |
| Llama-3.2-3B | 54.49 MB | 2.52 MB (prefill 0.90 MB + decoder 1.62 MB) | 21.7× |