### PR TITLE
+

### DIFF
--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -1073,12 +1073,15 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            penalty_kwargs = dict(C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N") \
-                if bool(getattr(self, "fpga_penalty", False)) else {}
+            # LM head with the on-FPGA repetition-penalty bias folded in UNCONDITIONALLY (qwen3 style):
+            # the matmul ALWAYS adds PENALTY_BIAS_DRAM (its per-vocab C term, bias_mode="broadcast_N")
+            # before the on-chip argmax. The bias buffer is zero pre-gate / in --pure-greedy, so the
+            # SAME programs.bin serves plain greedy and penalty.
             total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
-                write_back_disable=True, **penalty_kwargs)
+                write_back_disable=True,
+                C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N")
 
         self.generate_instruction_halt()
         self.pad_capture_to_64b_boundary()
@@ -1135,7 +1138,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_1b_bin/programs.bin"))
         instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json"))
-        # Single programs.bin: fpga_penalty and profile modes share one output path; rebuild as needed.
+        # Single unified programs.bin (qwen3 style): the LM-head matmul always carries the penalty C
+        # bias, so one bin serves greedy (zero bias) and penalty (real bias) — no per-mode rebuild.
         self._instruction_bin_path = instruction_bin_path
         self._instruction_meta_path = instruction_meta_path
         if not profile and os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):

