### PR TITLE
sync pcie_only 2bd3e917

### DIFF
--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -77,6 +77,9 @@ INT_CAUSE_HALT = 2
 
 # CLOCK_CYCLE_TIME_NS will be set based on target argument (default: 3 ns)
 CLOCK_CYCLE_TIME_NS = 3
+# HW prescales PIPELINE_COUNTER (0x30): one count = 16 aclk cycles
+# (pipeline_counter_module.sv CLK_DIV). Multiply readouts by this to get cycles.
+UE_PIPELINE_COUNTER_CLK_DIV = 16
 UE_PEAK_GFLOPS = 333.3 * 0.128
 UE_TRACE_SIZE = 8192
 UE_AXI_DATA_WIDTH_BITS = int(os.environ.get("UE_AXI_DATA_WIDTH_BITS", "256"))
@@ -803,7 +806,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x006e0d2f, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x006e0d2f. Please update FPGA with commit update_006e0d2f.bin using update_flash.py (public release v1.4)"
+        assert hw_version == 0x2bd3e917, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x2bd3e917. Please update FPGA with commit update_2bd3e917.bin using update_flash.py (public release v1.1)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address
@@ -9154,7 +9157,7 @@ class UnifiedEngine:
         """
         Report timing and instruction count
         """
-        latency = self.read_reg32(UE_LATENCY_COUNT_ADDR)
+        latency = self.read_reg32(UE_LATENCY_COUNT_ADDR) * UE_PIPELINE_COUNTER_CLK_DIV
         instruction_count = self.read_reg32(UE_INSTRUCTION_CTL_ADDR)
         print(f"Latency: {latency * self._clock_period_ns / 1e3:.3f} us, Instruction count: {instruction_count}")
         print(f"Latency in cycles: {latency}")
@@ -9164,14 +9167,15 @@ class UnifiedEngine:
         """
         Report latency
         """
-        return self.read_reg32(UE_LATENCY_COUNT_ADDR) * self._clock_period_ns / 1e3
+        return self.read_reg32(UE_LATENCY_COUNT_ADDR) * UE_PIPELINE_COUNTER_CLK_DIV * self._clock_period_ns / 1e3
 
     def report_flop_rate_gflops(self, num_flops: int):
         """
         Report flop rate and gflops ratio of peak throughput
         """
-        gflops_ratio = num_flops / 1.28 / self.read_reg32(UE_LATENCY_COUNT_ADDR)
-        return num_flops / (self.read_reg32(UE_LATENCY_COUNT_ADDR) * self._clock_period_ns), gflops_ratio
+        cycles = self.read_reg32(UE_LATENCY_COUNT_ADDR) * UE_PIPELINE_COUNTER_CLK_DIV
+        gflops_ratio = num_flops / 1.28 / cycles
+        return num_flops / (cycles * self._clock_period_ns), gflops_ratio
 
     # Fixed FP8 E4M3FN lookup, indexed by byte code 0x00..0xFF. All 254
     # finite values listed exactly (powers-of-two and 1/8-step fractions


### PR DESCRIPTION
Automated sync from `apex-compute/andromeda` @ `2bd3e917` (branch `pcie_only`).

**Changed by this sync:**
- user_dma_core.py

The sync covers 5 files — user_dma_core.py, user_hw_test.py and the gemma3
reference (gemma3_test.py, gemma3_test_IF8.py, gemma3_config.json). Any that
already match `main` are left untouched and are not listed above.

Verified on hardware by the PCIe CI: the FPGA was flashed with the bitstream
built from this same commit (so `hw_version == 0x2bd3e917` matches the
board), then `make clean` + `model_auto_test.py` — **passed**.

Before merging: attach the encrypted `update_2bd3e917.bin`. This PR
intentionally ships no bitstream, so merging without it leaves public users
unable to flash a matching image.
