### PR TITLE
Skip night run Slack post when secrets are unset

### DIFF
--- a/.github/workflows/night-run.yml
+++ b/.github/workflows/night-run.yml
@@ -128,6 +128,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post nightly result
+        # Skip rather than fail the run while the Slack secrets are unset.
+        if: ${{ env.SLACK_BOT_TOKEN != '' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage


### PR DESCRIPTION
## Why

`night-run.yml`'s `notify-slack` job reads `secrets.SLACK_BOT_TOKEN` and `secrets.SLACK_CHANNEL_ID`, but **unified-engine has no repository secrets** — andromeda has both, and neither repo inherits org-level secrets. Both values resolve to empty strings here, so `chat.postMessage` fails on auth and turns the entire nightly run red even when the hardware CI passed.

## What

Gate the Slack step on the token being present, so it skips instead of failing.

The condition goes through `env` because the `secrets` context isn't available in a job-level `if`. Once the secrets are added the guard flips to true on its own — no follow-up edit needed.

Nothing else changes: `core.setFailed` on a real CI failure still propagates, so a red night run continues to mean the hardware suite actually failed.

## Not addressed here

A full `ci.yml` run measured **110 min** against its `timeout-minutes: 115`, with the orchestrator at 120. Under 5% headroom — one slow model and `ci.yml` times out and the night run reports FAILED. Raising it means moving both numbers together to keep the 5-minute reporting gap intact; left alone pending a call on the shared-board time budget.

## Test plan

Not exercised on hardware — a full night run is ~110 min on the shared p620. YAML parse verified locally. @SiqinL is driving the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)