--- a/models/llama3.2_3b/README.md
+++ b/models/llama3.2_3b/README.md
@@ -50,8 +50,9 @@ Both scripts share `--prompt`, `--dev`, `--cycle`, and the sampling flags
 
 ```bash
 # Recompile the instruction bin (e.g. after editing the compile path)
+# One unified programs.bin serves both greedy and the on-FPGA penalty (the LM-head matmul
+# always carries the penalty C bias; greedy just zeroes it). No separate _fpgapenalty build.
 rm llama3.2_3b_bin/programs.bin llama3.2_3b_bin/programs.json
-# (and llama3.2_3b_bin/programs_fpgapenalty.{bin,json} for the on-FPGA penalty build)
 
 # Re-quantize the weight bin (from the cached HF model)
 rm llama3.2_3b_bin/params.bin llama3.2_3b_bin/params.json

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -12,11 +12,9 @@ running ``llama3.2_3b_test.py`` once on a build machine that has HF access):
   * ``params.bin``                   IF4 layer weights + bf16 embedding
   * ``params.json``                  size metadata for params.bin
   * ``programs.bin``                 unified dynamic-PBI instruction bin (prefill + decoder).
-                                     The on-FPGA repetition-penalty build is shipped as the
-                                     parallel ``programs_fpgapenalty.bin`` (separate compile;
-                                     LM-head matmul bias differs). --pure-greedy uses programs.bin.
+                                     The LM-head matmul ALWAYS carries the penalty C bias, so one
+                                     bin serves both modes: greedy zeroes the bias, penalty writes it.
   * ``programs.json``                per-stage start addresses / sizes / FLOPs
-                                     (``programs_fpgapenalty.json`` for the penalty build)
   * ``Llama-3.2-3B-Instruct/``       tokenizer files only (tokenizer.json /
                                      tokenizer_config.json). Model weights NOT needed.
 
@@ -347,14 +345,8 @@ class Llama32_3b_RunFromBin(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         meta_path = os.path.join(self.script_dir,
                                  paths_cfg.get("instruction_meta", "llama3.2_3b_bin/programs.json"))
-        if bool(getattr(self, "fpga_penalty", False)):
-            # On-FPGA penalty uses a separate bin (LM-head matmul bias on / logit writeback off);
-            # its meta points to the _fpgapenalty bin. Compiled by llama3.2_3b_test.py (default).
-            meta_path = meta_path.replace(".json", "_fpgapenalty.json")
-            if not os.path.exists(meta_path):
-                raise FileNotFoundError(
-                    f"on-FPGA penalty bin meta not found: {meta_path}\n"
-                    f"  build it with:  python llama3.2_3b_test.py")
+        # Single unified bin: the LM-head matmul always carries the penalty C bias, so greedy
+        # (zero bias) and penalty (real bias) share one programs.bin — no _fpgapenalty file.
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -510,9 +502,7 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
     """Hard-fail before any FPGA touch if a required artifact is missing."""
     paths = cfg["paths"]
     inst_bin, inst_meta = paths["instruction_bin"], paths["instruction_meta"]
-    if fpga_penalty:  # on-FPGA penalty loads the _fpgapenalty bin/meta (test.py default)
-        inst_bin = inst_bin.replace(".bin", "_fpgapenalty.bin")
-        inst_meta = inst_meta.replace(".json", "_fpgapenalty.json")
+    # Single unified bin: greedy and penalty share one programs.bin (no _fpgapenalty variant).
     required = [
         ("llama3.2_3b_config.json", "model config"),
         (paths["weights_bin"], "weight bin"),
@@ -552,12 +542,12 @@ def main():
     parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
     parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
-    # matmul bias so the HW argmax returns the penalized token directly (no logit readback); loads the
-    # _fpgapenalty bin. --pure-greedy disables it entirely (plain writeback-on bin).
+    # matmul bias so the HW argmax returns the penalized token directly (no logit readback). One
+    # unified programs.bin serves both modes; --pure-greedy just leaves the bias buffer zero.
     parser.add_argument("--pure-greedy", action="store_true",
-                        help="Disable the on-FPGA repetition penalty entirely — plain greedy decode "
-                             "(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy "
-                             "only for the A/B baseline and the compare/calibration tool.")
+                        help="Disable the on-FPGA repetition penalty — plain greedy decode (the bias "
+                             "buffer stays zero; same programs.bin). The penalty is ENABLED by default; "
+                             "use --pure-greedy only for the A/B baseline and the compare/calibration tool.")
     pen_group = parser.add_argument_group("on-FPGA repetition penalty (active unless --pure-greedy)")
     pen_group.add_argument("--greedy-until", type=int, default=512,
                         help="Pure greedy for the first N decoded tokens (correct math/reasoning), "
@@ -611,7 +601,7 @@ def main():
     ue.prefill_seq = prefill_seq
     # Decode config — deterministic, on-FPGA penalty only (no host penalty / sampling).
     ue.greedy_until = int(args.greedy_until)
-    ue.fpga_penalty = not bool(args.pure_greedy)   # selects the _fpgapenalty bin + matmul-bias path
+    ue.fpga_penalty = not bool(args.pure_greedy)   # enables the matmul-bias penalty path (runtime bias)
     ue.pen_alpha = float(args.pen_alpha)
     ue.pen_cap = float(args.pen_cap)
     ue.rep_window = int(args.rep_window)

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -970,12 +970,15 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         if layer_size == self.LAYER_SIZE:
             total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_OUTPUT_DRAM,
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
-            penalty_kwargs = dict(C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N") \
-                if bool(getattr(self, "fpga_penalty", False)) else {}
+            # LM head with the on-FPGA repetition-penalty bias folded in UNCONDITIONALLY (qwen3 style):
+            # the matmul ALWAYS adds PENALTY_BIAS_DRAM (its per-vocab C term, bias_mode="broadcast_N")
+            # before the on-chip argmax. The bias buffer is zero pre-gate / in --pure-greedy, so the
+            # SAME programs.bin serves plain greedy and penalty — no separate _fpgapenalty build.
             total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
-                write_back_disable=True, **penalty_kwargs)
+                write_back_disable=True,
+                C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N")
 
         self.generate_instruction_halt()
         self.pad_capture_to_64b_boundary()
@@ -1031,13 +1034,11 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_3b_bin/programs.bin"))
         instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/programs.json"))
-        if bool(getattr(self, "fpga_penalty", False)):
-            # On-FPGA penalty changes the LM-head matmul (bias on / writeback off) → a different bin.
-            # Separate cache file so it never clobbers the host-path bin. run_from_bin loads the same.
-            instruction_bin_path = instruction_bin_path.replace(".bin", "_fpgapenalty.bin")
-            instruction_meta_path = instruction_meta_path.replace(".json", "_fpgapenalty.json")
-            self._instruction_bin_path = instruction_bin_path
-            self._instruction_meta_path = instruction_meta_path
+        # Single unified bin (qwen3 style): the LM-head matmul always carries the penalty C bias,
+        # so one programs.bin serves both greedy (zero bias) and penalty (real bias) — no
+        # _fpgapenalty split. Record the paths so run_llama loads this same bin/meta.
+        self._instruction_bin_path = instruction_bin_path
+        self._instruction_meta_path = instruction_meta_path
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             print(f"Reusing existing instruction image at {instruction_bin_path}")
             print(f"  delete {instruction_bin_path} to force recompile.")
@@ -1149,8 +1150,8 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
         prefill or decoder program at runtime.
         """
         paths_cfg = self._cfg.get("paths", {})
-        # When fpga_penalty, compile_llama set _instruction_meta_path to the _fpgapenalty meta — use
-        # it so we load the bias bin (whose meta's instruction_bin points to the _fpgapenalty bin).
+        # compile_llama records _instruction_meta_path = the single programs.json; load it so we read
+        # the unified bin (its meta's instruction_bin points to programs.bin).
         meta_path = getattr(self, "_instruction_meta_path", None) or \
             os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_3b_bin/programs.json"))
         with open(meta_path, "r") as f:
@@ -1340,7 +1341,7 @@ def main():
     parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo).')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly (no logit readback), fully
-    # deterministic (separate _fpgapenalty bin). --pure-greedy disables it entirely.
+    # deterministic. One unified programs.bin serves both modes; --pure-greedy leaves the bias zero.
     parser.add_argument('--pure-greedy', action='store_true',
                         help='Disable the on-FPGA repetition penalty entirely — plain greedy decode '
                              '(writeback-on bin). The penalty is ENABLED by default; use --pure-greedy '

--- a/models/smolvlm2/smolvlm2_run_from_bin.py
+++ b/models/smolvlm2/smolvlm2_run_from_bin.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """SmolVLM2-500M standalone inference from pre-compiled bin files.
 
-Self-contained and OFFLINE: it loads the deployable artifacts under ``smolvlm2_bin/`` (weights.bin,
-instructions.bin, and the shipped tokenizer dir) and runs prefill + decode with no compilation and no
+Self-contained and OFFLINE: it loads the deployable artifacts under ``smolvlm2_bin/`` (params.bin,
+programs.bin, and the shipped tokenizer dir) and runs prefill + decode with no compilation and no
 network access. It does not import the build script and never downloads anything, so it can be shipped
 to a customer on its own. Generate the bins once with smolvlm2_test.py (the build/offline-prep step)."""
 import builtins
@@ -186,7 +186,7 @@ class SmolVLM2_UnifiedEngine(SmolVLM2RuntimeAttentionStateMixin, UnifiedEngine):
     def _artifact_mode_suffix(self) -> str:
         # Only the decode linear kernel changes the compiled artifacts. The repetition penalty is a pure
         # RUNTIME tensor-DRAM write (PENALTY_BIAS_DRAM, always wired as the LM-head C term with zeros =
-        # greedy), so it never affects weights.bin or instructions.bin and is not part of the suffix.
+        # greedy), so it never affects params.bin or programs.bin and is not part of the suffix.
         if bool(getattr(self, "decode_matmat_mul_core_enable", False)):
             return "_decode_matmat_mul_core"
         return ""
@@ -249,8 +249,8 @@ class SmolVLM2_UnifiedEngine(SmolVLM2RuntimeAttentionStateMixin, UnifiedEngine):
         """Load params DRAM from snapshot bin + restore all address metadata. Returns True if loaded."""
         bin_dir = os.path.join(self.script_dir, "smolvlm2_bin")
         suffix = self._artifact_mode_suffix()
-        bin_path = os.path.join(bin_dir, f"weights{suffix}.bin")
-        meta_path = os.path.join(bin_dir, f"weights{suffix}.json")
+        bin_path = os.path.join(bin_dir, f"params{suffix}.bin")
+        meta_path = os.path.join(bin_dir, f"params{suffix}.json")
         if not os.path.exists(bin_path) or not os.path.exists(meta_path):
             raise RuntimeError(
                 f"[artifact-mode] missing snapshot artifact for current mode: "
@@ -286,15 +286,15 @@ class SmolVLM2_UnifiedEngine(SmolVLM2RuntimeAttentionStateMixin, UnifiedEngine):
         (which restores params, including the shared vis_zeros LN buffer — Trick 9, no replay needed)."""
         bin_dir = os.path.join(self.script_dir, "smolvlm2_bin")
         suffix = self._artifact_mode_suffix()
-        meta_path = os.path.join(bin_dir, f"instructions{suffix}.json")
-        bin_path = os.path.join(bin_dir, f"instructions{suffix}.bin")
+        meta_path = os.path.join(bin_dir, f"programs{suffix}.json")
+        bin_path = os.path.join(bin_dir, f"programs{suffix}.bin")
         with open(meta_path) as f:
             meta = json.load(f)
         self._validate_artifact_mode(meta, os.path.basename(meta_path))
         with open(bin_path, "rb") as f:
             raw = f.read()
-        for name, entry in meta["programs"].items():
-            b = raw[entry["offset"]:entry["offset"] + entry["size"]]
+        for entry in meta["segments"]:
+            b = raw[entry["off"]:entry["off"] + entry["size"]]
             self.dma_write(DMA_DEVICE_H2C, entry["addr"], b, len(b))
         self._vis_program_addr = meta["encoder_addr"]
         self._decoder_program_addr = meta["decoder_addr"]
@@ -676,12 +676,12 @@ def main():
     snapshot_suffix = "_decode_matmat_mul_core" if args.decode_matmat_mul_core_enable else ""
     instruction_suffix = snapshot_suffix
 
-    # Check all static bins before any hardware init. SmolVLM2 now uses one instruction artifact:
-    # instructions.bin / instructions.json.
+    # Check all static bins before any hardware init. SmolVLM2 uses the unified scheme:
+    # params.bin / params.json (snapshot) + programs.bin / programs.json (instructions).
     def _missing_static_bins():
         missing = []
-        for name in (f"weights{snapshot_suffix}.bin", f"weights{snapshot_suffix}.json",
-                     f"instructions{instruction_suffix}.bin", f"instructions{instruction_suffix}.json"):
+        for name in (f"params{snapshot_suffix}.bin", f"params{snapshot_suffix}.json",
+                     f"programs{instruction_suffix}.bin", f"programs{instruction_suffix}.json"):
             if not os.path.exists(os.path.join(bin_dir, name)):
                 missing.append(name)
         return missing


### PR DESCRIPTION
…_from_bin meta schema

- llama3.2_1b/3b LM-head matmul always carries the penalty C bias (qwen3 style), so one programs.bin serves both greedy (zero bias) and penalty (real bias). Removes the llama3.2_3b programs_fpgapenalty.bin split. README + docstrings updated.
- smolvlm2_run_from_bin.py: align meta schema with test.py (params/programs naming; segments list keyed by 'off') -> fixes KeyError: 'programs'.