### PR TITLE
requirements: raise transformers floor to 5.5.0 to match the models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 torch>=2.4
-torchvision>=0.23.0
-torchaudio>=2.4
+torchvision>=0.23.0   # vision models (qwen2.5_vl, smolvlm2, mobilesam, swin, ...)
+torchaudio>=2.4       # speech models (parakeet, gemma4 audio mode)
 soundfile
 numpy<2
-transformers>=4.40.0
+transformers>=5.5.0   # gemma4_e2b/e4b and qwen3.5_2b need >= 5.5.0 (see model READMEs)
 huggingface-hub>=0.20.0
 pillow>=12.1.1
 sentencepiece

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ torchvision>=0.23.0   # vision models (qwen2.5_vl, smolvlm2, mobilesam, swin, ..
 torchaudio>=2.4       # speech models (parakeet, gemma4 audio mode)
 soundfile
 numpy<2
-transformers>=5.5.0   # gemma4_e2b/e4b and qwen3.5_2b need >= 5.5.0 (see model READMEs)
+transformers>=5.5.0,<5.13   # gemma4/qwen3.5 need >= 5.5.0; 5.13 restructures Gemma4TextAttention (no k_proj/v_proj submodules) and breaks weight_bin_generate
 huggingface-hub>=0.20.0
 pillow>=12.1.1
 sentencepiece


### PR DESCRIPTION
`requirements.txt` pins `transformers>=4.40.0`, but the Gemma 4 E2B/E4B READMEs require `transformers >= 5.5.0` (and Qwen3.5 is in the same boat), so a fresh `pip install -r requirements.txt` can resolve to an environment the newer models fail on. Raise the floor to match what the models actually need, annotate which model families pull in torchvision/torchaudio, and add the missing trailing newline.

If you want to keep older-transformers workflows installable, an alternative is per-model extras - happy to rework it that way instead.