### PR TITLE
cleanup: drop accidental re imports, fix stale core docstring

### DIFF
--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -1715,7 +1715,7 @@ def main():
     print(f"  USER: {DMA_DEVICE_USER}")
 
     dual_engine = args.dual_engine
-    assert dual_engine == False, (
+    assert not dual_engine, (
         "Dual-engine Gemma3 PBI is not verified end-to-end yet; compile preserves sharding hooks for "
         "future work. Re-run without --dual-engine until validation lands."
     )

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -1534,7 +1534,7 @@ def main():
     print(f"  USER: {DMA_DEVICE_USER}")
 
     dual_engine = args.dual_engine
-    assert dual_engine == False, "Dual engine is not supported yet for pbi mode"
+    assert not dual_engine, "Dual engine is not supported yet for pbi mode"
     ue = Gemma3_UnifiedEngine(local_weights=args.local_weights, dual_engine=dual_engine)
     ue.set_prefill_seq(args.prompt)
 

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -9,8 +9,8 @@ This module provides:
 - High-level engine APIs built on them (eltwise_add, matmat_mul, ...)
 - ``ue_35bit_addr_shifter()``: byte DRAM address to 35-bit word address for UE registers / captured instructions
 
-For tests and bf16 helpers (precompute_freqs_cis, calculate_snr, generic_tests),
-use user_dma_tests_bf16 or the combined user_dma_ops.
+For end-to-end usage see user_hw_test.py and the per-model scripts under
+models/ (e.g. models/gemma3/gemma3_test.py), which drive UnifiedEngine directly.
 
 Usage:
     from user_dma_core import UnifiedEngine, UE_MODE, DRAM_ACTIVATION_ADDR, ue_35bit_addr_shifter
@@ -19,7 +19,6 @@ Usage:
     result = handler(vec1, vec2)
 """
 
-from re import U
 import struct
 import os
 import sys

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -13,7 +13,6 @@ import atexit
 import math
 import os
 import random
-from re import S
 import time
 import threading
 from read_trace import generate_trace


### PR DESCRIPTION
- `user_dma_core.py` had `from re import U` and `user_hw_test.py` had `from re import S` - editor auto-import artifacts, both unused
- `user_dma_core.py`'s module docstring pointed readers at `user_dma_tests_bf16` / `user_dma_ops`, which are not in this repo; point at `user_hw_test.py` and the `models/` scripts instead
- gemma3: `assert x == False` -> `assert not x` (two spots)

No behavior change; all touched files byte-compile.