### PR TITLE
gemma4: fix stale --cycle help text and argparse descriptions

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
+++ b/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
@@ -7621,7 +7621,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Gemma4 E2B layer-0 prefill: run on accelerator, verify with torch ref.")
+    parser = argparse.ArgumentParser(description="Gemma4 E2B on the Unified Engine: execute-only inference from the precompiled bins.")
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt. Default is a built-in prompt per mode "
                              "(LM: a test question; VLM: 'Describe this image in detail.'; "
@@ -7650,7 +7650,7 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
     parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+                        help='Clock cycle time in nanoseconds (default: 5.62; use 2.5 for Alveo)')
     args = parser.parse_args()
 
     set_dma_device(args.dev)

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -9163,7 +9163,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Gemma4 E2B layer-0 prefill: run on accelerator, verify with torch ref.")
+    parser = argparse.ArgumentParser(description="Gemma4 E2B on the Unified Engine: build the instruction/weight bins if missing, then run prefill + decode.")
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt. Default is a built-in prompt per mode "
                              "(LM: a test question; VLM: 'Describe this image in detail.'; "
@@ -9192,7 +9192,7 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
     parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+                        help='Clock cycle time in nanoseconds (default: 5.62; use 2.5 for Alveo)')
     args = parser.parse_args()
 
     set_dma_device(args.dev)

--- a/models/gemma4_e4b/gemma4_e4b_run_from_bin.py
+++ b/models/gemma4_e4b/gemma4_e4b_run_from_bin.py
@@ -7372,7 +7372,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Gemma4 E4B layer-0 prefill: run on accelerator, verify with torch ref.")
+    parser = argparse.ArgumentParser(description="Gemma4 E4B on the Unified Engine: execute-only inference from the precompiled bins.")
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt. Default is a built-in prompt per mode "
                              "(LM: a test question; VLM: 'Describe this image in detail.'; "
@@ -7400,7 +7400,7 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
     parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+                        help='Clock cycle time in nanoseconds (default: 5.62; use 2.5 for Alveo)')
     args = parser.parse_args()
 
     set_dma_device(args.dev)

--- a/models/gemma4_e4b/gemma4_e4b_test.py
+++ b/models/gemma4_e4b/gemma4_e4b_test.py
@@ -9258,7 +9258,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Gemma4 E4B layer-0 prefill: run on accelerator, verify with torch ref.")
+    parser = argparse.ArgumentParser(description="Gemma4 E4B on the Unified Engine: build the instruction/weight bins if missing, then run prefill + decode.")
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt. Default is a built-in prompt per mode "
                              "(LM: a test question; VLM: 'Describe this image in detail.'; "
@@ -9286,7 +9286,7 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0',
                         help='DMA device name (e.g., xdma0, xdma1). Default: xdma0')
     parser.add_argument('--cycle', type=float, default=5.62,
-                        help='Clock cycle time in nanoseconds (default: 3.0, use 2.5 for alveo)')
+                        help='Clock cycle time in nanoseconds (default: 5.62; use 2.5 for Alveo)')
     args = parser.parse_args()
 
     set_dma_device(args.dev)


### PR DESCRIPTION
In all four Gemma 4 scripts (e2b/e4b x test/run_from_bin):

- `--cycle` help says "default: 3.0" but the actual default is 5.62, so users who read the help and want the default behavior get contradictory information
- the parser descriptions still describe the original bring-up ("layer-0 prefill: run on accelerator, verify with torch ref") rather than what the scripts do now (full build+run, or execute-only inference from precompiled bins)

Help-text only, no behavior change.