### PR TITLE
sync pcie_only 72531767

### DIFF
--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -18,7 +18,7 @@ Weights:
 Usage:
   python gemma3_test.py
   python gemma3_test.py --prompt "your prompt"
-  python gemma3_test.py --dev xdma0 [--device kintex7] [--cycle 5.15]
+  python gemma3_test.py --dev xdma0 [--device kintex7] [--cycle 4.8077]
   python gemma3_test.py --dev xdma0 --device bittware
   python gemma3_test.py --local-weights
   python gemma3_test.py --dual-engine
@@ -2683,7 +2683,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / 208
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0
@@ -2918,7 +2918,7 @@ def main():
         '--cycle',
         type=float,
         default=None,
-        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=5.1594ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
+        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=4.8077ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
     )
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile binary with per-step HALT checkpoints and run one decode step to measure per-step latency breakdown.')

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -35,7 +35,7 @@ Weights:
 Usage:
   python gemma3_test_IF8.py
   python gemma3_test_IF8.py --prompt "your prompt"
-  python gemma3_test_IF8.py --dev xdma0 [--device kintex7] [--cycle 5.15]
+  python gemma3_test_IF8.py --dev xdma0 [--device kintex7] [--cycle 4.8077]
   python gemma3_test_IF8.py --dev xdma0 --device bittware
   python gemma3_test_IF8.py --local-weights
   python gemma3_test_IF8.py --dual-engine
@@ -2741,7 +2741,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / 208
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0
@@ -2978,7 +2978,7 @@ def main():
         '--cycle',
         type=float,
         default=None,
-        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=5.1594ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
+        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=4.8077ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
     )
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile binary with per-step HALT checkpoints and run one decode step to measure per-step latency breakdown.')

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -806,7 +806,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x2bd3e917, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x2bd3e917. Please update FPGA with commit update_2bd3e917.bin using update_flash.py (public release v1.1)"
+        assert hw_version == 0x72531767, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x72531767. Please update FPGA with commit update_72531767.bin using update_flash.py (public release v1.4)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -8,6 +8,8 @@ Usage:
     python user_hw_test.py [--dev xdma0] [--ext]
 """
 
+# CI: dummy marker to force a substantive sync diff for end-to-end flow testing.
+
 import argparse
 import hashlib
 import atexit
@@ -5697,14 +5699,14 @@ if __name__ == "__main__":
     _seed_probe = torch.randn(4, dtype=torch.bfloat16)
     _RNG_STATE_START = _rng_state_fingerprint()
 
-    # kintex7 operates at 194 Mhz = 5.1594 ns
+    # kintex7 operates at 208 Mhz = 4.8077 ns
     # kintex7_systolic operates at 149.614035 MHz = 6683 ps.
     # alveo operates at 180 Mhz = 5.5556 ns
     # kintex ultrascale+ operates at 333 Mhz = 3.0 ns
     # bittware board operates at 300 Mhz = 3.3333 ns
     clock = None
     if args.device == "kintex7":
-        clock = 5.1594
+        clock = 1000 / 208
     elif args.device == "kintex7_systolic":
         clock = 1000 / 149.61403
     elif args.device == "rk" or args.device == "puzhi":


### PR DESCRIPTION
Automated sync from `apex-compute/andromeda` @ `72531767` (branch `pcie_only`).

**Changed by this sync:**
- models/gemma3/gemma3_test.py
- models/gemma3/gemma3_test_IF8.py
- user_dma_core.py
- user_hw_test.py

The sync covers 5 files — user_dma_core.py, user_hw_test.py and the gemma3
reference (gemma3_test.py, gemma3_test_IF8.py, gemma3_config.json). Any that
already match `main` are left untouched and are not listed above.

Verified on hardware by the PCIe CI: the FPGA was flashed with the bitstream
built from this same commit (so `hw_version == 0x72531767` matches the
board), then `make clean` + `model_auto_test.py` — **passed**.

The encrypted `update_72531767.bin` is committed to this branch automatically
by CI in a follow-up commit once the kintex7_encryption build finishes, so the
branch already carries a flashable image matching `hw_version`.
