### PR TITLE
Preserve model weights and HF cache across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,21 @@ jobs:
     timeout-minutes: 115
     steps:
       - name: Checkout
+        # Do NOT let checkout run `git clean -ffdx`: its default wipe deletes the
+        # untracked models/*/*_bin caches (model weights + HF snapshots), forcing
+        # every model to re-fetch multi-GB weights every run. We clean the tree
+        # ourselves below and preserve those caches.
         uses: actions/checkout@v4
+        with:
+          clean: false
 
       - name: Clean workspace and program bins
         run: |
+          # Restore tracked files, then wipe untracked cruft everywhere EXCEPT
+          # models/ (keeps weights + HF cache). clean_program_bins.sh then removes
+          # only the runtime-generated programs.bin/json inside models/*/*_bin.
           git reset --hard HEAD
+          git clean -ffdx -e models
           ./clean_program_bins.sh
 
       - name: Run CI suite


### PR DESCRIPTION
## Problem

`actions/checkout` defaults to `clean: true`, which runs `git clean -ffdx` as the **first step of every `hw-ci` job** — before our own cleanup runs. That wipes the untracked `models/*/*_bin/` directories, which hold the model **weights** (`params.bin`, `weights_*.bin`, `*.pt`) and **HF snapshot caches**.

Traced in [run 29640635501](https://github.com/apex-compute/unified-engine/actions/runs/29640635501/job/88070460890): log line 57 `git clean -ffdx`, lines 96–99 `Removing models/gemma3/gemma3_bin/` etc.

So `clean_program_bins.sh` — which is carefully written to delete only `programs.bin`/`programs.json` and leave weights alone — never mattered: checkout had already deleted the whole directory, and every model re-fetched multi-GB weights every run.

## Fix

- `clean: false` on checkout — stop the blanket `git clean -ffdx`.
- Do the cleanup explicitly in the next step:
  - `git reset --hard HEAD` — restore tracked files
  - `git clean -ffdx -e models` — wipe untracked cruft **everywhere except** `models/` (traces, `__pycache__`, etc. outside models/ — which the reporter explicitly doesn't care about)
  - `./clean_program_bins.sh` — remove only the runtime-generated `programs.bin`/`programs.json` inside `models/*/*_bin`

Net: weights + HF cache persist between runs; only program bins regenerate.

## Verification

`git clean -ffdxn -e models` (dry run) removes **0** paths under `models/`, vs. all `*_bin/` dirs without the exclude. YAML parses.

Not run on hardware — the change only affects checkout/cleanup, not the suite. @SiqinL is driving the run.

## Tradeoff

Persisting weights means a corrupt/stale weight `.bin` would also persist. The existing `clean_bins` dispatch input (`run_ci.sh --clean-bins`) remains the escape hatch to force a from-scratch refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)