### PR TITLE
sync pcie_only 5f1cb841

### DIFF
--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -803,7 +803,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x93ffa0c8, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x93ffa0c8. Please update FPGA with commit update_93ffa0c8.bin using update_flash.py (public release v1.42)"
+        assert hw_version == 0x5f1cb841, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x5f1cb841. Please update FPGA with commit update_5f1cb841.bin using update_flash.py (public release v1.1)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address


### PR DESCRIPTION
Automated sync from `apex-compute/andromeda` @ `5f1cb841` (branch `pcie_only`).

**Changed by this sync:**
- user_dma_core.py

The sync covers 5 files — user_dma_core.py, user_hw_test.py and the gemma3
reference (gemma3_test.py, gemma3_test_IF8.py, gemma3_config.json). Any that
already match `main` are left untouched and are not listed above.

Verified on hardware by the PCIe CI: the FPGA was flashed with the bitstream
built from this same commit (so `hw_version == 0x5f1cb841` matches the
board), then `make clean` + `model_auto_test.py` — **passed**.

Before merging: attach the encrypted `update_5f1cb841.bin`. This PR
intentionally ships no bitstream, so merging without it leaves public users
unable to flash a matching image.
