### PR TITLE
README: document all 16 supported model families

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,15 +163,23 @@ engine today; each folder has its own README/config, and most LLMs ship a
 Run the whole suite (or a subset) with the automated tester:
 
 ```bash
-make model_test run_from_bin   # all models, reusing existing compiled bins
-make model_test gemma4_e2b     # one model (clean + rebuild from the HF model)
+make model_test run_from_bin   # skip the pre-clean, reuse existing compiled bins
+make model_test gemma4_e2b     # one model
 make model_test_help           # all modes
 ```
 
-Note: without the `run_from_bin` word, `model_test` runs `make clean`
-first, which deletes cached model bins and rebuilds them from the HF
-models. On a deploy host that only has pregenerated bins (no HF models
-on disk), always use `make model_test run_from_bin`.
+Notes on the two modes:
+
+- Without the `run_from_bin` word, `model_test` runs `make clean` first,
+  which deletes cached model bins and rebuilds everything from the HF
+  models (slow; needs the HF models available).
+- `run_from_bin` skips the pre-clean so models with a
+  `*_run_from_bin.py` runtime (the LLM/VLM rows above) reuse their bins.
+  gemma3, gpt2 and the vision/speech models have no runtime-only entry
+  yet and still run through their `*_test.py` scripts, which need their
+  model assets on disk. On a deploy host that only has pregenerated
+  bins, run the runtime-only subset by name, e.g.
+  `make model_test gemma4_e2b llama3.2_1b qwen3_4b run_from_bin`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -163,10 +163,15 @@ engine today; each folder has its own README/config, and most LLMs ship a
 Run the whole suite (or a subset) with the automated tester:
 
 ```bash
-make model_test              # all models, concise PASS/FAIL summary
-make model_test gemma4_e2b   # one model
-make model_test_help         # all modes
+make model_test run_from_bin   # all models, reusing existing compiled bins
+make model_test gemma4_e2b     # one model (clean + rebuild from the HF model)
+make model_test_help           # all modes
 ```
+
+Note: without the `run_from_bin` word, `model_test` runs `make clean`
+first, which deletes cached model bins and rebuilds them from the HF
+models. On a deploy host that only has pregenerated bins (no HF models
+on disk), always use `make model_test run_from_bin`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,41 @@ Cold reboot the PC.
 
 ---
 
+## Supported Models
+
+Gemma3 above is just the quick-start example. Every model below runs on the
+engine today; each folder has its own README/config, and most LLMs ship a
+`*_run_from_bin.py` for execute-only deploys from precompiled bins.
+
+| Model | Folder | Type |
+|---|---|---|
+| Gemma 3 1B | [`models/gemma3`](models/gemma3) | Text LM |
+| Gemma 4 E2B | [`models/gemma4_e2b`](models/gemma4_e2b) | Multimodal LM (text, vision, audio) |
+| Gemma 4 E4B | [`models/gemma4_e4b`](models/gemma4_e4b) | Multimodal LM (text, vision, audio) |
+| Llama 3.2 1B | [`models/llama3.2_1b`](models/llama3.2_1b) | Text LM |
+| Llama 3.2 3B | [`models/llama3.2_3b`](models/llama3.2_3b) | Text LM |
+| Qwen3 1.7B | [`models/qwen3_1.7b`](models/qwen3_1.7b) | Text LM |
+| Qwen3 4B | [`models/qwen3_4b`](models/qwen3_4b) | Text LM |
+| Qwen3.5 2B | [`models/qwen3.5_2b`](models/qwen3.5_2b) | Text LM |
+| Qwen2.5-VL 3B | [`models/qwen2.5_vl_3b`](models/qwen2.5_vl_3b) | Vision-language |
+| SmolVLM2 | [`models/smolvlm2`](models/smolvlm2) | Vision-language |
+| GPT-2 | [`models/gpt2`](models/gpt2) | Text LM |
+| LocateAnything 3B | [`models/locateanything_3b`](models/locateanything_3b) | Open-vocabulary localization |
+| MobileNetV2 (224 + SSD-FPNLite 640) | [`models/mobilenetv2`](models/mobilenetv2) | Classification / detection |
+| Parakeet | [`models/parakeet`](models/parakeet) | Speech recognition (incl. streaming) |
+| MobileSAM | [`models/mobilesam`](models/mobilesam) | Segmentation |
+| Swin | [`models/swin`](models/swin) | Image classification |
+
+Run the whole suite (or a subset) with the automated tester:
+
+```bash
+make model_test              # all models, concise PASS/FAIL summary
+make model_test gemma4_e2b   # one model
+make model_test_help         # all modes
+```
+
+---
+
 ## Apex Compute Unified Engine v1.1 — Benchmark Results
 
 All benchmarks were collected on RTL running on a Kintex UltraScale+ FPGA in real time.


### PR DESCRIPTION
The README's inference section only walks through Gemma3, but the repo ships runnable ports of Gemma 4 E2B/E4B (multimodal), Llama 3.2 1B/3B, Qwen3 1.7B/4B, Qwen3.5 2B, Qwen2.5-VL, SmolVLM2, GPT-2, LocateAnything, MobileNetV2, Parakeet, MobileSAM and Swin - a much stronger story than the front page tells.

Adds a Supported Models table (folder links + modality) between the setup guide and the benchmark section, and points at `make model_test` / `make model_test_help` for the automated suite. Model names taken from `model_auto_test.py --list-names`.