### PR TITLE
docs: point model READMEs at real repo paths and current artifact names

### DIFF
--- a/models/gemma4_e2b/README.md
+++ b/models/gemma4_e2b/README.md
@@ -7,7 +7,7 @@ text (VLM), and audio + text — run from a single instruction bin.
 
 | Stage | Script | Notes |
 |---|---|---|
-| Build (once) | `gemma4_e2b_test.py` | Builds `gemma4_instruction.bin` + `weights_gemma4_e2b_hf.bin`, then sanity-runs. Needs the HF model locally. Default build includes LM + VLM + audio unless `GEMMA4_LM_ONLY_BIN=1`. |
+| Build (once) | `gemma4_e2b_test.py` | Builds `programs.bin` + `params.bin`, then sanity-runs. Needs the HF model locally. Default build includes LM + VLM + audio unless `GEMMA4_LM_ONLY_BIN=1`. |
 | Deploy (every run after) | `gemma4_e2b_run_from_bin.py` | Loads the bin files and runs. Never touches the HF model. |
 
 After the first `gemma4_e2b_test.py` run, every subsequent invocation
@@ -21,11 +21,11 @@ After the first `gemma4_e2b_test.py` run, every subsequent invocation
   refuses to compile, no HF model on disk required.
 - **gemma4_e2b_config.json** – Model + layout config.
 - **gemma4_e2b_bin/** – On-disk artifacts:
-  - `gemma4_instruction.bin` + `.json` – unified ISA. Full multimodal bin
+  - `programs.bin` + `.json` – unified ISA. Full multimodal bin
     is 14.39 MiB on disk (15,086,688 B): LM prefill + decode + vision
     + audio encoders + vision RoPE tables. Used size by mode: LM-only
     5.78 MiB, VLM 7.24 MiB, audio 12.93 MiB.
-  - `weights_gemma4_e2b_hf.bin` + `.json` – combined weights (~7 GB)
+  - `params.bin` – combined weights (~7 GB)
     with sections: `[LM | vision | audio | host]`.
   - `tokenizer/` – minimal tokenizer + processor configs (~32 MB).
 
@@ -42,16 +42,16 @@ After the first `gemma4_e2b_test.py` run, every subsequent invocation
 
 ```bash
 # VLM (recommended first run — builds vision encoder into the bin)
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py --vision-enable
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py --image my.jpg --prompt "?"
+python models/gemma4_e2b/gemma4_e2b_test.py --vision-enable
+python models/gemma4_e2b/gemma4_e2b_test.py --image my.jpg --prompt "?"
 
 # Audio
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py --audio-enable
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py --audio my.wav --prompt "Describe this audio."
+python models/gemma4_e2b/gemma4_e2b_test.py --audio-enable
+python models/gemma4_e2b/gemma4_e2b_test.py --audio my.wav --prompt "Describe this audio."
 
 # LM only
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py --prompt "What is 2+2?"
+python models/gemma4_e2b/gemma4_e2b_test.py
+python models/gemma4_e2b/gemma4_e2b_test.py --prompt "What is 2+2?"
 ```
 
 The first run builds the instruction bin and combined weight bin. Subsequent
@@ -60,9 +60,9 @@ runs just load and execute.
 Force a clean rebuild:
 
 ```bash
-rm gemma4_e2b_bin/gemma4_instruction.bin gemma4_e2b_bin/gemma4_instruction.json
-rm gemma4_e2b_bin/weights_gemma4_e2b_hf.bin gemma4_e2b_bin/weights_gemma4_e2b_hf.json
-python src/template/models/gemma4_e2b/gemma4_e2b_test.py --vision-enable
+rm models/gemma4_e2b/gemma4_e2b_bin/programs.bin models/gemma4_e2b/gemma4_e2b_bin/programs.json
+rm models/gemma4_e2b/gemma4_e2b_bin/params.bin
+python models/gemma4_e2b/gemma4_e2b_test.py --vision-enable
 ```
 
 ## Deploy / demo — `gemma4_e2b_run_from_bin.py`
@@ -71,16 +71,16 @@ Execute-only. Refuses to compile, never imports the HF model class.
 
 ```bash
 # LM
-python src/template/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
-python src/template/models/gemma4_e2b/gemma4_e2b_run_from_bin.py --prompt "What is 2+2?"
+python models/gemma4_e2b/gemma4_e2b_run_from_bin.py
+python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --prompt "What is 2+2?"
 
 # VLM
-python src/template/models/gemma4_e2b/gemma4_e2b_run_from_bin.py --vision-enable
-python src/template/models/gemma4_e2b/gemma4_e2b_run_from_bin.py --image my.jpg --prompt "?"
+python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --vision-enable
+python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --image my.jpg --prompt "?"
 
 # Audio
-python src/template/models/gemma4_e2b/gemma4_e2b_run_from_bin.py --audio-enable
-python src/template/models/gemma4_e2b/gemma4_e2b_run_from_bin.py --audio my.wav --prompt "Describe this audio."
+python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --audio-enable
+python models/gemma4_e2b/gemma4_e2b_run_from_bin.py --audio my.wav --prompt "Describe this audio."
 ```
 
 ### Deploy footprint
@@ -90,8 +90,8 @@ gemma4_e2b_run_from_bin.py
 gemma4_e2b_config.json
 user_dma_core.py + quant_lib.py
 gemma4_e2b_bin/
-  gemma4_instruction.bin + .json       (14.39 MiB full multimodal)
-  weights_gemma4_e2b_hf.bin  + .json   (~7 GB; LM + vision + audio + host sections)
+  programs.bin + .json       (14.39 MiB full multimodal)
+  params.bin   (~7 GB; LM + vision + audio + host sections)
   tokenizer/                           (~32 MB)
 ```
 
@@ -123,4 +123,4 @@ no per-bucket ISA copies):
 
 Both knobs live in `gemma4_e2b_config.json`. Increasing
 `prefill_max_seq_len` linearly grows the prefill ISA in
-`gemma4_instruction.bin`; the decoder bin size is fixed.
+`programs.bin`; the decoder bin size is fixed.

--- a/models/gemma4_e4b/README.md
+++ b/models/gemma4_e4b/README.md
@@ -14,7 +14,7 @@ opt-in (`GEMMA4_E4B_ALLOW_ENCODER=1` with `--vision-enable`/`--audio-enable`).
 
 | Stage | Script | Notes |
 |---|---|---|
-| Build (once) | `gemma4_e4b_test.py` | Builds `gemma4_instruction.bin` + `weights_gemma4_e4b_hf.bin`, then sanity-runs. Needs the HF model locally. Default build is LM-only; set `GEMMA4_LM_ONLY_BIN=0` and `GEMMA4_E4B_ALLOW_ENCODER=1` to build/test encoder modes. |
+| Build (once) | `gemma4_e4b_test.py` | Builds `programs.bin` + `params.bin`, then sanity-runs. Needs the HF model locally. Default build is LM-only; set `GEMMA4_LM_ONLY_BIN=0` and `GEMMA4_E4B_ALLOW_ENCODER=1` to build/test encoder modes. |
 | Deploy (every run after) | `gemma4_e4b_run_from_bin.py` | Loads the bin files and runs. Never touches the HF model. |
 
 After the first `gemma4_e4b_test.py` run, every subsequent invocation
@@ -28,11 +28,11 @@ After the first `gemma4_e4b_test.py` run, every subsequent invocation
   refuses to compile, no HF model on disk required.
 - **gemma4_e4b_config.json** – Model + layout config.
 - **gemma4_e4b_bin/** – On-disk artifacts:
-  - `gemma4_instruction.bin` + `.json` – instruction ISA. Full multimodal
+  - `programs.bin` + `.json` – instruction ISA. Full multimodal
     bin is 15.02 MiB on disk (15,746,912 B): LM prefill + decode + vision
     + audio encoders + vision RoPE tables. Used size by mode: LM-only
     6.38 MiB, VLM 7.84 MiB, audio 13.56 MiB.
-  - `weights_gemma4_e4b_hf.bin` + `.json` – combined weights (~10 GB)
+  - `params.bin` – combined weights (~10 GB)
     with sections: `[LM | vision | audio | host]`.
   - `tokenizer/` – minimal tokenizer + processor configs (~32 MB).
 
@@ -47,14 +47,14 @@ After the first `gemma4_e4b_test.py` run, every subsequent invocation
 ## Build / sanity-check — `gemma4_e4b_test.py`
 
 ```bash
-python src/template/models/gemma4_e4b/gemma4_e4b_test.py
-python src/template/models/gemma4_e4b/gemma4_e4b_test.py --prompt "What is 2+2?"
+python models/gemma4_e4b/gemma4_e4b_test.py
+python models/gemma4_e4b/gemma4_e4b_test.py --prompt "What is 2+2?"
 
 # Build/test encoder modes into the unified bin
 GEMMA4_LM_ONLY_BIN=0 GEMMA4_E4B_ALLOW_ENCODER=1 \
-  python src/template/models/gemma4_e4b/gemma4_e4b_test.py --vision-enable
+  python models/gemma4_e4b/gemma4_e4b_test.py --vision-enable
 GEMMA4_LM_ONLY_BIN=0 GEMMA4_E4B_ALLOW_ENCODER=1 \
-  python src/template/models/gemma4_e4b/gemma4_e4b_test.py --audio-enable
+  python models/gemma4_e4b/gemma4_e4b_test.py --audio-enable
 ```
 
 First run builds the instruction bin and combined weight bin. Subsequent
@@ -63,9 +63,9 @@ runs just load and execute.
 Force a clean rebuild:
 
 ```bash
-rm gemma4_e4b_bin/gemma4_instruction.bin gemma4_e4b_bin/gemma4_instruction.json
-rm gemma4_e4b_bin/weights_gemma4_e4b_hf.bin gemma4_e4b_bin/weights_gemma4_e4b_hf.json
-python src/template/models/gemma4_e4b/gemma4_e4b_test.py
+rm models/gemma4_e4b/gemma4_e4b_bin/programs.bin models/gemma4_e4b/gemma4_e4b_bin/programs.json
+rm models/gemma4_e4b/gemma4_e4b_bin/params.bin
+python models/gemma4_e4b/gemma4_e4b_test.py
 ```
 
 ## Deploy / demo — `gemma4_e4b_run_from_bin.py`
@@ -73,14 +73,14 @@ python src/template/models/gemma4_e4b/gemma4_e4b_test.py
 Execute-only. Refuses to compile, never imports the HF model class.
 
 ```bash
-python src/template/models/gemma4_e4b/gemma4_e4b_run_from_bin.py
-python src/template/models/gemma4_e4b/gemma4_e4b_run_from_bin.py --prompt "What is 2+2?"
+python models/gemma4_e4b/gemma4_e4b_run_from_bin.py
+python models/gemma4_e4b/gemma4_e4b_run_from_bin.py --prompt "What is 2+2?"
 
 # Encoder modes require an encoder-containing bin and the runtime gate.
 GEMMA4_E4B_ALLOW_ENCODER=1 GEMMA4_PENALTY=1 \
-  python src/template/models/gemma4_e4b/gemma4_e4b_run_from_bin.py --vision-enable
+  python models/gemma4_e4b/gemma4_e4b_run_from_bin.py --vision-enable
 GEMMA4_E4B_ALLOW_ENCODER=1 GEMMA4_PENALTY=1 \
-  python src/template/models/gemma4_e4b/gemma4_e4b_run_from_bin.py --audio-enable
+  python models/gemma4_e4b/gemma4_e4b_run_from_bin.py --audio-enable
 ```
 
 ### Deploy footprint
@@ -90,8 +90,8 @@ gemma4_e4b_run_from_bin.py
 gemma4_e4b_config.json
 user_dma_core.py + quant_lib.py
 gemma4_e4b_bin/
-  gemma4_instruction.bin + .json       (15.02 MiB full multimodal)
-  weights_gemma4_e4b_hf.bin  + .json   (~10 GB; LM + vision + audio + host sections)
+  programs.bin + .json       (15.02 MiB full multimodal)
+  params.bin   (~10 GB; LM + vision + audio + host sections)
   tokenizer/                           (~32 MB)
 ```
 

--- a/models/gpt2/gpt2_test.py
+++ b/models/gpt2/gpt2_test.py
@@ -3,7 +3,7 @@
 GPT-2 Base (124M) inference on accelerator: prefill + decode.
 
   - Config from gpt2_config.json; weights from a single bin (see below).
-  - Dynamic-PBI flow (see src/template/core_changes.md): ONE prefill program +
+  - Dynamic-PBI flow: ONE prefill program +
     ONE decoder program compiled into a single instruction bin. Runtime row
     counts and attention bucket selection are driven by fixed-index GPRs
     (gpr_seq_len / gpr_bucket_idx) primed by a tiny per-call preamble program.

--- a/models/qwen2.5_vl_3b/qwen2.5_vl_3b_test.py
+++ b/models/qwen2.5_vl_3b/qwen2.5_vl_3b_test.py
@@ -4,7 +4,7 @@ config-driven via qwen2.5_vl_3b_config.json::precision.{lm,vision}
 (values: int4 / fp4 / if4). Defaults: lm=if4 (eval-winning text codec
 per src/models/qwen2.5_VL_3b/compare/summary.md), vision=int4 (legacy
 released codec, byte-identical to the prior Q4_64 path). All
-quantization goes through src/template/quant_lib.py."""
+quantization goes through quant_lib.py."""
 
 import json
 import math

--- a/models/qwen3.5_2b/qwen3.5_2b_test.py
+++ b/models/qwen3.5_2b/qwen3.5_2b_test.py
@@ -50,7 +50,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-# user_dma_core lives at src/template/ — add that to path.
+# user_dma_core lives at the repo root — add that to path.
 _THIS = Path(__file__).resolve()
 sys.path.insert(0, str(_THIS.parents[2]))
 
@@ -4690,7 +4690,7 @@ def main():
                     help="Path to image file for VLM inference. Implies --vision-enable.")
     ap.add_argument("--vision-enable", action="store_true",
                     help="Run as VLM using the default sample image "
-                         "(src/template/test_samples/yosemite.jpg). "
+                         "(test_samples/yosemite.jpg). "
                          "Ignored if --image is also given.")
     ap.add_argument("--vision-on-hardware", action="store_true",
                     help="Run the vision encoder on FPGA. By default the vision "

--- a/models/qwen3_1.7b/README.md
+++ b/models/qwen3_1.7b/README.md
@@ -15,16 +15,16 @@ Qwen3-1.7B inference on the accelerator.
 
 - Run from the **repo root** so `user_dma_core` is on `sys.path`.
 - Python with `torch`, `transformers`, and DMA access (`/dev/xdma0_*`).
-- Between runs that may have left the FPGA in a bad state: `python src/template/user_hw_test.py` (software reset).
+- Between runs that may have left the FPGA in a bad state: `python user_hw_test.py` (software reset).
 
 ## Usage
 
 ```bash
 # First run (with network — downloads HF model, builds weight + instruction bins):
-python src/template/models/qwen3_1.7b/qwen3_1.7b_test.py --prompt "What is 2+2?"
+python models/qwen3_1.7b/qwen3_1.7b_test.py --prompt "What is 2+2?"
 
 # Subsequent runs from cached bins (offline-safe):
-python src/template/models/qwen3_1.7b/qwen3_1.7b_run_from_bin.py --prompt "What is 2+2?"
+python models/qwen3_1.7b/qwen3_1.7b_run_from_bin.py --prompt "What is 2+2?"
 ```
 
 **Prompt-length range:** the cached bin handles any prompt from 1 to
@@ -62,8 +62,3 @@ Decoder done in ~8.4s, total 38 tokens, decode speed: ~2.7 tokens/s.
 ```
 
 Prefill reports about 19.9 GFLOPS at 5.62 ns clock (~87 % of 22.8 GFLOPS peak).
-
-## More detail
-
-Design and architecture notes: `src/template/notes/notes_qwen3_1.7b.md`.
-Cross-model dynamic-PBI design that these scripts implement: `src/template/core_changes.md`.

--- a/models/qwen3_4b/README.md
+++ b/models/qwen3_4b/README.md
@@ -15,16 +15,16 @@ Qwen3-4B inference on the accelerator.
 
 - Run from the **repo root** so `user_dma_core` is on `sys.path`.
 - Python with `torch`, `transformers`, and DMA access (`/dev/xdma0_*`).
-- Between runs that may have left the FPGA in a bad state: `python src/template/user_hw_test.py` (software reset).
+- Between runs that may have left the FPGA in a bad state: `python user_hw_test.py` (software reset).
 
 ## Usage
 
 ```bash
 # First run (with network — downloads HF model, builds weight + instruction bins):
-python src/template/models/qwen3_4b/qwen3_4b_test.py --prompt "What is 2+2?"
+python models/qwen3_4b/qwen3_4b_test.py --prompt "What is 2+2?"
 
 # Subsequent runs from cached bins (offline-safe):
-python src/template/models/qwen3_4b/qwen3_4b_run_from_bin.py --prompt "What is 2+2?"
+python models/qwen3_4b/qwen3_4b_run_from_bin.py --prompt "What is 2+2?"
 ```
 
 **Prompt-length range:** the cached bin handles any prompt from 1 to
@@ -70,8 +70,3 @@ Prefill reports about **20.12 GFLOPS** at 5.62 ns clock (~88 % of 22.8 GFLOPS pe
 - Tensor DRAM: **730 MB** (KV cache 288 MB + activations 442 MB).
 - Program DRAM: **58 MB** (one prefill + one decoder program).
 - Host: 778 MB bf16 embedding stays in CPU RAM (per-token row pushed inline).
-
-## More detail
-
-Design and architecture notes: `src/template/notes/notes_qwen3_4b.md`.
-Cross-model dynamic-PBI design that these scripts implement: `src/template/core_changes.md`.

--- a/models/smolvlm2/README.md
+++ b/models/smolvlm2/README.md
@@ -21,7 +21,7 @@ permute elimination, single bin, encoder layer-body sharing, prefill GEMM kernel
 
 ## Prerequisites
 
-- `user_dma_core` is on the path automatically (the scripts self-insert `src/template`), so they run
+- `user_dma_core` is on the path automatically (the scripts put the repo root on `sys.path`), so they run
   from any working directory.
 - Python with `torch`, `transformers`, and DMA device access. The first run downloads the HF model.
 


### PR DESCRIPTION
Several model READMEs still carry paths from an internal layout that does not exist in this repo, so the documented commands fail verbatim:

- run commands used `python src/template/models/...` - fixed to `python models/...` (run from repo root), and `src/template/user_hw_test.py` -> `user_hw_test.py` (gemma4_e2b, gemma4_e4b, qwen3_1.7b, qwen3_4b)
- gemma4_e2b / gemma4_e4b READMEs referenced pre-rename artifacts (`gemma4_instruction.bin`, `weights_*_hf.bin`); today the build writes `programs.bin/.json` + `params.bin` and `*_run_from_bin.py` refuses to start without them, so the documented clean-rebuild `rm` commands deleted nothing. Renamed throughout and fixed the `rm` paths to be repo-root relative
- qwen3_1.7b / qwen3_4b linked internal-only notes files (`notes_*.md`, `core_changes.md`) not present in the repo - dropped
- smolvlm2 / qwen3.5_2b / gpt2 / qwen2.5_vl: reworded remaining `src/template` comment references

Docs plus comments only; the touched .py files still byte-compile.