### PR TITLE
README: fix Hardware Architecture Update v1.2 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="update_2461830.bin">&#9881;&#65039; Hardware Architecture Update v1.2(update_2461830.bin)</a>
+  <a href="update_253d5525.bin">&#9881;&#65039; Hardware Architecture Update v1.3 (update_253d5525.bin)</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The front-page update link points at `update_2461830.bin`, which is not in the repo; the shipped firmware file is `update_253d5525.bin`, so anyone following the update flow from the README hits a 404.

The label also says v1.2, but `user_dma_core.py`'s hardware-version assert calls `0x253d5525` "public release v1.3":

```
HW version mismatch: ... Please update FPGA with commit update_253d5525.bin using update_flash.py (public release v1.3)
```

so this also relabels the link v1.2 -> v1.3 to match. One line total.