### PR TITLE
build: add .gitignore; clean gemma4 and qwen3.5 bins in 'make clean'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+
+# Model build artifacts (rebuilt by models/*/*_test.py)
+models/*/*_bin/
+model_test_bg.out
+model_auto_test_results.txt
+
+# Vivado / flash programming
+*.mcs
+*.prm
+*.jou
+*.log
+andromeda_IP-*/
+andromeda_wrapper-*/
+
+# Editors / OS
+.DS_Store
+.vscode/
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ clean:
 	rm -f models/llama3.2_1b/llama3.2_1b_bin/llama_instruction*
 	rm -f models/llama3.2_1b/llama3.2_1b_bin/llama_profile_instruction*
 	rm -f models/llama3.2_3b/llama3.2_3b_bin/llama3.2_3b_instruction_fpgapenalty.bin
+	rm -f models/gemma4_e2b/gemma4_e2b_bin/programs.* models/gemma4_e2b/gemma4_e2b_bin/params.*
+	rm -f models/gemma4_e4b/gemma4_e4b_bin/programs.* models/gemma4_e4b/gemma4_e4b_bin/params.*
+	rm -f models/qwen3.5_2b/qwen3.5_2b_bin/programs.* models/qwen3.5_2b/qwen3.5_2b_bin/params.*
 	# rm -f models/locateanything_3b/locateanything_3b_bin/
 	rm -rf models/mobilesam/mobilesam_bin/
 	rm -f models/parakeet/parakeet_bin/*.bin


### PR DESCRIPTION
`make model_test` runs `clean` first specifically so stale bins cannot poison a run, but the clean target predates gemma4_e2b, gemma4_e4b and qwen3.5_2b - their compiled `programs.*` / `params.*` survived cleans and got reused across code versions (exactly the cached-state class of bug the pre-clean is there to prevent; `INSTRUCTION_BIN_COMPILE_VERSION` catches layout bumps but not same-version recompiles).

Also adds a `.gitignore` covering Python caches, model bin outputs, Vivado run droppings (`*.jou`/`*.log`/`*.mcs`/`*.prm`), and editor/OS files, so future contributor diffs stay clean.