### PR TITLE
gemma4: make run_decoder's no-token path an explicit error

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
+++ b/models/gemma4_e2b/gemma4_e2b_run_from_bin.py
@@ -7469,15 +7469,14 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         self.seq_len = actual_seq_len
         return latency, flop_rate
 
-    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> dict:
+    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> tuple[int, float, float]:
         """Run decode loop with dynamic PBI.
 
         Single decoder program — gpr_seq_len primed ONCE; program self-advances
         via trailing add_inc. gpr_bucket_idx re-set each step.
         """
         if token_id is None:
-            print("No last token available for decode.")
-            return {}
+            raise ValueError("run_decoder called with token_id=None (no last prompt token)")
 
         global _SILENT_MODE
         max_seq_len = self.MAX_CONTEXT_SIZE

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -9001,7 +9001,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         self.seq_len = actual_seq_len
         return latency, flop_rate
 
-    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> dict:
+    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> tuple[int, float, float]:
         """Run decode loop with dynamic PBI.
 
         Single decoder program — same address every token. gpr_seq_len is
@@ -9012,8 +9012,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         UE_VECTOR_SIZE boundary).
         """
         if token_id is None:
-            print("No last token available for decode.")
-            return {}
+            raise ValueError("run_decoder called with token_id=None (no last prompt token)")
 
         global _SILENT_MODE
         max_seq_len = self.MAX_CONTEXT_SIZE

--- a/models/gemma4_e4b/gemma4_e4b_run_from_bin.py
+++ b/models/gemma4_e4b/gemma4_e4b_run_from_bin.py
@@ -7215,11 +7215,10 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         self.seq_len = actual_seq_len
         return latency, flop_rate
 
-    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> dict:
+    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> tuple[int, float, float]:
         """Dynamic-PBI decoder loop (E4B run_from_bin)."""
         if token_id is None:
-            print("No last token available for decode.")
-            return {}
+            raise ValueError("run_decoder called with token_id=None (no last prompt token)")
 
         global _SILENT_MODE
         max_seq_len = self.MAX_CONTEXT_SIZE

--- a/models/gemma4_e4b/gemma4_e4b_test.py
+++ b/models/gemma4_e4b/gemma4_e4b_test.py
@@ -9029,11 +9029,10 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 
         return latency, flop_rate
 
-    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> dict:
+    def run_decoder(self, decoder_program_sizes: list[int], decoder_base_addr: int, token_id: int, flops_per_token: list[int] | None = None) -> tuple[int, float, float]:
         """Run decode loop with dynamic PBI (E4B). Single decoder program."""
         if token_id is None:
-            print("No last token available for decode.")
-            return {}
+            raise ValueError("run_decoder called with token_id=None (no last prompt token)")
 
         global _SILENT_MODE
         max_seq_len = self.MAX_CONTEXT_SIZE


### PR DESCRIPTION
`run_decoder` is annotated `-> dict` and returns `{}` when `token_id` is None, but every call site unpacks a `(seq_len, latency, flop_rate)` tuple:

```python
token_cnt_decoded, latency_hw_decoder, flop_rate_hw_decoder = ue.run_decoder(...)
```

so that early-return path can only ever crash at the caller with an opaque "cannot unpack" error. Raise a clear ValueError at the source instead, and fix the annotation to the real return type. Applied to all four copies (e2b/e4b x test/run_from_bin).