### PR TITLE
sync pcie_only 06329e07

### DIFF
--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -803,7 +803,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x93ffa0c8, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x93ffa0c8. Please update FPGA with commit update_93ffa0c8.bin using update_flash.py (public release v1.42)"
+        assert hw_version == 0x06329e07, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x06329e07. Please update FPGA with commit update_06329e07.bin using update_flash.py (public release v1.1)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address


### PR DESCRIPTION
Automated sync from `apex-compute/andromeda` @ `06329e07` (branch `pcie_only`).

Synced files (library + gemma3 reference only):
`user_dma_core.py`, `user_hw_test.py`, `models/gemma3/gemma3_test.py`,
`models/gemma3/gemma3_test_IF8.py`, `models/gemma3/gemma3_config.json`

Verified on hardware by the PCIe nightly: the FPGA was flashed with the
bitstream built from this same commit (so `hw_version == 0x06329e07` matches
the board), then `make clean` + `model_auto_test.py` across the full model
suite — **passed**.

Before merging: attach the encrypted `update_06329e07.bin`. This PR
intentionally ships no bitstream, so merging without it leaves public users
unable to flash a matching image.
