### PR TITLE
Add matmatmul kernel selection for Llama 3.2 1B decoder

### DIFF
--- a/clean_program_bins.sh
+++ b/clean_program_bins.sh
@@ -51,22 +51,18 @@ del andromeda_IP-* andromeda_wrapper-*
 del codebooks/
 
 # --- gemma3 (IF4 + IF8): keep params.* ; drop programs/instruction ----------
-del models/gemma3/gemma3_bin/programs*.bin
-del models/gemma3/gemma3_bin/programs*.json
-del models/gemma3/gemma3_bin/*instruction.bin
-del models/gemma3/gemma3_bin/*instruction.json
-del models/gemma3/gemma3_if8_bin/programs*.bin
-del models/gemma3/gemma3_if8_bin/programs*.json
-del models/gemma3/gemma3_if8_bin/*instruction.bin
-del models/gemma3/gemma3_if8_bin/*instruction.json
+del models/gemma3/gemma3_bin/*program*.bin
+del models/gemma3/gemma3_bin/*program*.json
+del models/gemma3/gemma3_if8_bin/*program*.bin
+del models/gemma3/gemma3_if8_bin/*program*.json
 
 # --- gemma4 e2b / e4b: keep params.* ; drop programs/instruction ------------
-del models/gemma4_e2b/gemma4_e2b_bin/programs*.bin
-del models/gemma4_e2b/gemma4_e2b_bin/programs*.json
+del models/gemma4_e2b/gemma4_e2b_bin/*program*.bin
+del models/gemma4_e2b/gemma4_e2b_bin/*program*.json
 del models/gemma4_e2b/gemma4_e2b_bin/*instruction*.bin
 del models/gemma4_e2b/gemma4_e2b_bin/*instruction*.json
-del models/gemma4_e4b/gemma4_e4b_bin/programs*.bin
-del models/gemma4_e4b/gemma4_e4b_bin/programs*.json
+del models/gemma4_e4b/gemma4_e4b_bin/*program*.bin
+del models/gemma4_e4b/gemma4_e4b_bin/*program*.json
 del models/gemma4_e4b/gemma4_e4b_bin/*instruction*.bin
 del models/gemma4_e4b/gemma4_e4b_bin/*instruction*.json
 
@@ -74,12 +70,12 @@ del models/gemma4_e4b/gemma4_e4b_bin/*instruction*.json
 del models/gpt2/gpt2_bin/
 
 # --- llama3.2 1b / 3b: keep params.* ; drop programs/instruction ------------
-del models/llama3.2_1b/llama3.2_1b_bin/programs*.bin
-del models/llama3.2_1b/llama3.2_1b_bin/programs*.json
-del models/llama3.2_1b/llama3.2_1b_bin/llama_instruction*
-del models/llama3.2_1b/llama3.2_1b_bin/llama_profile_instruction*
-del models/llama3.2_3b/llama3.2_3b_bin/programs*.bin
-del models/llama3.2_3b/llama3.2_3b_bin/programs*.json
+del models/llama3.2_1b/llama3.2_1b_bin/*program*.bin
+del models/llama3.2_1b/llama3.2_1b_bin/*program*.json
+del models/llama3.2_1b/llama3.2_1b_if8_bin/*program*.bin
+del models/llama3.2_1b/llama3.2_1b_if8_bin/*program*.json
+del models/llama3.2_3b/llama3.2_3b_bin/*program*.bin
+del models/llama3.2_3b/llama3.2_3b_bin/*program*.json
 del models/llama3.2_3b/llama3.2_3b_bin/llama3.2_3b_instruction_fpgapenalty.bin
 
 # --- locateanything_3b: keep params.* ; drop programs + output boxes --------

--- a/models/gemma3/README.md
+++ b/models/gemma3/README.md
@@ -22,30 +22,29 @@ This folder contains the Gemma3 accelerator inference example and numeric verifi
 
 ## Prerequisites
 
-- Run from the **parent directory** (`pcie_utils`) so that `user_dma_core` is on the path:
+- Run from the **repository root**:
   ```bash
-  cd pcie_utils
-  python gemma3_example/gemma3_test.py
+  python models/gemma3/gemma3_test.py
   ```
 - Python with `torch`, `transformers`, and DMA device access.
 
 ## Usage
 
-From the **pcie_utils** (parent) directory:
+From the repository root:
 
 ```bash
 # Prefill + decode (default prompt)
-python gemma3_example/gemma3_test.py
+python models/gemma3/gemma3_test.py
 
 # Custom prompt
-python gemma3_example/gemma3_test.py --prompt "Your prompt here"
+python models/gemma3/gemma3_test.py --prompt "Your prompt here"
 
-# DMA device and clock cycle time (default: xdma0, 5.62 ns)
-python gemma3_example/gemma3_test.py --dev xdma0 --cycle 5.62
+# DMA device and clock (Kintex-7: xdma0, 1066 / 5.375 = 198.3256 MHz, 5.0422 ns)
+python models/gemma3/gemma3_test.py --dev xdma0 --cycle 5.0422
 
 # Use local full-model weights bin
-python gemma3_example/gemma3_test.py --local-weights
+python models/gemma3/gemma3_test.py --local-weights
 
 # Dual engine (master + slave)
-python gemma3_example/gemma3_test.py --dual-engine
+python models/gemma3/gemma3_test.py --dual-engine
 ```

--- a/models/gemma3/gemma3_numeric.py
+++ b/models/gemma3/gemma3_numeric.py
@@ -670,7 +670,7 @@ class Gemma3_NumericEngine(Gemma3_UnifiedEngine):
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -18,7 +18,7 @@ Weights:
 Usage:
   python gemma3_test.py
   python gemma3_test.py --prompt "your prompt"
-  python gemma3_test.py --dev xdma0 [--device kintex7] [--cycle 4.8077]
+  python gemma3_test.py --dev xdma0 [--device kintex7] [--cycle 5.0422]
   python gemma3_test.py --dev xdma0 --device bittware
   python gemma3_test.py --local-weights
   python gemma3_test.py --dual-engine
@@ -2418,7 +2418,6 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
         print(f"Prompt ({len(self.prefill_seq)}) tokens: {self.prefill_seq}")
-        timer = time.perf_counter()
         if slave_prefill_addr is not None:
             slave_engine.program_execute(slave_prefill_addr, timeout=0)
 
@@ -2454,6 +2453,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         bias_one_group[:, q_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
         # Execute from the preamble; preamble jumps into cached prefill, which HALTs on completion.
+        timer = time.perf_counter()
         latency_hw_prefill, flop_rate_hw_prefill = self.program_execute(preamble_addr, flops=flops_prefill)
         latency_prefill = time.perf_counter() - timer
         if slave_prefill_flops is not None:
@@ -2659,10 +2659,21 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         peak_tokens_per_s = 1000.0 / hw_decode_first_ms if hw_decode_first_ms > 0 else 0.0
         avg_tokens_per_s = tokens_decoded / latency_decoder if latency_decoder > 0 else 0.0
         return {
+            "prefill_tokens": prefill_seq_len,
             "decoded_text": decoded_text,
+            "decoded_tokens": tokens_decoded,
             "tokens_decoded": tokens_decoded,
             "avg_tokens_per_s": avg_tokens_per_s,
             "peak_tokens_per_s": peak_tokens_per_s,
+            "prefill_speed_tok_s": prefill_seq_len / latency_prefill if latency_prefill > 0 else 0.0,
+            "decode_speed_tok_s": avg_tokens_per_s,
+            "prefill_size_kb": round(meta["prefill_program_size"] / 1024, 1),
+            "decoder_size_kb": round(meta["decoder_program_size"] / 1024, 1),
+            "prefill_hw_ms": latency_hw_prefill / 1e3,
+            "prefill_cpu_ms": latency_prefill * 1e3,
+            "decode_first_hw_ms": hw_decode_first_ms,
+            "decode_avg_hw_ms": hw_decode_avg_ms,
+            "decode_avg_cpu_ms": cpu_decode_avg_ms,
             "snr_k_pre": snr_k_pre,
             "snr_v_pre": snr_v_pre,
             "snr_k_new": snr_k_new,
@@ -2683,7 +2694,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 1000 / 208
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0
@@ -2919,7 +2930,7 @@ def main():
         '--cycle',
         type=float,
         default=None,
-        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=4.8077ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
+        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=5.0422ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
     )
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile binary with per-step HALT checkpoints and run one decode step to measure per-step latency breakdown.')
@@ -2987,6 +2998,7 @@ def main():
 
     run_result = ue.run_gemma3(slave_engine=ue2 if dual_engine else None, numeric=args.numeric)
     print("Gemma3 test ends.")
+    _original_print(f"TEST_RESULT: {json.dumps(run_result)}")
 
 if __name__ == "__main__":
     main()

--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -566,7 +566,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         self._zero_dram_bf16(self.LAYER0_FLASH_K_DRAM, elements)
         self._zero_dram_bf16(self.LAYER0_FLASH_V_DRAM, elements)
 
-    def _compile_prefill_program(self, prefill_seq_len: int, layer_size: int = 26, use_pbi: bool = False) -> dict:
+    def _compile_prefill_program(self, prefill_seq_len: int, layer_size: int = 26, use_pbi: bool = False, profile: bool = False) -> dict:
         """
         Compile a single prefill program and return its metadata (start_addr, size_bytes, flops).
 
@@ -607,6 +607,16 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         seq_len = prefill_seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
+        checkpoints: list[list] = []
+
+        def _checkpoint(name: str) -> None:
+            # HALT + 64B pad inside the folded body; the resume address is the next instruction.
+            # The body is hardware-looped layer_size×, so each checkpoint fires once per layer at
+            # runtime — run_gemma3_profile walks all iterations and sums per step (no per-layer rows).
+            self.generate_instruction_halt()
+            self.pad_capture_to_64b_boundary()
+            resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
+            checkpoints.append([name, f"0x{resume:X}"])
         engine_master = not self.engine_slave
         row_offset = 0 if engine_master else seq_len // 2
         # Dual-engine: halve per-engine ``seq_len`` and offset DRAM views. Not validated with PBI
@@ -892,6 +902,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     const_addr(self.LAYER0_PRE_NORM_DRAM, gpr_scratch_b),
                     layer_addr(self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA, gpr_scratch_c),
                 )
+            if profile:
+                _checkpoint("pre_norm")
             total_flops += self.matmat_mul_core(
                 M=seq_len,
                 K=self.vector_length,
@@ -946,6 +958,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                 gpr_scale_addr=layer_addr(self.DRAM_ADDR_LAYER0_V_PROJ_SCALE, gpr_scratch_d),
                 gpr_out_addr=kv_addr(self.LAYER0_V_DRAM, gpr_scratch_c),
             )
+            if profile:
+                _checkpoint("qkv_proj_vcache")
             if engine_master:
                 total_flops += fold_rms(
                     seq_len, self.head_dim,
@@ -993,6 +1007,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     gpr_out_addr=const_addr(self.LAYER0_FLASH_Q_DRAM, gpr_scratch_b),
                     gpr_cos_addr=gpr_rope_base,
                 )
+                if profile:
+                    _checkpoint("qk_norm_rope")
 
                 # Pre-flash-attn layout:
                 # Q: [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
@@ -1043,6 +1059,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     gpr_scale_reg=gpr_attn_scale,
                 )
                 total_flops += flash_attention_result or 0
+                if profile:
+                    _checkpoint("attention")
             total_flops += self.matmat_mul_core(
                 M=seq_len,
                 K=self.head_dim * self.group_size,
@@ -1083,6 +1101,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     gpr_b_addr=const_addr(self.LAYER0_POST_ATTN_NORM_DRAM, gpr_scratch_b),
                     gpr_out_addr=const_addr(self.LAYER0_POST_ATTN_RESIDUAL_DRAM, gpr_scratch_c),
                 )
+                if profile:
+                    _checkpoint("o_proj_post_attn_norm_residual")
                 total_flops += fold_rms(
                     seq_len, self.vector_length,
                     self.LAYER0_POST_ATTN_RESIDUAL_DRAM, self.LAYER0_PRE_MLP_NORM_DRAM, self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA,
@@ -1091,6 +1111,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     const_addr(self.LAYER0_PRE_MLP_NORM_DRAM, gpr_scratch_b),
                     layer_addr(self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA, gpr_scratch_c),
                 )
+                if profile:
+                    _checkpoint("pre_ffn_norm")
             total_flops += self.matmat_mul_core(
                 M=seq_len,
                 K=self.vector_length,
@@ -1145,6 +1167,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     gpr_b_addr=const_addr(self.LAYER0_MLP_UP_DRAM, gpr_scratch_b),
                     gpr_out_addr=const_addr(self.LAYER0_MLP_MULT_DRAM, gpr_scratch_c),
                 )
+                if profile:
+                    _checkpoint("mlp_gateup_gelu_mul")
             total_flops += self.matmat_mul_core(
                 M=seq_len,
                 K=self.mlp_elements,
@@ -1185,6 +1209,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     gpr_b_addr=const_addr(self.LAYER0_POST_MLP_NORM_DRAM, gpr_scratch_b),
                     gpr_out_addr=const_addr(self.LAYER0_INPUT_DRAM, gpr_scratch_c),
                 )
+                if profile:
+                    _checkpoint("mlp_down_post_ffn_norm_residual")
 
             # Advance the running per-layer offsets by one layer stride for the NEXT iteration.
             # Done here at the end (not the top) so iteration i reads layer i: the offsets hold
@@ -1460,6 +1486,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "start_addr": prefill_program_addr,
             "size_bytes": prefill_program_size,
             "flops": total_flops,
+            "checkpoints": checkpoints,
         }
         
     def _compile_decoder_programs(self, layer_size: int = 26, use_pbi: bool = False, profile: bool = False) -> dict:
@@ -2131,21 +2158,21 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             assert self.prefill_seq is not None, "--legacy requires set_prefill_seq() before compile_gemma3()"
             prefill_seq_len = len(self.prefill_seq) - 1
             matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.json")
         elif profile:
             prefill_seq_len = UE_VECTOR_SIZE
             matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_bin/gemma3{matmatmul_tag}_profile_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3{matmatmul_tag}_profile_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_bin/gemma3{matmatmul_tag}_profile_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3{matmatmul_tag}_profile_program.json")
         elif self.matmatmul:
             prefill_seq_len = UE_VECTOR_SIZE
-            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_bin/gemma3_matmatmul_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_matmatmul_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_bin/gemma3_matmatmul_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_matmatmul_program.json")
         else:
             prefill_seq_len = UE_VECTOR_SIZE
-            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_bin/gemma3_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_bin/gemma3_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_program.json")
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             print(f"Reusing existing instruction image at {instruction_bin_path}")
             print(f"  delete {instruction_bin_path} to force recompile.")
@@ -2156,7 +2183,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         print(f"Compiling prefill (prefill_seq_len={prefill_seq_len}; use_pbi={use_pbi})...")
         compile_t0 = time.perf_counter()
         prefill_prog = self._compile_prefill_program(
-            prefill_seq_len=prefill_seq_len, layer_size=layer_size, use_pbi=use_pbi
+            prefill_seq_len=prefill_seq_len, layer_size=layer_size, use_pbi=use_pbi, profile=profile
         )
         print(f"  prefill compiled, size={prefill_prog['size_bytes']} bytes, "
               f"elapsed={time.perf_counter() - compile_t0:.1f}s")
@@ -2212,6 +2239,11 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "decoder_total_flops": decoder_program["total_flops"],
         }
         if profile:
+            # Both prefill and decoder are FOLDED (one body hardware-looped `layer_size`×), so each
+            # checkpoint fires once per layer at runtime. run_gemma3_profile walks all iterations and
+            # sums per step. Store the fold count so the profiler knows how many times to loop.
+            metadata["profile_folded_layers"] = layer_size
+            metadata["prefill_profile_checkpoints"] = prefill_prog["checkpoints"]
             metadata["decoder_profile_checkpoints"] = decoder_program["checkpoints"]
 
         if slave_engine is not None:
@@ -2247,35 +2279,70 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         print(f"  decoder: {decoder_program['program_size_bytes']} bytes")
         print(f"Metadata written to {instruction_meta_path}")
 
-    def _decode_profile_execute(self, preamble_addr: int, checkpoints: list, timeout: float = 30.0) -> list:
-        """Execute one decoder step through profile checkpoints; return per-step HW latencies."""
-        results = []
+    def _profile_execute_folded(self, preamble_addr: int, checkpoints: list, folded_layers: int,
+                                tail_label: str | None = None, timeout: float = 30.0) -> tuple[list, dict]:
+        """Walk a FOLDED program (one body hardware-looped ``folded_layers``×) through its per-step
+        HALT checkpoints for *every* loop iteration, summing each step's HW latency across all layers.
+
+        Prefill and decoder are both a single captured layer body that the hardware repeats
+        ``folded_layers`` times, so each checkpoint fires once per layer at runtime. Entering at
+        ``preamble_addr`` runs the register-seeding preamble and stops at the first checkpoint; the
+        host then walks ``folded_layers × len(checkpoints)`` HALTs, resuming each at its captured
+        address. The post-loop fall-through segment (the once-per-token final norm + LM head for
+        decode; just the terminating HALT for prefill) is always drained, and recorded under
+        ``tail_label`` when one is given. Returns ``(ordered_step_names, {step: summed_ms})``.
+        """
+        from collections import OrderedDict
+        step_ms = OrderedDict((name, 0.0) for name, _ in checkpoints)
+        order = [name for name, _ in checkpoints]
         self.start_execute_from_dram(preamble_addr)
-        for name, resume_addr_hex in checkpoints:
-            self.wait_queue(timeout)
-            results.append((name, self.report_latency_in_us() / 1e3))
-            self.start_execute_from_dram(int(resume_addr_hex, 16))
+        for _ in range(folded_layers):
+            for name, resume_addr_hex in checkpoints:
+                self.wait_queue(timeout)
+                step_ms[name] += self.report_latency_in_us() / 1e3
+                self.start_execute_from_dram(int(resume_addr_hex, 16))
+        # Drain the post-loop fall-through (final norm + LM head for decode; bare HALT for prefill).
         self.wait_queue(timeout)
-        results.append(("output_norm_lm_head", self.report_latency_in_us() / 1e3))
-        return results
+        tail_ms = self.report_latency_in_us() / 1e3
+        if tail_label is not None:
+            step_ms[tail_label] = tail_ms
+            order.append(tail_label)
+        return order, step_ms
+
+    @staticmethod
+    def _print_profile_table(title: str, order: list, step_ms: dict) -> float:
+        """Print one per-step HW-latency table (summed over all layers) and return the total ms."""
+        total_ms = sum(step_ms.values())
+        print(f"\n=== {title} (HW latency, summed over all layers) ===")
+        print(f"{'Step':<38} {'ms':>9}  {'%':>6}")
+        print("-" * 57)
+        for name in order:
+            ms = step_ms[name]
+            pct = ms / total_ms * 100 if total_ms > 0 else 0.0
+            print(f"{name:<38} {ms:>9.3f}  {pct:>5.1f}%")
+        print("-" * 57)
+        print(f"{'Total':<38} {total_ms:>9.3f}  100.0%")
+        return total_ms
 
     def run_gemma3_profile(self) -> None:
-        """Load the profile instruction image, run prefill + one profiled decoder step,
-        and print a per-step latency breakdown for the decoder.
+        """Load the profile instruction image and print ONE per-step table for prefill and ONE for
+        the first decoded token. Both programs are folded (one body hardware-looped ``layer_size``×),
+        so :meth:`_profile_execute_folded` walks every iteration and sums each step across all layers
+        — the tables are per-step totals for the whole phase, with no per-layer breakdown.
         """
         matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-        profile_meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3{matmatmul_tag}_profile_instruction.json")
+        profile_meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3{matmatmul_tag}_profile_program.json")
         with open(profile_meta_path, "r") as f:
             meta = json.load(f)
 
         self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))
         preamble_addr = self.get_program_dram_addr()
 
-        prefill_program_addr   = _parse_offset(meta["prefill_program_start_addr"])
-        decoder_program_addr   = _parse_offset(meta["decoder_program_start_addr"])
-        flops_prefill_template = meta["prefill_template_flops"]
-        template_prefill_seq_len = int(meta["prefill_template_seq_len"])
-        checkpoints            = meta["decoder_profile_checkpoints"]
+        prefill_program_addr = _parse_offset(meta["prefill_program_start_addr"])
+        decoder_program_addr = _parse_offset(meta["decoder_program_start_addr"])
+        folded_layers        = int(meta.get("profile_folded_layers", self.LAYER_SIZE))
+        prefill_checkpoints  = meta.get("prefill_profile_checkpoints", [])
+        decoder_checkpoints  = meta["decoder_profile_checkpoints"]
 
         prefill_seq = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
         prefill_seq = prefill_seq[:-1]
@@ -2284,10 +2351,10 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         q_seq_len = prefill_seq_len * self.group_size
         aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
-        flops_prefill = flops_prefill_template * prefill_seq_len // max(template_prefill_seq_len, 1)
         self._zero_kv_cache()
         self._zero_flash_attention_inputs()
 
+        # --- Prefill preamble + inputs ---
         self.clear_inst_id()
         self.start_capture()
         self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
@@ -2308,11 +2375,14 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         print(f"\n--- Profiling: prefill (seq_len={prefill_seq_len}) ---")
-        timer = time.perf_counter()
-        self.program_execute(preamble_addr, flops=flops_prefill)
-        print(f"Prefill done in {time.perf_counter() - timer:.2f}s")
+        if prefill_checkpoints:
+            order, step_ms = self._profile_execute_folded(preamble_addr, prefill_checkpoints, folded_layers)
+            prefill_total_ms = self._print_profile_table(f"Prefill  (seq_len={prefill_seq_len})", order, step_ms)
+        else:
+            prefill_total_ms = 0.0
+            print("  (no prefill checkpoints in meta — recompile with --profile to enable)")
 
-        # Decoder preamble for the first decode token
+        # --- Decoder preamble + inputs for the first decoded token ---
         token_id = prefill_seq[-1]
         self._zero_kv_cache(start_token=prefill_seq_len)
         self._zero_flash_attention_inputs()
@@ -2334,33 +2404,19 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         self.write_captured_instructions_to_dram(preamble_addr)
         self.clear_capture_buffer()
 
-        print("\n--- Profiling: decoder step breakdown ---")
-        results = self._decode_profile_execute(preamble_addr, checkpoints)
+        print("\n--- Profiling: decoder (first decoded token) ---")
+        order, step_ms = self._profile_execute_folded(
+            preamble_addr, decoder_checkpoints, folded_layers, tail_label="output_norm_lm_head")
+        decoder_total_ms = self._print_profile_table("Decoder  (first token)", order, step_ms)
 
-        total_ms = sum(ms for _, ms in results)
-        from collections import defaultdict
-        step_totals: dict = defaultdict(float)
-        for name, ms in results:
-            step = name.split("_", 1)[1] if "_" in name else name
-            step_totals[step] += ms
-
-        print(f"\n{'Step (all layers)':<35} {'ms':>9}  {'%':>6}")
-        print("-" * 54)
-        for step, ms in step_totals.items():
-            print(f"{step:<35} {ms:>9.2f}  {ms/total_ms*100:>5.1f}%")
-        print("-" * 54)
-        print(f"{'Total':<35} {total_ms:>9.2f}  100.0%")
-        print(f"\nDecode speed (HW): {1000/total_ms:.2f} tok/s  ({total_ms:.1f} ms/tok)")
-
-        print(f"\n{'Step':<40} {'ms':>8}")
-        print("-" * 50)
-        for name, ms in results:
-            print(f"{name:<40} {ms:>8.2f}")
+        if prefill_total_ms > 0:
+            print(f"\nPrefill (HW): {prefill_total_ms:.2f} ms  ({prefill_seq_len} tokens)")
+        print(f"Decode  (HW): {decoder_total_ms:.2f} ms/tok  ({1000/decoder_total_ms:.2f} tok/s)")
 
     def run_gemma3_prefill(self, slave_engine = None, numeric: bool = False) -> dict:
         """Load the unified instruction image once and run prefill only.
 
-        The cached gemma3_instruction.bin is seq_len-agnostic; the runtime prefill_seq_len is
+        The cached gemma3_program.bin is seq_len-agnostic; the runtime prefill_seq_len is
         applied via a small preamble program compiled fresh per run that primes three GPRs
         (gpr_seq_len, gpr_q_seq_len, gpr_aligned_seq_len) and then unconditional-jumps into the cached
         prefill program.
@@ -2373,11 +2429,11 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         if self.legacy:
             prefill_seq_len = len(self.prefill_seq) - 1
             matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-            meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.json")
+            meta_path = os.path.join(self.script_dir, f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.json")
         elif self.matmatmul:
-            meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_matmatmul_instruction.json")
+            meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_matmatmul_program.json")
         else:
-            meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_instruction.json")
+            meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_program.json")
         with open(meta_path, "r") as f:
             meta = json.load(f)
         self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))
@@ -2650,6 +2706,19 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         hw_decode_avg_ms  = sum(hw_decode_lats_us) / len(hw_decode_lats_us) / 1e3 if hw_decode_lats_us else 0.0
         hw_decode_first_ms = hw_decode_lats_us[0] / 1e3 if hw_decode_lats_us else 0.0
+        hw_decode_total_us = sum(hw_decode_lats_us)
+        decoder_gflops = (
+            decoder_flops_per_token * len(hw_decode_lats_us)
+            / (hw_decode_total_us * 1e3)
+            if (
+                hw_decode_total_us > 0
+                and isinstance(decoder_flops_per_token, (int, float))
+            )
+            else 0.0
+        )
+        _original_print(
+            f"Report FLOPS for decoder execution: {decoder_gflops:.2f} GFLOPS"
+        )
         cpu_decode_avg_ms = latency_decoder * 1e3 / tokens_decoded if tokens_decoded else 0.0
         _original_print("\n=== Performance Summary ===")
         _original_print(f"Instruction size  : prefill={meta['prefill_program_size']/1024:.1f} kB  decoder={meta['decoder_program_size']/1024:.1f} kB  total={(meta['prefill_program_size']+meta['decoder_program_size'])/1024:.1f} kB")
@@ -2674,6 +2743,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "decode_first_hw_ms": hw_decode_first_ms,
             "decode_avg_hw_ms": hw_decode_avg_ms,
             "decode_avg_cpu_ms": cpu_decode_avg_ms,
+            "decoder_gflops": round(decoder_gflops, 2),
             "snr_k_pre": snr_k_pre,
             "snr_v_pre": snr_v_pre,
             "snr_k_new": snr_k_new,
@@ -2937,7 +3007,7 @@ def main():
     parser.add_argument('--legacy', action='store_true',
                         help='Compile without PBI for non-attention ops (static M/K/N). '
                              'Attention (flash_attention, decoder_group_attention) stays dynamic. '
-                             'Uses a separate gemma3_legacy_instruction.bin cache. '
+                             'Uses a separate gemma3_legacy_program.bin cache. '
                              'Without --legacy (the usual path), prefill compiles as a single '
                              'hardware-looped layer body where rope, flash attention, and every '
                              'matmul use fully dynamic (runtime GPR-sourced) addressing.')

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -2189,21 +2189,21 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             assert self.prefill_seq is not None, "--legacy requires set_prefill_seq() before compile_gemma3()"
             prefill_seq_len = len(self.prefill_seq) - 1
             matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.json")
         elif profile:
             prefill_seq_len = UE_VECTOR_SIZE
             matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3{matmatmul_tag}_profile_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3{matmatmul_tag}_profile_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3{matmatmul_tag}_profile_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3{matmatmul_tag}_profile_program.json")
         elif self.matmatmul:
             prefill_seq_len = UE_VECTOR_SIZE
-            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_matmatmul_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_matmatmul_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_matmatmul_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_matmatmul_program.json")
         else:
             prefill_seq_len = UE_VECTOR_SIZE
-            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_instruction.bin")
-            instruction_meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_instruction.json")
+            instruction_bin_path  = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_program.json")
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             print(f"Reusing existing instruction image at {instruction_bin_path}")
             print(f"  delete {instruction_bin_path} to force recompile.")
@@ -2322,7 +2322,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         and print a per-step latency breakdown for the decoder.
         """
         matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-        profile_meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3{matmatmul_tag}_profile_instruction.json")
+        profile_meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3{matmatmul_tag}_profile_program.json")
         with open(profile_meta_path, "r") as f:
             meta = json.load(f)
 
@@ -2418,7 +2418,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
     def run_gemma3_prefill(self, slave_engine = None, numeric: bool = False) -> dict:
         """Load the unified instruction image once and run prefill only.
 
-        The cached gemma3_instruction.bin is seq_len-agnostic; the runtime prefill_seq_len is
+        The cached gemma3_program.bin is seq_len-agnostic; the runtime prefill_seq_len is
         applied via a small preamble program compiled fresh per run that primes three GPRs
         (gpr_seq_len, gpr_q_seq_len, gpr_aligned_seq_len) and then unconditional-jumps into the cached
         prefill program.
@@ -2431,11 +2431,11 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         if self.legacy:
             prefill_seq_len = len(self.prefill_seq) - 1
             matmatmul_tag = "_matmatmul" if self.matmatmul else ""
-            meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.json")
+            meta_path = os.path.join(self.script_dir, f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.json")
         elif self.matmatmul:
-            meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_matmatmul_instruction.json")
+            meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_matmatmul_program.json")
         else:
-            meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_instruction.json")
+            meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_program.json")
         with open(meta_path, "r") as f:
             meta = json.load(f)
         self.load_program_instructions_from_file(os.path.join(self.script_dir, meta["instruction_bin"]))

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -35,7 +35,7 @@ Weights:
 Usage:
   python gemma3_test_IF8.py
   python gemma3_test_IF8.py --prompt "your prompt"
-  python gemma3_test_IF8.py --dev xdma0 [--device kintex7] [--cycle 4.8077]
+  python gemma3_test_IF8.py --dev xdma0 [--device kintex7] [--cycle 5.0422]
   python gemma3_test_IF8.py --dev xdma0 --device bittware
   python gemma3_test_IF8.py --local-weights
   python gemma3_test_IF8.py --dual-engine
@@ -2741,7 +2741,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 1000 / 208
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0
@@ -2979,7 +2979,7 @@ def main():
         '--cycle',
         type=float,
         default=None,
-        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=4.8077ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
+        help='Clock cycle time in nanoseconds. Default: from --device (kintex7=5.0422ns, bittware=3.3333ns, rk/puzhi=3.0ns, alveo=4.0ns).',
     )
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile binary with per-step HALT checkpoints and run one decode step to measure per-step latency breakdown.')

--- a/models/llama3.2_1b/README.md
+++ b/models/llama3.2_1b/README.md
@@ -24,9 +24,30 @@ python models/llama3.2_1b/llama3.2_1b_test.py
 # Custom prompt
 python models/llama3.2_1b/llama3.2_1b_test.py --prompt "What is 2+2?"
 
+# Restore Meta's full dated system block (the default is the lower-latency minimal chat wrapper)
+python models/llama3.2_1b/llama3.2_1b_test.py --prompt "What is 2+2?" --standard-chat-template
+
+# Compatibility A/B: restore the slower dequantize-then-BF16 prefill matmuls
+python models/llama3.2_1b/llama3.2_1b_test.py --prompt "What is 2+2?" --two-pass-prefill
+
 # Override the board clock when needed (Kintex-7 default: 5.0422 ns / 198.33 MHz)
 python models/llama3.2_1b/llama3.2_1b_test.py --cycle 5.0422
 ```
+
+## Measured prefill performance
+
+Kintex-7 at 198.3256 MHz, hardware `0x884c96b9`, prompt `"x^2=-1"`:
+
+| Path | Prefill tokens | FPGA time | Rate |
+| --- | ---: | ---: | ---: |
+| Previous Llama, dated system template | 39 | 3,432.9 ms | 11.36 tok/s |
+| Optimized Llama, minimal chat template | 14 | **1,158.3 ms** | **12.09 tok/s** |
+| Gemma3, equivalent 14-token prefill | 14 | 884.0 ms | 15.84 tok/s |
+
+The default minimal wrapper removes the tokenizer's automatically injected 25-token
+system/date block. The prefill compiler also uses one-pass streaming IF4 matmuls,
+keeps layer state in one recurrent DRAM buffer, and scales the full query tensor once.
+Use `--standard-chat-template` when the dated system metadata is required.
 
 ## Measured decode performance
 

--- a/models/llama3.2_1b/README.md
+++ b/models/llama3.2_1b/README.md
@@ -10,7 +10,7 @@ This folder contains the LLaMA 3.2 1B accelerator inference.
 
 ## Prerequisites
 
-- Run from the **repo root directory** so that `user_dma_core` is on the path:
+- Run from the **repo root directory** so that `user_dma_core` is on the path.
 - Python with `torch`, `transformers`, and DMA device access.
 
 ## Usage
@@ -23,4 +23,29 @@ python models/llama3.2_1b/llama3.2_1b_test.py
 
 # Custom prompt
 python models/llama3.2_1b/llama3.2_1b_test.py --prompt "What is 2+2?"
+
+# Override the board clock when needed (Kintex-7 default: 5.0422 ns / 198.33 MHz)
+python models/llama3.2_1b/llama3.2_1b_test.py --cycle 5.0422
 ```
+
+## Measured decode performance
+
+Kintex-7 at 1066 / 5.375 = 198.3256 MHz, hardware `0x884c96b9`, prompt `"x^2=-1"`:
+
+| Metric | Before | Optimized |
+| --- | ---: | ---: |
+| End-to-end decode | 7.89 tok/s | 8.21 tok/s |
+| CPU time | 126.8 ms/token | 121.8 ms/token |
+| FPGA time | 123.4 ms/token | 121.2 ms/token |
+| Decoder instructions | 1,865.1 KiB | 1,633.2 KiB |
+
+The optimized decoder reads each per-head K/V cache directly, hoists query
+scaling once per layer, writes attention output into its final slot, avoids the
+inter-layer hidden-state copy, prebuilds position dispatch entries, and reuses
+host buffers. Generated instruction binaries are fingerprinted against the
+compiler sources and config, so stale binaries rebuild automatically.
+
+Gemma3 remains faster for this prompt (9.71 tok/s) because this Llama decoder
+performs 3.022 GFLOP/token versus Gemma3's 2.056 GFLOP/token, about 47% more
+model work. Llama's measured FPGA throughput is actually higher per unit of
+work; the remaining absolute gap is architectural rather than host overhead.

--- a/models/llama3.2_1b/llama3.2_1b_IF8.py
+++ b/models/llama3.2_1b/llama3.2_1b_IF8.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
 """
-Llama-3.2-1B inference on accelerator: prefill + decode.
+Llama-3.2-1B IF8 inference on accelerator: prefill + decode.
 
-  - Config from llama3.2_1b_config.json; weights from a single bin (see below).
-  - Prefill: compiled each run. Decoder: if llama3.2_1b_bin/decoder_program.bin and
-    llama3.2_1b_bin/decoder_program.json exist, skip decoder compile and load
-    program sizes from meta; otherwise compile and write the bin + meta.
+This is the IF8 (8-bit adaptive block-scaled) variant of
+``llama3.2_1b_test.py``, following the design used by
+``models/gemma3/gemma3_test_IF8.py``:
+
+  - Quantized weight data regions are doubled and repacked because IF8 stores
+    one byte per element instead of two elements per byte.
+  - Every quantized matmul uses ``TYPE.IF8``.
+  - Weights use per-block MixMSE selection between INT8 and FP8 E4M3.
+  - IF8 weights and programs live in ``llama3.2_1b_if8_bin/`` so they cannot
+    collide with the IF4/FP4 artifacts.
+
+  - Config from llama3.2_1b_config.json; its on-disk IF4 layout is rewritten
+    in memory for IF8.
   - Run prefill then decode loop.
 
 Architecture differences vs Gemma3:
@@ -18,17 +27,16 @@ Architecture differences vs Gemma3:
   - gamma_offset = 0.0 (LLaMA uses w directly, not 1+w).
 
 Weights:
-  - Default: llama3.2_1b_bin/params.bin (generated from HF model if missing).
-  - --local-weights: use llama3.2_1b_bin/full_model_weights.bin instead.
+  - Default: llama3.2_1b_if8_bin/params.bin (generated from HF model if missing).
+  - --local-weights: use llama3.2_1b_if8_bin/full_model_weights.bin instead.
 
 Usage:
-  python llama3.2_1b_test.py
-  python llama3.2_1b_test.py --prompt "your prompt"
-  python llama3.2_1b_test.py --dev xdma0 [--cycle 5.15]
-  python llama3.2_1b_test.py --local-weights
+  python llama3.2_1b_IF8.py
+  python llama3.2_1b_IF8.py --prompt "your prompt"
+  python llama3.2_1b_IF8.py --dev xdma0 [--cycle 5.042]
+  python llama3.2_1b_IF8.py --local-weights
 """
 
-import hashlib
 import json
 import math
 import os
@@ -47,12 +55,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(SCRIPT_DIR)))
 import user_dma_core
 from user_dma_core import DMA_DEVICE_H2C, TYPE, UE_MODE, UE_FMAX_CONTEXT_SIZE, UE_VECTOR_SIZE, URAM_NEAR_FULL_ELEMENTS, URAM_FULL_ELEMENTS, set_dma_device, ue_35bit_addr_shifter, INSTRUCTION_SIZE_BYTES
 from user_dma_core import UnifiedEngine
-# Canonical, HW-aligned 4-bit codec shared across all model templates.
-# 1B uses pure FP4 (E2M1) — the best 4-bit scheme for this model by WikiText-2
-# perplexity; see src/models/llama3.2_1b/compare/summary.md. FP4 blocks are stored
-# in the HW 4-bit container with a positive scale, so the FPGA's IF4 dispatch reads
-# them as FP4. (3B uses MixMSE IF4 instead — the scheme is chosen per model.)
-from quant_lib import quantize_fp4
+# Canonical HW-aligned codec shared across all model templates. IF8 performs
+# per-block MixMSE selection between INT8 and FP8 E4M3; the bf16 scale sign
+# selects the matching hardware codebook.
+from quant_lib import quantize
+
+QUANT_PRECISION = "if8"
 
 # --- BROAD PRINT SUPPRESSION FOR LIBRARIES ---
 import builtins
@@ -76,13 +84,56 @@ def _parse_offset(val) -> int:
     return int(val)
 
 
-def _minimal_chat_prompt(prompt: str) -> str:
-    """Render the canonical Llama user/assistant headers without the dated system block."""
-    return (
-        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
-        f"{prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-    )
+def _if4_to_if8_layout(cfg: dict) -> dict:
+    """Rewrite the IF4 config layout in memory for one-byte IF8 data.
 
+    Scale and bf16 regions keep their sizes. Every quantized ``*_DATA`` region
+    doubles, layer offsets are repacked contiguously, and non-layer regions are
+    moved after the enlarged layer block. The shared JSON file is not modified.
+    """
+    regions = cfg.get("regions", {})
+    non_layer_regions = cfg.get("non_layer_regions", {})
+
+    base = 0
+    if regions:
+        ordered = sorted(
+            regions, key=lambda key: _parse_offset(regions[key]["offset"])
+        )
+        base = _parse_offset(regions[ordered[0]]["offset"])
+        cursor = base
+        for key in ordered:
+            region = regions[key]
+            if key.endswith("_DATA"):
+                region["size"] *= 2
+            region["offset"] = f"0x{cursor:08X}"
+            cursor += region["size"]
+        cfg["file_info"]["layer_size"] = cursor - base
+
+    if non_layer_regions:
+        cursor = (
+            base
+            + cfg["file_info"]["num_layers"] * cfg["file_info"]["layer_size"]
+        )
+        ordered = sorted(
+            non_layer_regions,
+            key=lambda key: _parse_offset(non_layer_regions[key]["offset"]),
+        )
+        for key in ordered:
+            region = non_layer_regions[key]
+            if key.endswith("_DATA"):
+                region["size"] *= 2
+            region["offset"] = f"0x{cursor:08X}"
+            cursor += region["size"]
+
+    paths = cfg.get("paths", {})
+    for key in ("weights_bin", "params_meta", "instruction_bin", "instruction_meta"):
+        value = paths.get(key)
+        if isinstance(value, str) and value.startswith("llama3.2_1b_bin/"):
+            paths[key] = (
+                "llama3.2_1b_if8_bin/"
+                + value[len("llama3.2_1b_bin/"):]
+            )
+    return cfg
 
 def _rope_kv_perm(num_kv_heads: int, actual_head_dim: int) -> torch.Tensor:
     """Return the 1-D index permutation that reorders a combined KV-head vector from
@@ -107,7 +158,7 @@ def _rope_kv_perm(num_kv_heads: int, actual_head_dim: int) -> torch.Tensor:
 
 
 def weight_bin_generate(script_dir: str | None = None, output_path: str | None = None) -> str:
-    """Generate params.bin from HuggingFace model per llama3.2_1b_config.json layout.
+    """Generate IF8 params.bin from HuggingFace model and the rewritten layout.
     Returns the path to the written file."""
     script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
     cfg = _load_config(script_dir)
@@ -190,17 +241,17 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
 
         region_writes = [
             (gamma_in, "bf16"),
-            (q_w, "if4"),
-            (k_w, "if4"),
-            (v_w, "if4"),
+            (q_w, "quant"),
+            (k_w, "quant"),
+            (v_w, "quant"),
             (gamma_q, "bf16"),
             (gamma_k, "bf16"),
-            (o_w, "if4"),
+            (o_w, "quant"),
             (gamma_post, "bf16"),
             (gamma_ffn, "bf16"),
-            (up_w, "if4"),
-            (gate_w, "if4"),
-            (down_w, "if4"),
+            (up_w, "quant"),
+            (gate_w, "quant"),
+            (down_w, "quant"),
             (gamma_post_ffn, "bf16"),
         ]
         j = 0
@@ -212,10 +263,12 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
             sz = weight_defs[sz_key]
             file_off = off + layer_idx * LAYER_WEIGHT_SIZE
             tensor, kind = region_writes[j]
-            if kind == "if4":
+            if kind == "quant":
                 next_key = blk0_structure[i + 1]["key"]
                 data_sz = weight_defs[f"{next_key}_SIZE"]
-                data_bytes, scale_bytes = quantize_fp4(tensor, block_size=block_size)
+                data_bytes, scale_bytes = quantize(
+                    QUANT_PRECISION, tensor, block_size=block_size
+                )
                 scale_padded = (scale_bytes + b"\x00" * sz)[:sz]
                 data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
                 write_at(file_off, scale_padded)
@@ -267,12 +320,15 @@ def weight_bin_generate(script_dir: str | None = None, output_path: str | None =
     lm_head_w = model.get_input_embeddings().weight.detach().cpu().to(torch.bfloat16)
     scale_sz = weight_defs["LM_HEAD_WEIGHT_SCALE_SIZE"]
     data_sz = weight_defs["LM_HEAD_WEIGHT_DATA_SIZE"]
-    data_bytes, scale_bytes = quantize_fp4(lm_head_w, block_size=block_size)
+    data_bytes, scale_bytes = quantize(
+        QUANT_PRECISION, lm_head_w, block_size=block_size
+    )
     scale_padded = (scale_bytes + b"\x00" * scale_sz)[:scale_sz]
     data_padded = (data_bytes + b"\x00" * data_sz)[:data_sz]
     write_at(weight_defs["LM_HEAD_WEIGHT_SCALE"], scale_padded)
     write_at(weight_defs["LM_HEAD_WEIGHT_DATA"], data_padded)
 
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
     with open(out_path, "wb") as f:
         f.write(buf)
     meta_path = paths.get("params_meta")
@@ -298,10 +354,11 @@ def _ensure_hf_model(script_dir: str, cfg: dict):
     return model, model_dir
 
 def _load_config(script_dir: str) -> dict:
-    """Load llama3.2_1b_config.json and build weight_defs (offset/size dict) from regions."""
+    """Load the shared config, rewrite it for IF8, and build weight definitions."""
     config_path = os.path.join(script_dir, "llama3.2_1b_config.json")
     with open(config_path, "r") as f:
         cfg = json.load(f)
+    cfg = _if4_to_if8_layout(cfg)
     weight_defs = {"LAYER_WEIGHT_SIZE": cfg["file_info"]["layer_size"]}
     for key, r in cfg.get("regions", {}).items():
         weight_defs[key] = _parse_offset(r["offset"])
@@ -315,8 +372,8 @@ def _load_config(script_dir: str) -> dict:
 # -----------------------------------------------------------------------------
 # Llama-3.2-1B unified engine
 # -----------------------------------------------------------------------------
-class Llama32_1b_UnifiedEngine(UnifiedEngine):
-    """UnifiedEngine for Llama-3.2-1B: loads config + weight bin, compile_prefill/compile_decoder, run_prefill/run_decoder.
+class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
+    """IF8 UnifiedEngine for Llama-3.2-1B.
 
     Key architectural differences from Gemma3:
       - No Q/K per-head norm (q_norm, k_norm): compile pipeline skips those RMS norm steps.
@@ -327,8 +384,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
       - LM head weight tied to input embedding.
     """
 
-    def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None,
-                 matmatmul: bool = False, stream_prefill: bool = True):
+    def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None):
         # Full 4 GB DRAM layout (mirrors qwen3_1.7b): the default split reserves only
         # 512 MB for the tensor region, which overflows at max_context_size=4096
         # (attention + activation buffers in tensor_init scale with context). The
@@ -342,12 +398,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             program_dram_base=0xE0000000,
         )
         self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
-        # Decode matmul kernel select (mirrors gemma3's --matmatmul):
-        #   False (default) -> quantized_matmat_core: 1-pass streaming IF4 dot.
-        #   True            -> matmat_mul_core(is_B_quantized=True): dequantize B to bf16
-        #                      in URAM, then bf16 dot (2 passes over the weight bytes).
-        self.matmatmul = matmatmul
-        self.stream_prefill = stream_prefill
         self._cfg = _load_config(self.script_dir)
         self.weight_defs = self._cfg["_weight_defs"]
 
@@ -579,8 +629,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         When ``profile`` is True, a HALT checkpoint is emitted after every major per-layer
         step so :meth:`run_llama_profile` can measure the per-step HW latency breakdown
-        (summed over all layers). Checkpoint names carry an ``L<idx>_`` prefix that the
-        profiler strips before rolling the per-layer HALTs up by step type.
+        (mirrors the decoder checkpoints in :meth:`_compile_decoder_program`).
         """
         if not getattr(self, "is_capture_on", False):
             raise RuntimeError("_compile_prefill_program() requires an active capture session")
@@ -611,38 +660,40 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         half_ahd    = ahd // 2              # 32
         rope_row    = hd * 2 * bpe          # bytes per rope table row
 
-        # The host uploads prompt embeddings to OUTPUT_DRAM. Each layer consumes
-        # that recurrent buffer and writes its final residual back to the same
-        # buffer, eliminating the old OUTPUT->INPUT inter-layer copy.
-        layer_input_addr = self.LAYER0_OUTPUT_DRAM
-
-        def prefill_matmat_mul_core(M: int, K: int, N: int, **kwargs) -> int:
-            """Select the one-pass streaming prefill kernel or compatibility fallback."""
-            if self.stream_prefill:
-                kwargs.pop("is_B_quantized", None)
-                return self.quantized_matmat_core(M=M, K=K, N=N, **kwargs)
-            return self.matmat_mul_core(M=M, K=K, N=N, **kwargs)
-
         for layer_idx in range(layer_size):
             layer_off = layer_idx * LAYER_WEIGHT_SIZE
-            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=layer_input_addr,
+            if layer_idx != 0:
+                # Inter-layer copy: previous layer's OUTPUT → next layer's INPUT.
+                # Per-token PBI loop (one row of vector_length per iter, gpr_seq_len trips)
+                # so it never exceeds URAM-A; a single seq_len*vector_length SRAM stage
+                # would overflow URAM once PREFILL_CONTEXT_SIZE > 64 (see notes).
+                self._emit_pbi_scatter_per_token(
+                    read_base=self.LAYER0_OUTPUT_DRAM,
+                    read_stride_bytes=self.vector_length * self.bytes_per_element,
+                    write_specs=[(self.LAYER0_INPUT_DRAM, self.vector_length * self.bytes_per_element)],
+                    sram_byte_addr=0x10000,
+                    element_count=self.vector_length,
+                    gpr_seq_len=self.gpr_seq_len,
+                    template_seq_len=seq_len,
+                )
+            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off,
                               gpr_M_reg=self.gpr_seq_len)
             if profile:
                 _checkpoint(f"L{layer_idx}_pre_norm")
 
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
             # v_proj writes to interleaved temp (T, 512); per-head KV cache populated below.
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_V_PROJ_TEMP,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
             if profile:
                 _checkpoint(f"L{layer_idx}_qkv_proj")
@@ -686,19 +737,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             )
             if profile:
                 _checkpoint(f"L{layer_idx}_rope")
-
-            # Scale the full post-RoPE query tensor once. Otherwise each of the
-            # eight per-KV-head attention calls launches its own scaling kernel.
-            total_flops += self.eltwise_core_dram(
-                M=seq_len,
-                N=total_q_dim,
-                dram_a=self.LAYER0_Q_DRAM,
-                dram_b=None,
-                dram_out=self.LAYER0_Q_DRAM,
-                mode=UE_MODE.MUL_BROADCAST,
-                scalar=1.0 / math.sqrt(ahd),
-                gpr_M_reg=self.gpr_seq_len,
-            )
 
             # Phase 3: Per-KV-head scatter → KV cache + flash buffers → flash_attention
             for kv_h in range(nkvh):
@@ -802,7 +840,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
                     gpr_batch_reg=self.gpr_q_seq_len,
                     gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                    q_pre_scaled=True,
                 )
                 total_flops += attn_result or 0
 
@@ -829,16 +866,16 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if profile:
                 _checkpoint(f"L{layer_idx}_attention")
 
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
 
             # LLaMA: no post-attention norm; add residual directly to o_proj output.
             # Per-row PBI loop (gpr_seq_len trips) — no URAM cap on prefill length.
             self.eltwise_core_dram(
                 M=seq_len, N=self.vector_length,
-                dram_a=layer_input_addr,
+                dram_a=self.LAYER0_INPUT_DRAM,
                 dram_b=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                 dram_out=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
                 mode=UE_MODE.ELTWISE_ADD,
@@ -853,13 +890,13 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                               gpr_M_reg=self.gpr_seq_len)
             if profile:
                 _checkpoint(f"L{layer_idx}_pre_ffn_norm")
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF8, silu_enable=True,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
             # gate × up — per-row PBI loop (gpr_seq_len trips); one row of mlp_elements per iter.
             self.eltwise_core_dram(
@@ -872,9 +909,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             )
             if profile:
                 _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
+            total_flops += self.matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4,
+                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
 
             # LLaMA: no post-FFN norm; add residual directly to down_proj output.
@@ -899,9 +936,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         Returns dict with ``program_size_bytes``, ``total_flops`` and (profile only) ``checkpoints``.
 
         When ``profile`` is True, a HALT checkpoint is emitted after every major per-layer
-        step so :meth:`run_llama_profile` can measure the per-step HW latency breakdown
-        (summed over all layers). The once-per-token final norm + LM head after the layer
-        loop is drained as the trailing ``output_norm_lm_head`` segment by the profiler.
+        step so :meth:`run_llama_profile` can measure the per-step HW latency breakdown.
         """
         if not getattr(self, "is_capture_on", False):
             raise RuntimeError("_compile_decoder_program() requires an active capture session")
@@ -917,46 +952,26 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
             checkpoints.append([name, f"0x{resume:X}"])
 
-        def decoder_matmat_mul_core(K: int, N: int, force_stream: bool = False, **kwargs) -> int:
-            """Decode matmul dispatch — the llama mirror of gemma3's ``decoder_matmat_mul_core``.
-
-            Both paths read the SAME IF4 weight; they differ in how the dot is computed:
-
-            - default (``--matmatmul`` off) -> :meth:`quantized_matmat_core`: 1-pass streaming
-              quantized dot (inline fp4->bf19 unpack straight through the DOT_PRODUCT unit).
-            - ``--matmatmul`` -> :meth:`matmat_mul_core` with ``is_B_quantized=True``:
-              DEQUANTIZES B to bf16 in URAM, then a bf16 dot — two passes over the weight
-              bytes, so ~2x the DRAM traffic (and ~2x slower) for higher-precision accumulate.
-
-            ``force_stream`` pins an individual call to the streaming path regardless of the flag.
-            """
-            if not self.matmatmul or force_stream:
-                kwargs.pop("is_B_quantized", None)
-                return self.quantized_matmat_core(M=1, K=K, N=N, **kwargs)
-            m_reg = self.alloc_isa_reg()
-            self.generate_instruction_add_set(m_reg, 1)
-            flops = self.matmat_mul_core(M=1, K=K, N=N, gpr_M_reg=m_reg, **kwargs)
-            self.release_isa_reg()
-            return flops
-
         global _SILENT_MODE
         _SILENT_MODE = True
         for layer_idx in range(layer_size):
                 layer_off = layer_idx * LAYER_WEIGHT_SIZE
-                layer_input_addr = self.LAYER0_INPUT_DRAM if layer_idx == 0 else self.LAYER0_OUTPUT_DRAM
-                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=layer_input_addr,
+                if layer_idx != 0:
+                    self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
+                    self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_INPUT_DRAM, element_size=self.vector_length)
+                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
                 if profile:
                     _checkpoint(f"L{layer_idx}_pre_norm")
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim * self.group_size,
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim * self.group_size,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF8)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF8)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF8)
                 if profile:
                     _checkpoint(f"L{layer_idx}_qkv_proj")
 
@@ -995,14 +1010,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_rope")
 
-                # Apply 1/sqrt(head_dim) once to the contiguous post-RoPE Q vector.
-                # Each of the eight per-KV-head attention calls can then consume its
-                # gathered query group directly instead of repeating this multiply.
-                total_flops += self.eltwise_core_dram(
-                    M=1, N=total_q_dim, dram_a=self.LAYER0_Q_DRAM, dram_b=None,
-                    dram_out=self.LAYER0_Q_DRAM, mode=UE_MODE.MUL_BROADCAST,
-                    scalar=1.0 / math.sqrt(ahd))
-
                 # Step 3: Per-KV-head scatter K/V to cache + scatter Q → decoder_attention
                 for kv_h in range(nkvh):
                     k_cache_base = (self.LAYER0_K_ROPE_DRAM
@@ -1026,6 +1033,17 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(k_cache_base + half_ahd * bpe), self.TMP_REG)
                     self.sram_to_accelerator_memory(0x10080, 0, half_ahd, general_reg_src=self.TMP_REG)
 
+                    # Copy valid K history → LAYER0_FLASH_K_DRAM; loop count = gpr_bucket_idx
+                    # so only current_seq_len tokens are copied, not the full MAX_CONTEXT_SIZE.
+                    self._emit_pbi_scatter_per_token(
+                        read_base=k_cache_base,
+                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_K_DRAM, UE_VECTOR_SIZE * ahd * bpe)],
+                        sram_byte_addr=0,
+                        element_count=UE_VECTOR_SIZE * ahd,
+                        gpr_seq_len=self.gpr_bucket_idx,
+                    )
+
                     # Scatter V_h (64-dim, standard layout) → V cache at decode position
                     # v_proj output at LAYER0_FLASH_V_DRAM: [V_KV0(64)..V_KV7(64)] = 512-dim
                     self.accelerator_memory_to_sram(
@@ -1033,6 +1051,17 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.generate_instruction_add_imm(
                         self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(v_cache_base), self.TMP_REG)
                     self.sram_to_accelerator_memory(0x20000, 0, ahd, general_reg_src=self.TMP_REG)
+
+                    # Copy valid V history → LAYER0_FLASH_V_DRAM + k_size; same dynamic size.
+                    # Offset by k_size to avoid the v_proj output at [0..k_size-1].
+                    self._emit_pbi_scatter_per_token(
+                        read_base=v_cache_base,
+                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_V_DRAM + self.k_size, UE_VECTOR_SIZE * ahd * bpe)],
+                        sram_byte_addr=0,
+                        element_count=UE_VECTOR_SIZE * ahd,
+                        gpr_seq_len=self.gpr_bucket_idx,
+                    )
 
                     # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q base (no kv_h offset)
                     # KV head kv_h → Q group g = kv_h//2; sub_idx = (kv_h%2)*qpkv + q
@@ -1049,35 +1078,36 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                             0x30080, half_ahd)
                         self.sram_to_accelerator_memory(0x30000, flash_q_addr, half_ahd)
                         self.sram_to_accelerator_memory(0x30080, flash_q_addr + half_ahd * bpe, half_ahd)
-                    # Each head's K/V cache is already laid out as
-                    # [MAX_CONTEXT_SIZE, actual_head_dim]. Pass its base straight
-                    # to the read-only attention core; staging the aligned prefix
-                    # copied the same contiguous history twice per KV head, per
-                    # layer, per token.
+                    # Scaled dot-product attention for this KV head's qpkv query heads,
+                    # called inline per KV head (unified_attention_core replaces the old
+                    # shared decoder_group_attention_core subroutine + JUMP_ABS call-site).
                     attn_result = self.unified_attention_core(
                         batch=qpkv,
                         aligned_seq_len=decoder_aligned_seq_len,
                         head_dim=ahd,
                         Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                        K_DRAM_ADDR=k_cache_base,
-                        V_DRAM_ADDR=v_cache_base,
+                        K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
+                        V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM + self.k_size,
                         BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                        OUTPUT_DRAM_ADDR=(self.LAYER0_FLASH_OUTPUT_DRAM
-                                          + kv_h * qpkv * ahd * bpe),
+                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
                         SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
                         IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
                         gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                        q_pre_scaled=True,
                     )
                     total_flops += attn_result or 0
+                    # Copy per-head output to its slot in FLASH_OUTPUT_DRAM.
+                    self.accelerator_memory_to_sram(
+                        self.LAYER0_FLASH_OUT_HEAD_DRAM, 0x40000, qpkv * ahd)
+                    self.sram_to_accelerator_memory(
+                        0x40000, self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe, qpkv * ahd)
                 if profile:
                     _checkpoint(f"L{layer_idx}_attention")
-                total_flops += decoder_matmat_mul_core(K=self.head_dim * self.group_size, N=self.vector_length,
+                total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF8)
 
                 # LLaMA: no post-attention norm; residual directly on o_proj output
-                self.accelerator_memory_to_sram(accelerator_dram_address=layer_input_addr, sram_address=0x10000, element_size=self.vector_length)
+                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_INPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, sram_address=0x90000, element_size=self.vector_length)
                 self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
@@ -1090,12 +1120,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_pre_ffn_norm")
 
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF8, silu_enable=True)
+                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF8)
 
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_GATE_DRAM, sram_address=0x10000, element_size=self.mlp_elements)
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
@@ -1104,9 +1134,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
 
-                total_flops += decoder_matmat_mul_core(K=self.mlp_elements, N=self.vector_length,
+                total_flops += self.quantized_matmat_core(M=1, K=self.mlp_elements, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF8)
 
                 # LLaMA: no post-FFN norm; residual directly on down_proj output
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, sram_address=0x10000, element_size=self.vector_length)
@@ -1121,53 +1151,15 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
             penalty_kwargs = dict(C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N") \
                 if bool(getattr(self, "fpga_penalty", False)) else {}
-            # LM head uses the same dual-kernel dispatch as the layer matmuls (mirrors gemma3):
-            # streaming IF4 by default, dequantize-to-bf16 dot under --matmatmul. Both kernels
-            # honor the folded repetition-penalty bias (broadcast_N) and the argmax-only
-            # write_back_disable, so the HW argmax still returns the penalized token id.
-            total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+            total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
-                SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4, is_B_quantized=True,
+                SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF8,
                 write_back_disable=True, **penalty_kwargs)
 
         self.generate_instruction_halt()
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"program_size_bytes": decoder_program_size, "total_flops": total_flops, "checkpoints": checkpoints}
-
-    def _instruction_paths(self) -> tuple[str, str]:
-        """(bin, meta) cache paths for the current compile mode (mirrors gemma3's tagging).
-
-        The captured image depends on BOTH the decode matmul kernel (``--matmatmul`` folds a
-        dequantize-to-bf16 dot in place of the streaming IF4 dot) and the on-FPGA penalty
-        (which folds a bias term into the LM-head matmul), so each combination gets its own
-        cache entry — otherwise switching modes silently reuses a stale bin compiled for the
-        other one.
-        """
-        paths_cfg = self._cfg.get("paths", {})
-        bin_rel = paths_cfg.get("instruction_bin", "llama3.2_1b_bin/programs.bin")
-        meta_rel = paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json")
-        tag = ("_matmatmul" if self.matmatmul else "")
-        tag += ("" if self.stream_prefill else "_twopassprefill")
-        tag += ("" if bool(getattr(self, "fpga_penalty", False)) else "_puregreedy")
-        if tag:
-            b_root, b_ext = os.path.splitext(bin_rel)
-            m_root, m_ext = os.path.splitext(meta_rel)
-            bin_rel, meta_rel = f"{b_root}{tag}{b_ext}", f"{m_root}{tag}{m_ext}"
-        return (os.path.join(self.script_dir, bin_rel), os.path.join(self.script_dir, meta_rel))
-
-    def _instruction_compiler_fingerprint(self, layer_size: int) -> str:
-        """Hash every local input that can change the captured instruction stream."""
-        digest = hashlib.sha256()
-        config_path = os.path.join(self.script_dir, "llama3.2_1b_config.json")
-        for source_path in (__file__, user_dma_core.__file__, config_path):
-            digest.update(os.path.abspath(source_path).encode())
-            with open(source_path, "rb") as source_file:
-                digest.update(source_file.read())
-        digest.update(
-            f"layers={layer_size};matmatmul={self.matmatmul};stream_prefill={self.stream_prefill};"
-            f"penalty={getattr(self, 'fpga_penalty', False)}".encode())
-        return digest.hexdigest()
 
     def compile_llama(self, layer_size: int | None = None, profile: bool = False) -> None:
         """Compile prefill + decoder into a single combined instruction image.
@@ -1176,12 +1168,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         Prefill is compiled with a fixed template (UE_VECTOR_SIZE) — all runtime
         loop counts are driven by GPRs primed by the preamble, so the same bin
-        works for any seq_len. A matching compiler fingerprint makes this a no-op.
+        works for any seq_len. If both bin and meta already exist, this is a no-op.
 
-        When ``profile`` is True, both programs are compiled with per-step HALT
-        checkpoints into a separate profile image (so the normal bin is never
-        overwritten with checkpoint HALTs). The checkpoint resume-address lists are
-        stored in the meta for :meth:`run_llama_profile`.
+        When ``profile`` is True, both the prefill and decoder programs are compiled
+        with per-step HALT checkpoints into a separate profile image (so the normal
+        bin is never overwritten with checkpoint HALTs). The checkpoint resume-address
+        lists are stored in the meta for :meth:`run_llama_profile`.
 
         Writes:
           - paths.instruction_bin  : combined raw instruction stream
@@ -1189,28 +1181,19 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         """
         if layer_size is None:
             layer_size = self.LAYER_SIZE
+        paths_cfg = self._cfg.get("paths", {})
         if profile:
-            instruction_bin_path = os.path.join(self.script_dir, "llama3.2_1b_bin/llama3.2_1b_profile_program.bin")
-            instruction_meta_path = os.path.join(self.script_dir, "llama3.2_1b_bin/llama3.2_1b_profile_program.json")
+            instruction_bin_path = os.path.join(self.script_dir, "llama3.2_1b_if8_bin/llama3.2_1b_if8_profile_program.bin")
+            instruction_meta_path = os.path.join(self.script_dir, "llama3.2_1b_if8_bin/llama3.2_1b_if8_profile_program.json")
         else:
-            instruction_bin_path, instruction_meta_path = self._instruction_paths()
+            instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_1b_if8_bin/programs.bin"))
+            instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_if8_bin/programs.json"))
         self._instruction_bin_path = instruction_bin_path
         self._instruction_meta_path = instruction_meta_path
-        compiler_fingerprint = self._instruction_compiler_fingerprint(layer_size)
-        print(f"Decode matmul kernel: {'matmat_mul_core (dequantize->bf16 dot, 2-pass)' if self.matmatmul else 'quantized_matmat_core (streaming IF4, 1-pass)'}")
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
-            try:
-                with open(instruction_meta_path, "r") as meta_file:
-                    cached_meta = json.load(meta_file)
-                cached_bin_size = os.path.getsize(instruction_bin_path)
-            except (OSError, ValueError, TypeError):
-                cached_meta = {}
-                cached_bin_size = -1
-            if (cached_meta.get("compiler_fingerprint") == compiler_fingerprint
-                    and cached_meta.get("instruction_total_size") == cached_bin_size):
-                print(f"Reusing validated instruction image at {instruction_bin_path}")
-                return
-            print(f"Rebuilding stale instruction image at {instruction_bin_path}")
+            print(f"Reusing existing instruction image at {instruction_bin_path}")
+            print(f"  delete {instruction_bin_path} to force recompile.")
+            return
 
         # Compile the prefill template at PREFILL_CONTEXT_SIZE (the max prompt length).
         # All loop counts are GPR-driven (gpr_seq_len), so the single cached program
@@ -1247,7 +1230,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         metadata = {
             "instruction_bin": os.path.relpath(instruction_bin_path, self.script_dir),
-            "compiler_fingerprint": compiler_fingerprint,
             "instruction_base_addr": f"0x{instruction_base_addr:X}",
             "instruction_total_size": len(instruction_bytes),
             "prefill_template_seq_len": template_seq_len,
@@ -1326,8 +1308,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         Primes GPRs via a small captured preamble that jumps into the cached
         prefill or decoder program at runtime.
         """
-        # Mode-specific bin/meta (decode matmul kernel + penalty) that compile_llama produced.
-        meta_path = getattr(self, "_instruction_meta_path", None) or self._instruction_paths()[1]
+        paths_cfg = self._cfg.get("paths", {})
+        # With the on-FPGA penalty (default) use the penalty-specific bin/meta compile_llama produced.
+        meta_path = getattr(self, "_instruction_meta_path", None) or \
+            os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_if8_bin/programs.json"))
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -1371,39 +1355,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.allocate_program_dram(self.get_capture_instruction_size_bytes())
         self.clear_capture_buffer()
 
-        # Build every position-dependent decoder preamble once. Each 64-byte-aligned
-        # entry is six instructions (four register sets, jump, unreachable padding NOP),
-        # so the hot loop only selects an address instead of compiling and DMA-writing it.
-        decoder_dispatch_addr = self.get_program_dram_addr()
-        decoder_dispatch_stride = 6 * INSTRUCTION_SIZE_BYTES
-        self.clear_inst_id()
-        self.start_capture()
-        for decode_pos in range(prefill_seq_len, self.MAX_CONTEXT_SIZE):
-            runtime_seq_len = decode_pos + 1
-            runtime_aligned_seq_len = ((runtime_seq_len + 63) // 64) * 64
-            runtime_bucket_idx = min((runtime_seq_len + 63) // 64, _max_gpr_bucket)
-            entry_start = self.capture_count
-            self.clear_inst_id()
-            self.generate_instruction_add_set(self.gpr_bucket_idx, runtime_bucket_idx)
-            self.generate_instruction_add_set(self.gpr_aligned_seq_len, runtime_aligned_seq_len)
-            self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
-            self.generate_instruction_add_set(self.ROPE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _rope_row))
-            self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
-            self.generate_instruction_nop()
-            entry_size = self.capture_count - entry_start
-            assert entry_size == 6, (
-                f"decoder dispatch entry at position {decode_pos} has {entry_size} instructions"
-            )
-        self.stop_capture()
-        decoder_dispatch_size = self.get_capture_instruction_size_bytes()
-        dispatch_bytes_written = self.write_captured_instructions_to_dram(decoder_dispatch_addr)
-        if dispatch_bytes_written != decoder_dispatch_size:
-            raise RuntimeError("Failed to write the complete decoder dispatch table")
-        self.allocate_program_dram(decoder_dispatch_size)
-        self.clear_capture_buffer()
-
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
-        self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
@@ -1422,8 +1375,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         print("--- Starting decoder ---")
         hw_decode_lats_us: list[float] = []
         decoded_chars: list[str] = []
-        decode_bias_host: torch.Tensor | None = None
-        decode_bias_aligned_seq_len = 0
         timer = time.perf_counter()
         token_id = self.prefill_seq[-1]
         _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
@@ -1483,28 +1434,30 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             _SILENT_MODE = True
             self.seq_len += 1
             aligned_seq_len = ((self.seq_len + 63) // 64) * 64
+            bucket_idx = min((self.seq_len + 63) // 64, _max_gpr_bucket)
             decode_pos = self.seq_len - 1
 
-            if 0 <= token_id < self.embedding_weight.shape[0]:
-                embedding_tensor = self.embedding_weight[token_id:token_id + 1]
-            else:
-                embedding_tensor = self.get_embedding_for_tokens([token_id])
+            embedding_tensor = self.get_embedding_for_tokens([token_id])
             self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
             # unified_attention_core's dynamic path always uses bias_mode="full_matrix" (one bias
             # row per batch item); the decoder attention call's batch=qpkv query heads all share the
-            # same causal mask. Reuse one contiguous buffer within each 64-token bucket.
-            if aligned_seq_len != decode_bias_aligned_seq_len:
-                decode_bias_host = torch.full(
-                    (self.group_size, aligned_seq_len), -1e36, dtype=torch.bfloat16)
-                decode_bias_host[:, :self.seq_len] = 0.0
-                decode_bias_aligned_seq_len = aligned_seq_len
-            else:
-                decode_bias_host[:, self.seq_len - 1] = 0.0
-            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, decode_bias_host)
+            # same causal mask, so replicate the single mask row qpkv times (mirrors gemma3_test.py).
+            bias_host = torch.full((1, aligned_seq_len), -1e36, dtype=torch.bfloat16)
+            bias_host[0, :self.seq_len] = 0.0
+            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host.repeat(self.group_size, 1))
 
-            # Select the prebuilt register setup + jump for this absolute position.
-            decoder_step_addr = decoder_dispatch_addr + (
-                decode_pos - prefill_seq_len) * decoder_dispatch_stride
+            # Decoder preamble: prime position GPRs (+ gpr_aligned_seq_len for
+            # unified_attention_core's dynamic aligned_seq_len), then jump into cached decoder.
+            self.clear_inst_id()
+            self.start_capture()
+            self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+            self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
+            self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
+            self.generate_instruction_add_set(self.ROPE_SIZE_REG,    ue_35bit_addr_shifter(decode_pos * _rope_row))
+            self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
+            self.stop_capture()
+            self.write_captured_instructions_to_dram(preamble_addr)
+            self.clear_capture_buffer()
 
             # On-FPGA penalty: refresh the per-vocab bias (this step's LM-head matmul C term) from the
             # windowed token frequency once past the gate, so the HW argmax of (logits + bias) returns
@@ -1514,7 +1467,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
                 self._write_penalty_bias(self._generated_tokens)
 
-            hw_lat_dec_us, _ = self.program_execute(decoder_step_addr, flops=decoder_flops_per_token)
+            hw_lat_dec_us, _ = self.program_execute(preamble_addr, flops=decoder_flops_per_token)
             hw_decode_lats_us.append(hw_lat_dec_us)
             # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
             # already added the bias, so the register holds the penalized token; in plain mode it's
@@ -1554,8 +1507,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             f"Report FLOPS for decoder execution: {decoder_gflops:.2f} GFLOPS"
         )
         cpu_decode_avg_ms = latency_decoder * 1e3 / tokens_decoded if tokens_decoded else 0.0
-        peak_tokens_per_s = 1000.0 / hw_decode_first_ms if hw_decode_first_ms > 0 else 0.0
-        avg_tokens_per_s = tokens_decoded / latency_decoder if latency_decoder > 0 else 0.0
         _original_print("\n=== Performance Summary ===")
         _original_print(f"Instruction size  : prefill={meta['prefill_program_size']/1024:.1f} kB  decoder={meta['decoder_program_size']/1024:.1f} kB  total={(meta['prefill_program_size']+meta['decoder_program_size'])/1024:.1f} kB")
         _original_print(f"Prefill ({prefill_seq_len} tokens): HW={hw_lat_prefill_us/1e3:,.1f} ms  CPU={latency_prefill*1e3:,.1f} ms")
@@ -1566,20 +1517,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             "prefill_tokens": prefill_seq_len,
             "decoded_text": "".join(decoded_chars),
             "decoded_tokens": tokens_decoded,
-            # Compatibility aliases shared with Gemma3 and user_hw_test.py.
-            "tokens_decoded": tokens_decoded,
-            "avg_tokens_per_s": avg_tokens_per_s,
-            "peak_tokens_per_s": peak_tokens_per_s,
             "prefill_speed_tok_s": round(prefill_seq_len / latency_prefill, 2),
-            "decode_speed_tok_s": round(avg_tokens_per_s, 2),
+            "decode_speed_tok_s": round(tokens_decoded / latency_decoder, 2),
             "decoder_gflops": round(decoder_gflops, 2),
             "prefill_size_kb": round(meta["prefill_program_size"] / 1024, 1),
             "decoder_size_kb": round(meta["decoder_program_size"] / 1024, 1),
-            "prefill_hw_ms": hw_lat_prefill_us / 1e3,
-            "prefill_cpu_ms": latency_prefill * 1e3,
-            "decode_first_hw_ms": hw_decode_first_ms,
-            "decode_avg_hw_ms": hw_decode_avg_ms,
-            "decode_avg_cpu_ms": cpu_decode_avg_ms,
         }
 
     def _profile_execute(self, preamble_addr: int, checkpoints: list,
@@ -1631,7 +1573,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         totals for the whole phase — with no per-layer breakdown (mirrors gemma3's profiler).
         """
         meta_path = getattr(self, "_instruction_meta_path", None) or \
-            os.path.join(self.script_dir, "llama3.2_1b_bin/llama3.2_1b_profile_program.json")
+            os.path.join(self.script_dir, "llama3.2_1b_if8_bin/llama3.2_1b_if8_profile_program.json")
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -1732,8 +1674,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 # Main
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
-    """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 1000 / (1066 / 5.375)
+    """Return default clock period (ns); kintex7 matches gemma4_e2b_refactor.py."""
+    if device == "kintex7":                       return 1000 / 198.3256
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0
@@ -1743,34 +1685,15 @@ def _clock_ns_default_for_device(device: str) -> float:
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Llama-3.2-1B prefill + decode on accelerator.")
+    parser = argparse.ArgumentParser(description="Llama-3.2-1B IF8 prefill + decode on accelerator.")
     parser.add_argument("--prompt", type=str, default=None, help="Text prompt")
-    parser.add_argument(
-        "--standard-chat-template",
-        action="store_true",
-        help="Use the tokenizer's full dated system prompt. Default: canonical user/assistant "
-             "headers without the system/date block.",
-    )
-    parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")  # legacy dev path; not in standard bin set
+    parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_if8_bin/full_model_weights.bin")
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
     parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo, efinix).')
-    parser.add_argument('--matmatmul', action='store_true',
-                        help='Use matmat_mul_core for the decoder quantized matmats (incl. the LM head) '
-                             'instead of the default quantized_matmat_core (streaming) path. Same IF4 '
-                             'weights either way: matmat_mul_core dequantizes B to bf16 in URAM and does '
-                             'a bf16 dot (2 passes over the weight bytes, ~2x slower, higher-precision '
-                             'accumulate); the default streams IF4 through the dot unit in 1 pass.')
-    parser.add_argument(
-        '--two-pass-prefill',
-        action='store_true',
-        help='Use the compatibility prefill matmul that dequantizes weights before the BF16 dot. '
-             'Default: faster one-pass streaming IF4 dot.',
-    )
     parser.add_argument('--profile', action='store_true',
-                        help='Compile a profile binary with per-step HALT checkpoints and print one '
-                             'per-step HW-latency table (summed over all layers) for prefill and for '
-                             'the first decoded token.')
+                        help='Compile a profile binary with per-step HALT checkpoints and run prefill + '
+                             'one decode step to measure the per-step latency breakdown of both phases.')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly — no logit readback,
     # fully deterministic. --pure-greedy disables it entirely.
@@ -1794,9 +1717,9 @@ def main():
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     if args.local_weights:
-        weights_bin_rel = "llama3.2_1b_bin/full_model_weights.bin"
+        weights_bin_rel = "llama3.2_1b_if8_bin/full_model_weights.bin"
     else:
-        weights_bin_rel = "llama3.2_1b_bin/params.bin"
+        weights_bin_rel = "llama3.2_1b_if8_bin/params.bin"
         weights_bin_full = os.path.join(script_dir, weights_bin_rel)
         if not os.path.exists(weights_bin_full):
             weight_bin_generate(script_dir=script_dir, output_path=weights_bin_full)
@@ -1817,24 +1740,17 @@ def main():
 
     ue = UnifiedEngine()
     ue.software_reset()
-    
-    ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel,
-                                  matmatmul=args.matmatmul, stream_prefill=not args.two_pass_prefill)
+
+    ue = Llama32_1b_IF8_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
     cfg = _load_config(script_dir)
 
     if args.prompt is not None:
         tok_path = os.path.join(script_dir, cfg["paths"]["hf_model_dir"])
         tokenizer = AutoTokenizer.from_pretrained(tok_path, trust_remote_code=True)
-        if args.standard_chat_template:
-            conversation = [{"role": "user", "content": args.prompt}]
-            prompt_with_template = tokenizer.apply_chat_template(
-                conversation, tokenize=False, add_generation_prompt=True)
-            template_name = "standard dated"
-        else:
-            prompt_with_template = _minimal_chat_prompt(args.prompt)
-            template_name = "minimal"
+        conversation = [{"role": "user", "content": args.prompt}]
+        prompt_with_template = tokenizer.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)
         prefill_seq = tuple(tokenizer.encode(prompt_with_template, add_special_tokens=False))
-        print(f"Prefill from prompt ({len(prefill_seq)} tokens, {template_name} template): {args.prompt!r}")
+        print(f"Prefill from prompt ({len(prefill_seq)} tokens): {args.prompt!r}")
     else:
         prefill_seq = tuple(cfg["default_prefill_tokens"])
 
@@ -1880,7 +1796,7 @@ def main():
 
     print("\n--- Running ---")
     run_result = ue.run_llama()
-    print("Llama-3.2-1B test ends.")
+    print("Llama-3.2-1B IF8 test ends.")
     _original_print(f"TEST_RESULT: {json.dumps(run_result)}")
 
 if __name__ == "__main__":

--- a/models/llama3.2_1b/llama3.2_1b_config.json
+++ b/models/llama3.2_1b/llama3.2_1b_config.json
@@ -20,7 +20,7 @@
     "bytes_per_element": 2
   },
   "model": {
-    "max_context_size": 4096,
+    "max_context_size": 1024,
     "prefill_context_size": 128,
     "end_of_turn_token_id": 128009,
     "rope_global_layers": []
@@ -339,7 +339,7 @@
     },
     "rope": {
       "head_dim": 512,
-      "num_positions": 4096,
+      "num_positions": 1024,
       "theta": 500000.0,
       "local_base": 500000.0
     },

--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -65,6 +65,14 @@ def _parse_offset(val) -> int:
     return int(val)
 
 
+def _minimal_chat_prompt(prompt: str) -> str:
+    """Render the canonical Llama user/assistant headers without the dated system block."""
+    return (
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+        f"{prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+
+
 def _load_config(script_dir: str) -> dict:
     config_path = os.path.join(script_dir, "llama3.2_1b_config.json")
     with open(config_path, "r") as f:
@@ -126,6 +134,8 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
         self.ROPE_SIZE_REG = fixed["ROPE_SIZE_REG"]
         self.gpr_bucket_idx = fixed["GPR_BUCKET_IDX_REG"]
         self.gpr_seq_len = fixed["GPR_SEQ_LEN_REG"]
+        self.gpr_q_seq_len = fixed["GPR_Q_SEQ_LEN_REG"]
+        self.gpr_aligned_seq_len = fixed["GPR_ALIGNED_SEQ_LEN_REG"]
         self._isa_reg_counter = max(fixed.values()) + 1
         self._rope_global_layers = set(model["rope_global_layers"])
         self._end_of_turn_token_id = model["end_of_turn_token_id"]
@@ -379,6 +389,8 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
         self.start_capture()
         self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
         self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+        self.generate_instruction_add_set(self.gpr_q_seq_len, q_seq_len)
+        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
         self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
         self.stop_capture()
         self.write_captured_instructions_to_dram(preamble_addr)
@@ -386,7 +398,7 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
         self.clear_capture_buffer()
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
-        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
@@ -447,16 +459,20 @@ class Llama32_1b_RunFromBin(UnifiedEngine):
             bucket_idx = min((self.seq_len + 63) // 64, _max_gpr_bucket)
             decode_pos = self.seq_len - 1
 
-            embedding_tensor = self.get_embedding_for_tokens([token_id])
+            if 0 <= token_id < self.embedding_weight.shape[0]:
+                embedding_tensor = self.embedding_weight[token_id:token_id + 1]
+            else:
+                embedding_tensor = self.get_embedding_for_tokens([token_id])
             self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
             bias_host = torch.full((1, aligned_seq_len), -1e36, dtype=torch.bfloat16)
             bias_host[0, :self.seq_len] = 0.0
-            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host)
+            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host.repeat(self.group_size, 1))
 
             # Decoder preamble: prime bucket + 2 position GPRs, jump into cached decoder.
             self.clear_inst_id()
             self.start_capture()
             self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
+            self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
             self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
             self.generate_instruction_add_set(self.ROPE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _rope_row))
             self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
@@ -539,6 +555,12 @@ def main():
         description="Llama-3.2-1B inference from pre-compiled bins (no HF, no internet, no test-script import).")
     parser.add_argument("--prompt", type=str, default=None,
                         help="Text prompt (tokenized via the local chat template). Overrides the config default.")
+    parser.add_argument(
+        "--standard-chat-template",
+        action="store_true",
+        help="Use the tokenizer's full dated system prompt. Default: canonical user/assistant "
+             "headers without the system/date block.",
+    )
     parser.add_argument("--dev", type=str, default="xdma0", help="DMA device name. Default: xdma0.")
     parser.add_argument("--cycle", type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
     parser.add_argument("--device", type=str, default="kintex7", help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo, efinix).')
@@ -584,11 +606,16 @@ def main():
     _original_print(f"  Weights + tensors: {time.perf_counter() - t0:.2f}s")
 
     if args.prompt is not None:
-        conversation = [{"role": "user", "content": args.prompt}]
-        prompt_with_template = ue.tokenizer.apply_chat_template(
-            conversation, tokenize=False, add_generation_prompt=True)
+        if args.standard_chat_template:
+            conversation = [{"role": "user", "content": args.prompt}]
+            prompt_with_template = ue.tokenizer.apply_chat_template(
+                conversation, tokenize=False, add_generation_prompt=True)
+            template_name = "standard dated"
+        else:
+            prompt_with_template = _minimal_chat_prompt(args.prompt)
+            template_name = "minimal"
         prefill_seq = tuple(ue.tokenizer.encode(prompt_with_template, add_special_tokens=False))
-        _original_print(f"Prompt ({len(prefill_seq)} tokens): {args.prompt!r}")
+        _original_print(f"Prompt ({len(prefill_seq)} tokens, {template_name} template): {args.prompt!r}")
     else:
         prefill_seq = tuple(cfg["default_prefill_tokens"])
         _original_print(f"Default prompt ({len(prefill_seq)} tokens)")

--- a/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
+++ b/models/llama3.2_1b/llama3.2_1b_run_from_bin.py
@@ -525,7 +525,7 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -75,6 +75,15 @@ def _parse_offset(val) -> int:
         return int(val, 0)
     return int(val)
 
+
+def _minimal_chat_prompt(prompt: str) -> str:
+    """Render the canonical Llama user/assistant headers without the dated system block."""
+    return (
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+        f"{prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+
+
 def _rope_kv_perm(num_kv_heads: int, actual_head_dim: int) -> torch.Tensor:
     """Return the 1-D index permutation that reorders a combined KV-head vector from
     standard layout  [h0[lo,hi], h1[lo,hi], ..., h_{N-1}[lo,hi]]
@@ -319,7 +328,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
     """
 
     def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None,
-                 matmatmul: bool = False):
+                 matmatmul: bool = False, stream_prefill: bool = True):
         # Full 4 GB DRAM layout (mirrors qwen3_1.7b): the default split reserves only
         # 512 MB for the tensor region, which overflows at max_context_size=4096
         # (attention + activation buffers in tensor_init scale with context). The
@@ -338,6 +347,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         #   True            -> matmat_mul_core(is_B_quantized=True): dequantize B to bf16
         #                      in URAM, then bf16 dot (2 passes over the weight bytes).
         self.matmatmul = matmatmul
+        self.stream_prefill = stream_prefill
         self._cfg = _load_config(self.script_dir)
         self.weight_defs = self._cfg["_weight_defs"]
 
@@ -589,36 +599,34 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         half_ahd    = ahd // 2              # 32
         rope_row    = hd * 2 * bpe          # bytes per rope table row
 
+        # The host uploads prompt embeddings to OUTPUT_DRAM. Each layer consumes
+        # that recurrent buffer and writes its final residual back to the same
+        # buffer, eliminating the old OUTPUT->INPUT inter-layer copy.
+        layer_input_addr = self.LAYER0_OUTPUT_DRAM
+
+        def prefill_matmat_mul_core(M: int, K: int, N: int, **kwargs) -> int:
+            """Select the one-pass streaming prefill kernel or compatibility fallback."""
+            if self.stream_prefill:
+                kwargs.pop("is_B_quantized", None)
+                return self.quantized_matmat_core(M=M, K=K, N=N, **kwargs)
+            return self.matmat_mul_core(M=M, K=K, N=N, **kwargs)
+
         for layer_idx in range(layer_size):
             layer_off = layer_idx * LAYER_WEIGHT_SIZE
-            if layer_idx != 0:
-                # Inter-layer copy: previous layer's OUTPUT → next layer's INPUT.
-                # Per-token PBI loop (one row of vector_length per iter, gpr_seq_len trips)
-                # so it never exceeds URAM-A; a single seq_len*vector_length SRAM stage
-                # would overflow URAM once PREFILL_CONTEXT_SIZE > 64 (see notes).
-                self._emit_pbi_scatter_per_token(
-                    read_base=self.LAYER0_OUTPUT_DRAM,
-                    read_stride_bytes=self.vector_length * self.bytes_per_element,
-                    write_specs=[(self.LAYER0_INPUT_DRAM, self.vector_length * self.bytes_per_element)],
-                    sram_byte_addr=0x10000,
-                    element_count=self.vector_length,
-                    gpr_seq_len=self.gpr_seq_len,
-                    template_seq_len=seq_len,
-                )
-            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=layer_input_addr,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off,
                               gpr_M_reg=self.gpr_seq_len)
 
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
             # v_proj writes to interleaved temp (T, 512); per-head KV cache populated below.
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_V_PROJ_TEMP,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -658,6 +666,19 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 output_dram_addr=self.LAYER0_Q_DRAM,
                 cos_dram_addr=ROPE_WEIGHT_ADDR,
                 sin_dram_addr=ROPE_WEIGHT_ADDR + hd * bpe,
+                gpr_M_reg=self.gpr_seq_len,
+            )
+
+            # Scale the full post-RoPE query tensor once. Otherwise each of the
+            # eight per-KV-head attention calls launches its own scaling kernel.
+            total_flops += self.eltwise_core_dram(
+                M=seq_len,
+                N=total_q_dim,
+                dram_a=self.LAYER0_Q_DRAM,
+                dram_b=None,
+                dram_out=self.LAYER0_Q_DRAM,
+                mode=UE_MODE.MUL_BROADCAST,
+                scalar=1.0 / math.sqrt(ahd),
                 gpr_M_reg=self.gpr_seq_len,
             )
 
@@ -763,6 +784,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
                     gpr_batch_reg=self.gpr_q_seq_len,
                     gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
+                    q_pre_scaled=True,
                 )
                 total_flops += attn_result or 0
 
@@ -787,7 +809,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 self.release_isa_reg()  # src_off_reg
                 self.release_isa_reg()  # t_reg
 
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -796,7 +818,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             # Per-row PBI loop (gpr_seq_len trips) — no URAM cap on prefill length.
             self.eltwise_core_dram(
                 M=seq_len, N=self.vector_length,
-                dram_a=self.LAYER0_INPUT_DRAM,
+                dram_a=layer_input_addr,
                 dram_b=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                 dram_out=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
                 mode=UE_MODE.ELTWISE_ADD,
@@ -807,11 +829,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off,
                               gpr_M_reg=self.gpr_seq_len)
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -824,7 +846,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 mode=UE_MODE.ELTWISE_MUL,
                 gpr_M_reg=self.gpr_seq_len,
             )
-            total_flops += self.matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
+            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -1070,6 +1092,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         bin_rel = paths_cfg.get("instruction_bin", "llama3.2_1b_bin/programs.bin")
         meta_rel = paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json")
         tag = ("_matmatmul" if self.matmatmul else "")
+        tag += ("" if self.stream_prefill else "_twopassprefill")
         tag += ("" if bool(getattr(self, "fpga_penalty", False)) else "_puregreedy")
         if tag:
             b_root, b_ext = os.path.splitext(bin_rel)
@@ -1086,7 +1109,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             with open(source_path, "rb") as source_file:
                 digest.update(source_file.read())
         digest.update(
-            f"layers={layer_size};matmatmul={self.matmatmul};penalty={getattr(self, 'fpga_penalty', False)}".encode())
+            f"layers={layer_size};matmatmul={self.matmatmul};stream_prefill={self.stream_prefill};"
+            f"penalty={getattr(self, 'fpga_penalty', False)}".encode())
         return digest.hexdigest()
 
     def compile_llama(self, layer_size: int | None = None) -> None:
@@ -1311,7 +1335,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.clear_capture_buffer()
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
-        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
+        self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
@@ -1497,6 +1521,12 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description="Llama-3.2-1B prefill + decode on accelerator.")
     parser.add_argument("--prompt", type=str, default=None, help="Text prompt")
+    parser.add_argument(
+        "--standard-chat-template",
+        action="store_true",
+        help="Use the tokenizer's full dated system prompt. Default: canonical user/assistant "
+             "headers without the system/date block.",
+    )
     parser.add_argument("--local-weights", action="store_true", help="Use llama3.2_1b_bin/full_model_weights.bin")  # legacy dev path; not in standard bin set
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
@@ -1507,6 +1537,12 @@ def main():
                              'weights either way: matmat_mul_core dequantizes B to bf16 in URAM and does '
                              'a bf16 dot (2 passes over the weight bytes, ~2x slower, higher-precision '
                              'accumulate); the default streams IF4 through the dot unit in 1 pass.')
+    parser.add_argument(
+        '--two-pass-prefill',
+        action='store_true',
+        help='Use the compatibility prefill matmul that dequantizes weights before the BF16 dot. '
+             'Default: faster one-pass streaming IF4 dot.',
+    )
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly — no logit readback,
     # fully deterministic. --pure-greedy disables it entirely.
@@ -1554,16 +1590,23 @@ def main():
     ue = UnifiedEngine()
     ue.software_reset()
     
-    ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel, matmatmul=args.matmatmul)
+    ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel,
+                                  matmatmul=args.matmatmul, stream_prefill=not args.two_pass_prefill)
     cfg = _load_config(script_dir)
 
     if args.prompt is not None:
         tok_path = os.path.join(script_dir, cfg["paths"]["hf_model_dir"])
         tokenizer = AutoTokenizer.from_pretrained(tok_path, trust_remote_code=True)
-        conversation = [{"role": "user", "content": args.prompt}]
-        prompt_with_template = tokenizer.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)
+        if args.standard_chat_template:
+            conversation = [{"role": "user", "content": args.prompt}]
+            prompt_with_template = tokenizer.apply_chat_template(
+                conversation, tokenize=False, add_generation_prompt=True)
+            template_name = "standard dated"
+        else:
+            prompt_with_template = _minimal_chat_prompt(args.prompt)
+            template_name = "minimal"
         prefill_seq = tuple(tokenizer.encode(prompt_with_template, add_special_tokens=False))
-        print(f"Prefill from prompt ({len(prefill_seq)} tokens): {args.prompt!r}")
+        print(f"Prefill from prompt ({len(prefill_seq)} tokens, {template_name} template): {args.prompt!r}")
     else:
         prefill_seq = tuple(cfg["default_prefill_tokens"])
 

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -28,6 +28,7 @@ Usage:
   python llama3.2_1b_test.py --local-weights
 """
 
+import hashlib
 import json
 import math
 import os
@@ -317,7 +318,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
       - LM head weight tied to input embedding.
     """
 
-    def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None):
+    def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None,
+                 matmatmul: bool = False):
         # Full 4 GB DRAM layout (mirrors qwen3_1.7b): the default split reserves only
         # 512 MB for the tensor region, which overflows at max_context_size=4096
         # (attention + activation buffers in tensor_init scale with context). The
@@ -331,6 +333,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             program_dram_base=0xE0000000,
         )
         self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
+        # Decode matmul kernel select (mirrors gemma3's --matmatmul):
+        #   False (default) -> quantized_matmat_core: 1-pass streaming IF4 dot.
+        #   True            -> matmat_mul_core(is_B_quantized=True): dequantize B to bf16
+        #                      in URAM, then bf16 dot (2 passes over the weight bytes).
+        self.matmatmul = matmatmul
         self._cfg = _load_config(self.script_dir)
         self.weight_defs = self._cfg["_weight_defs"]
 
@@ -848,24 +855,44 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         total_flops = 0
         decoder_aligned_seq_len = ((self.MAX_CONTEXT_SIZE + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE) * UE_VECTOR_SIZE
 
+        def decoder_matmat_mul_core(K: int, N: int, force_stream: bool = False, **kwargs) -> int:
+            """Decode matmul dispatch — the llama mirror of gemma3's ``decoder_matmat_mul_core``.
+
+            Both paths read the SAME IF4 weight; they differ in how the dot is computed:
+
+            - default (``--matmatmul`` off) -> :meth:`quantized_matmat_core`: 1-pass streaming
+              quantized dot (inline fp4->bf19 unpack straight through the DOT_PRODUCT unit).
+            - ``--matmatmul`` -> :meth:`matmat_mul_core` with ``is_B_quantized=True``:
+              DEQUANTIZES B to bf16 in URAM, then a bf16 dot — two passes over the weight
+              bytes, so ~2x the DRAM traffic (and ~2x slower) for higher-precision accumulate.
+
+            ``force_stream`` pins an individual call to the streaming path regardless of the flag.
+            """
+            if not self.matmatmul or force_stream:
+                kwargs.pop("is_B_quantized", None)
+                return self.quantized_matmat_core(M=1, K=K, N=N, **kwargs)
+            m_reg = self.alloc_isa_reg()
+            self.generate_instruction_add_set(m_reg, 1)
+            flops = self.matmat_mul_core(M=1, K=K, N=N, gpr_M_reg=m_reg, **kwargs)
+            self.release_isa_reg()
+            return flops
+
         global _SILENT_MODE
         _SILENT_MODE = True
         for layer_idx in range(layer_size):
                 layer_off = layer_idx * LAYER_WEIGHT_SIZE
-                if layer_idx != 0:
-                    self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
-                    self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_INPUT_DRAM, element_size=self.vector_length)
-                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+                layer_input_addr = self.LAYER0_INPUT_DRAM if layer_idx == 0 else self.LAYER0_OUTPUT_DRAM
+                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=layer_input_addr,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
-                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim * self.group_size,
+                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim * self.group_size,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
-                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
+                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
-                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.head_dim,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
+                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
                 # LLaMA 8-head GQA decoder: rope_hf_core(N=512) on [lo|hi]-permuted K and Q
                 # in-place, then scatter 64-dim per-head slices to KV cache (via
@@ -900,6 +927,14 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         rope_size_reg=self.ROPE_SIZE_REG,
                         tmp_reg=self.TMP_REG)
 
+                # Apply 1/sqrt(head_dim) once to the contiguous post-RoPE Q vector.
+                # Each of the eight per-KV-head attention calls can then consume its
+                # gathered query group directly instead of repeating this multiply.
+                total_flops += self.eltwise_core_dram(
+                    M=1, N=total_q_dim, dram_a=self.LAYER0_Q_DRAM, dram_b=None,
+                    dram_out=self.LAYER0_Q_DRAM, mode=UE_MODE.MUL_BROADCAST,
+                    scalar=1.0 / math.sqrt(ahd))
+
                 # Step 3: Per-KV-head scatter K/V to cache + scatter Q → decoder_attention
                 for kv_h in range(nkvh):
                     k_cache_base = (self.LAYER0_K_ROPE_DRAM
@@ -923,17 +958,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                         self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(k_cache_base + half_ahd * bpe), self.TMP_REG)
                     self.sram_to_accelerator_memory(0x10080, 0, half_ahd, general_reg_src=self.TMP_REG)
 
-                    # Copy valid K history → LAYER0_FLASH_K_DRAM; loop count = gpr_bucket_idx
-                    # so only current_seq_len tokens are copied, not the full MAX_CONTEXT_SIZE.
-                    self._emit_pbi_scatter_per_token(
-                        read_base=k_cache_base,
-                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
-                        write_specs=[(self.LAYER0_FLASH_K_DRAM, UE_VECTOR_SIZE * ahd * bpe)],
-                        sram_byte_addr=0,
-                        element_count=UE_VECTOR_SIZE * ahd,
-                        gpr_seq_len=self.gpr_bucket_idx,
-                    )
-
                     # Scatter V_h (64-dim, standard layout) → V cache at decode position
                     # v_proj output at LAYER0_FLASH_V_DRAM: [V_KV0(64)..V_KV7(64)] = 512-dim
                     self.accelerator_memory_to_sram(
@@ -941,17 +965,6 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self.generate_instruction_add_imm(
                         self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(v_cache_base), self.TMP_REG)
                     self.sram_to_accelerator_memory(0x20000, 0, ahd, general_reg_src=self.TMP_REG)
-
-                    # Copy valid V history → LAYER0_FLASH_V_DRAM + k_size; same dynamic size.
-                    # Offset by k_size to avoid the v_proj output at [0..k_size-1].
-                    self._emit_pbi_scatter_per_token(
-                        read_base=v_cache_base,
-                        read_stride_bytes=UE_VECTOR_SIZE * ahd * bpe,
-                        write_specs=[(self.LAYER0_FLASH_V_DRAM + self.k_size, UE_VECTOR_SIZE * ahd * bpe)],
-                        sram_byte_addr=0,
-                        element_count=UE_VECTOR_SIZE * ahd,
-                        gpr_seq_len=self.gpr_bucket_idx,
-                    )
 
                     # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q base (no kv_h offset)
                     # KV head kv_h → Q group g = kv_h//2; sub_idx = (kv_h%2)*qpkv + q
@@ -968,34 +981,33 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                             0x30080, half_ahd)
                         self.sram_to_accelerator_memory(0x30000, flash_q_addr, half_ahd)
                         self.sram_to_accelerator_memory(0x30080, flash_q_addr + half_ahd * bpe, half_ahd)
-                    # Scaled dot-product attention for this KV head's qpkv query heads,
-                    # called inline per KV head (unified_attention_core replaces the old
-                    # shared decoder_group_attention_core subroutine + JUMP_ABS call-site).
+                    # Each head's K/V cache is already laid out as
+                    # [MAX_CONTEXT_SIZE, actual_head_dim]. Pass its base straight
+                    # to the read-only attention core; staging the aligned prefix
+                    # copied the same contiguous history twice per KV head, per
+                    # layer, per token.
                     attn_result = self.unified_attention_core(
                         batch=qpkv,
                         aligned_seq_len=decoder_aligned_seq_len,
                         head_dim=ahd,
                         Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                        K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                        V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM + self.k_size,
+                        K_DRAM_ADDR=k_cache_base,
+                        V_DRAM_ADDR=v_cache_base,
                         BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                        OUTPUT_DRAM_ADDR=(self.LAYER0_FLASH_OUTPUT_DRAM
+                                          + kv_h * qpkv * ahd * bpe),
                         SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
                         IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
                         gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
+                        q_pre_scaled=True,
                     )
                     total_flops += attn_result or 0
-                    # Copy per-head output to its slot in FLASH_OUTPUT_DRAM.
-                    self.accelerator_memory_to_sram(
-                        self.LAYER0_FLASH_OUT_HEAD_DRAM, 0x40000, qpkv * ahd)
-                    self.sram_to_accelerator_memory(
-                        0x40000, self.LAYER0_FLASH_OUTPUT_DRAM + kv_h * qpkv * ahd * bpe, qpkv * ahd)
-                total_flops += self.quantized_matmat_core(M=1, K=self.head_dim * self.group_size, N=self.vector_length,
+                total_flops += decoder_matmat_mul_core(K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
                 # LLaMA: no post-attention norm; residual directly on o_proj output
-                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_INPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
+                self.accelerator_memory_to_sram(accelerator_dram_address=layer_input_addr, sram_address=0x10000, element_size=self.vector_length)
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, sram_address=0x90000, element_size=self.vector_length)
                 self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
@@ -1004,21 +1016,21 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off)
 
-                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
+                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True)
-                total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.mlp_elements,
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True, is_B_quantized=True)
+                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_GATE_DRAM, sram_address=0x10000, element_size=self.mlp_elements)
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
                 self.eltwise_mul_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.mlp_elements)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_MLP_MULT_DRAM, element_size=self.mlp_elements)
 
-                total_flops += self.quantized_matmat_core(M=1, K=self.mlp_elements, N=self.vector_length,
+                total_flops += decoder_matmat_mul_core(K=self.mlp_elements, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
-                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4)
+                    SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
                 # LLaMA: no post-FFN norm; residual directly on down_proj output
                 self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, sram_address=0x10000, element_size=self.vector_length)
@@ -1031,15 +1043,51 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 OUTPUT_DRAM_ADDR=self.OUTPUT_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_OUTPUT_NORM_GAMMA)
             penalty_kwargs = dict(C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N") \
                 if bool(getattr(self, "fpga_penalty", False)) else {}
-            total_flops += self.quantized_matmat_core(M=1, K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+            # LM head uses the same dual-kernel dispatch as the layer matmuls (mirrors gemma3):
+            # streaming IF4 by default, dequantize-to-bf16 dot under --matmatmul. Both kernels
+            # honor the folded repetition-penalty bias (broadcast_N) and the argmax-only
+            # write_back_disable, so the HW argmax still returns the penalized token id.
+            total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
-                SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4,
+                SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4, is_B_quantized=True,
                 write_back_disable=True, **penalty_kwargs)
 
         self.generate_instruction_halt()
         decoder_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
         return {"program_size_bytes": decoder_program_size, "total_flops": total_flops}
+
+    def _instruction_paths(self) -> tuple[str, str]:
+        """(bin, meta) cache paths for the current compile mode (mirrors gemma3's tagging).
+
+        The captured image depends on BOTH the decode matmul kernel (``--matmatmul`` folds a
+        dequantize-to-bf16 dot in place of the streaming IF4 dot) and the on-FPGA penalty
+        (which folds a bias term into the LM-head matmul), so each combination gets its own
+        cache entry — otherwise switching modes silently reuses a stale bin compiled for the
+        other one.
+        """
+        paths_cfg = self._cfg.get("paths", {})
+        bin_rel = paths_cfg.get("instruction_bin", "llama3.2_1b_bin/programs.bin")
+        meta_rel = paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json")
+        tag = ("_matmatmul" if self.matmatmul else "")
+        tag += ("" if bool(getattr(self, "fpga_penalty", False)) else "_puregreedy")
+        if tag:
+            b_root, b_ext = os.path.splitext(bin_rel)
+            m_root, m_ext = os.path.splitext(meta_rel)
+            bin_rel, meta_rel = f"{b_root}{tag}{b_ext}", f"{m_root}{tag}{m_ext}"
+        return (os.path.join(self.script_dir, bin_rel), os.path.join(self.script_dir, meta_rel))
+
+    def _instruction_compiler_fingerprint(self, layer_size: int) -> str:
+        """Hash every local input that can change the captured instruction stream."""
+        digest = hashlib.sha256()
+        config_path = os.path.join(self.script_dir, "llama3.2_1b_config.json")
+        for source_path in (__file__, user_dma_core.__file__, config_path):
+            digest.update(os.path.abspath(source_path).encode())
+            with open(source_path, "rb") as source_file:
+                digest.update(source_file.read())
+        digest.update(
+            f"layers={layer_size};matmatmul={self.matmatmul};penalty={getattr(self, 'fpga_penalty', False)}".encode())
+        return digest.hexdigest()
 
     def compile_llama(self, layer_size: int | None = None) -> None:
         """Compile prefill + decoder into a single combined instruction image.
@@ -1048,7 +1096,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         Prefill is compiled with a fixed template (UE_VECTOR_SIZE) — all runtime
         loop counts are driven by GPRs primed by the preamble, so the same bin
-        works for any seq_len. If both bin and meta already exist, this is a no-op.
+        works for any seq_len. A matching compiler fingerprint makes this a no-op.
 
         Writes:
           - paths.instruction_bin  : combined raw instruction stream
@@ -1056,15 +1104,24 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         """
         if layer_size is None:
             layer_size = self.LAYER_SIZE
-        paths_cfg = self._cfg.get("paths", {})
-        instruction_bin_path = os.path.join(self.script_dir, paths_cfg.get("instruction_bin", "llama3.2_1b_bin/programs.bin"))
-        instruction_meta_path = os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json"))
+        instruction_bin_path, instruction_meta_path = self._instruction_paths()
         self._instruction_bin_path = instruction_bin_path
         self._instruction_meta_path = instruction_meta_path
+        compiler_fingerprint = self._instruction_compiler_fingerprint(layer_size)
+        print(f"Decode matmul kernel: {'matmat_mul_core (dequantize->bf16 dot, 2-pass)' if self.matmatmul else 'quantized_matmat_core (streaming IF4, 1-pass)'}")
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
-            print(f"Reusing existing instruction image at {instruction_bin_path}")
-            print(f"  delete {instruction_bin_path} to force recompile.")
-            return
+            try:
+                with open(instruction_meta_path, "r") as meta_file:
+                    cached_meta = json.load(meta_file)
+                cached_bin_size = os.path.getsize(instruction_bin_path)
+            except (OSError, ValueError, TypeError):
+                cached_meta = {}
+                cached_bin_size = -1
+            if (cached_meta.get("compiler_fingerprint") == compiler_fingerprint
+                    and cached_meta.get("instruction_total_size") == cached_bin_size):
+                print(f"Reusing validated instruction image at {instruction_bin_path}")
+                return
+            print(f"Rebuilding stale instruction image at {instruction_bin_path}")
 
         # Compile the prefill template at PREFILL_CONTEXT_SIZE (the max prompt length).
         # All loop counts are GPR-driven (gpr_seq_len), so the single cached program
@@ -1101,6 +1158,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         metadata = {
             "instruction_bin": os.path.relpath(instruction_bin_path, self.script_dir),
+            "compiler_fingerprint": compiler_fingerprint,
             "instruction_base_addr": f"0x{instruction_base_addr:X}",
             "instruction_total_size": len(instruction_bytes),
             "prefill_template_seq_len": template_seq_len,
@@ -1176,10 +1234,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         Primes GPRs via a small captured preamble that jumps into the cached
         prefill or decoder program at runtime.
         """
-        paths_cfg = self._cfg.get("paths", {})
-        # With the on-FPGA penalty (default) use the penalty-specific bin/meta compile_llama produced.
-        meta_path = getattr(self, "_instruction_meta_path", None) or \
-            os.path.join(self.script_dir, paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json"))
+        # Mode-specific bin/meta (decode matmul kernel + penalty) that compile_llama produced.
+        meta_path = getattr(self, "_instruction_meta_path", None) or self._instruction_paths()[1]
         with open(meta_path, "r") as f:
             meta = json.load(f)
 
@@ -1223,6 +1279,37 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.allocate_program_dram(self.get_capture_instruction_size_bytes())
         self.clear_capture_buffer()
 
+        # Build every position-dependent decoder preamble once. Each 64-byte-aligned
+        # entry is six instructions (four register sets, jump, unreachable padding NOP),
+        # so the hot loop only selects an address instead of compiling and DMA-writing it.
+        decoder_dispatch_addr = self.get_program_dram_addr()
+        decoder_dispatch_stride = 6 * INSTRUCTION_SIZE_BYTES
+        self.clear_inst_id()
+        self.start_capture()
+        for decode_pos in range(prefill_seq_len, self.MAX_CONTEXT_SIZE):
+            runtime_seq_len = decode_pos + 1
+            runtime_aligned_seq_len = ((runtime_seq_len + 63) // 64) * 64
+            runtime_bucket_idx = min((runtime_seq_len + 63) // 64, _max_gpr_bucket)
+            entry_start = self.capture_count
+            self.clear_inst_id()
+            self.generate_instruction_add_set(self.gpr_bucket_idx, runtime_bucket_idx)
+            self.generate_instruction_add_set(self.gpr_aligned_seq_len, runtime_aligned_seq_len)
+            self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
+            self.generate_instruction_add_set(self.ROPE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _rope_row))
+            self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
+            self.generate_instruction_nop()
+            entry_size = self.capture_count - entry_start
+            assert entry_size == 6, (
+                f"decoder dispatch entry at position {decode_pos} has {entry_size} instructions"
+            )
+        self.stop_capture()
+        decoder_dispatch_size = self.get_capture_instruction_size_bytes()
+        dispatch_bytes_written = self.write_captured_instructions_to_dram(decoder_dispatch_addr)
+        if dispatch_bytes_written != decoder_dispatch_size:
+            raise RuntimeError("Failed to write the complete decoder dispatch table")
+        self.allocate_program_dram(decoder_dispatch_size)
+        self.clear_capture_buffer()
+
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
@@ -1243,6 +1330,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         print("--- Starting decoder ---")
         hw_decode_lats_us: list[float] = []
         decoded_chars: list[str] = []
+        decode_bias_host: torch.Tensor | None = None
+        decode_bias_aligned_seq_len = 0
         timer = time.perf_counter()
         token_id = self.prefill_seq[-1]
         _llama_stop_tokens = {128001, 128008, self._end_of_turn_token_id}
@@ -1302,30 +1391,28 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             _SILENT_MODE = True
             self.seq_len += 1
             aligned_seq_len = ((self.seq_len + 63) // 64) * 64
-            bucket_idx = min((self.seq_len + 63) // 64, _max_gpr_bucket)
             decode_pos = self.seq_len - 1
 
-            embedding_tensor = self.get_embedding_for_tokens([token_id])
+            if 0 <= token_id < self.embedding_weight.shape[0]:
+                embedding_tensor = self.embedding_weight[token_id:token_id + 1]
+            else:
+                embedding_tensor = self.get_embedding_for_tokens([token_id])
             self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
             # unified_attention_core's dynamic path always uses bias_mode="full_matrix" (one bias
             # row per batch item); the decoder attention call's batch=qpkv query heads all share the
-            # same causal mask, so replicate the single mask row qpkv times (mirrors gemma3_test.py).
-            bias_host = torch.full((1, aligned_seq_len), -1e36, dtype=torch.bfloat16)
-            bias_host[0, :self.seq_len] = 0.0
-            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_host.repeat(self.group_size, 1))
+            # same causal mask. Reuse one contiguous buffer within each 64-token bucket.
+            if aligned_seq_len != decode_bias_aligned_seq_len:
+                decode_bias_host = torch.full(
+                    (self.group_size, aligned_seq_len), -1e36, dtype=torch.bfloat16)
+                decode_bias_host[:, :self.seq_len] = 0.0
+                decode_bias_aligned_seq_len = aligned_seq_len
+            else:
+                decode_bias_host[:, self.seq_len - 1] = 0.0
+            self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, decode_bias_host)
 
-            # Decoder preamble: prime position GPRs (+ gpr_aligned_seq_len for
-            # unified_attention_core's dynamic aligned_seq_len), then jump into cached decoder.
-            self.clear_inst_id()
-            self.start_capture()
-            self.generate_instruction_add_set(self.gpr_bucket_idx, bucket_idx)
-            self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
-            self.generate_instruction_add_set(self.V_CACHE_SIZE_REG, ue_35bit_addr_shifter(decode_pos * _kv_stride))
-            self.generate_instruction_add_set(self.ROPE_SIZE_REG,    ue_35bit_addr_shifter(decode_pos * _rope_row))
-            self.generate_instruction_jump_abs(ue_35bit_addr_shifter(decoder_program_addr))
-            self.stop_capture()
-            self.write_captured_instructions_to_dram(preamble_addr)
-            self.clear_capture_buffer()
+            # Select the prebuilt register setup + jump for this absolute position.
+            decoder_step_addr = decoder_dispatch_addr + (
+                decode_pos - prefill_seq_len) * decoder_dispatch_stride
 
             # On-FPGA penalty: refresh the per-vocab bias (this step's LM-head matmul C term) from the
             # windowed token frequency once past the gate, so the HW argmax of (logits + bias) returns
@@ -1335,7 +1422,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if _fpga_penalty and (self.seq_len - prefill_seq_len) > _greedy_until:
                 self._write_penalty_bias(self._generated_tokens)
 
-            hw_lat_dec_us, _ = self.program_execute(preamble_addr, flops=decoder_flops_per_token)
+            hw_lat_dec_us, _ = self.program_execute(decoder_step_addr, flops=decoder_flops_per_token)
             hw_decode_lats_us.append(hw_lat_dec_us)
             # Token selection: read the HW argmax register. In penalty mode the LM-head matmul
             # already added the bias, so the register holds the penalized token; in plain mode it's
@@ -1366,6 +1453,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         hw_decode_avg_ms = sum(hw_decode_lats_us) / len(hw_decode_lats_us) / 1e3 if hw_decode_lats_us else 0.0
         hw_decode_first_ms = hw_decode_lats_us[0] / 1e3 if hw_decode_lats_us else 0.0
         cpu_decode_avg_ms = latency_decoder * 1e3 / tokens_decoded if tokens_decoded else 0.0
+        peak_tokens_per_s = 1000.0 / hw_decode_first_ms if hw_decode_first_ms > 0 else 0.0
+        avg_tokens_per_s = tokens_decoded / latency_decoder if latency_decoder > 0 else 0.0
         _original_print("\n=== Performance Summary ===")
         _original_print(f"Instruction size  : prefill={meta['prefill_program_size']/1024:.1f} kB  decoder={meta['decoder_program_size']/1024:.1f} kB  total={(meta['prefill_program_size']+meta['decoder_program_size'])/1024:.1f} kB")
         _original_print(f"Prefill ({prefill_seq_len} tokens): HW={hw_lat_prefill_us/1e3:,.1f} ms  CPU={latency_prefill*1e3:,.1f} ms")
@@ -1376,10 +1465,19 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             "prefill_tokens": prefill_seq_len,
             "decoded_text": "".join(decoded_chars),
             "decoded_tokens": tokens_decoded,
+            # Compatibility aliases shared with Gemma3 and user_hw_test.py.
+            "tokens_decoded": tokens_decoded,
+            "avg_tokens_per_s": avg_tokens_per_s,
+            "peak_tokens_per_s": peak_tokens_per_s,
             "prefill_speed_tok_s": round(prefill_seq_len / latency_prefill, 2),
-            "decode_speed_tok_s": round(tokens_decoded / latency_decoder, 2),
+            "decode_speed_tok_s": round(avg_tokens_per_s, 2),
             "prefill_size_kb": round(meta["prefill_program_size"] / 1024, 1),
             "decoder_size_kb": round(meta["decoder_program_size"] / 1024, 1),
+            "prefill_hw_ms": hw_lat_prefill_us / 1e3,
+            "prefill_cpu_ms": latency_prefill * 1e3,
+            "decode_first_hw_ms": hw_decode_first_ms,
+            "decode_avg_hw_ms": hw_decode_avg_ms,
+            "decode_avg_cpu_ms": cpu_decode_avg_ms,
         }
 
 # -----------------------------------------------------------------------------
@@ -1387,7 +1485,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0
@@ -1403,6 +1501,12 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
     parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo, efinix).')
+    parser.add_argument('--matmatmul', action='store_true',
+                        help='Use matmat_mul_core for the decoder quantized matmats (incl. the LM head) '
+                             'instead of the default quantized_matmat_core (streaming) path. Same IF4 '
+                             'weights either way: matmat_mul_core dequantizes B to bf16 in URAM and does '
+                             'a bf16 dot (2 passes over the weight bytes, ~2x slower, higher-precision '
+                             'accumulate); the default streams IF4 through the dot unit in 1 pass.')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly — no logit readback,
     # fully deterministic. --pure-greedy disables it entirely.
@@ -1450,7 +1554,7 @@ def main():
     ue = UnifiedEngine()
     ue.software_reset()
     
-    ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel)
+    ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel, matmatmul=args.matmatmul)
     cfg = _load_config(script_dir)
 
     if args.prompt is not None:

--- a/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
+++ b/models/llama3.2_3b/llama3.2_3b_run_from_bin.py
@@ -535,7 +535,7 @@ def _verify_artifacts(script_dir: str, cfg: dict, fpga_penalty: bool = False) ->
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/llama3.2_3b/llama3.2_3b_test.py
+++ b/models/llama3.2_3b/llama3.2_3b_test.py
@@ -1275,7 +1275,7 @@ class Llama32_3b_UnifiedEngine(UnifiedEngine):
 # -----------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/mobilenetv2/mobilenetv2_224_test.py
+++ b/models/mobilenetv2/mobilenetv2_224_test.py
@@ -1132,7 +1132,7 @@ def preprocess_image(image_path: str, size: int = 224) -> torch.Tensor:
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
     if device == "efinix":                         return 4.0
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/mobilenetv2/mobilenetv2_ssd_fpnlite_640_test.py
+++ b/models/mobilenetv2/mobilenetv2_ssd_fpnlite_640_test.py
@@ -2177,7 +2177,7 @@ def draw_and_save(img: "Image.Image", W0: int, H0: int, size: int,
 # ---------------------------------------------------------------------------
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/mobilesam/mobilesam_run_from_bin.py
+++ b/models/mobilesam/mobilesam_run_from_bin.py
@@ -211,7 +211,7 @@ class MobileSAM_UE_Run(UnifiedEngine):
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
     if device == "efinix":                         return 4.0
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/mobilesam/mobilesam_test.py
+++ b/models/mobilesam/mobilesam_test.py
@@ -4527,7 +4527,7 @@ def _bn_fold(w_conv, bn_w, bn_b, bn_mean, bn_var, eps=1e-5):
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
     if device == "efinix":                         return 4.0
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/parakeet/parakeet_run_from_bin.py
+++ b/models/parakeet/parakeet_run_from_bin.py
@@ -452,7 +452,7 @@ def check_bins_early():
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/parakeet/parakeet_stream.py
+++ b/models/parakeet/parakeet_stream.py
@@ -404,7 +404,7 @@ _event_loop = None
 
 def main():
     global _event_loop
-    args = argparse.Namespace(dev="xdma0", cycle=5.1594, port=8000, chunk_seconds=5)
+    args = argparse.Namespace(dev="xdma0", cycle=1000 / (1066 / 5.375), port=8000, chunk_seconds=5)
 
     _original_print("Initializing FPGA engines...")
     init_engine(args)

--- a/models/parakeet/parakeet_test.py
+++ b/models/parakeet/parakeet_test.py
@@ -1729,7 +1729,7 @@ class Parakeet_UnifiedEngine(UnifiedEngine):
         return tokens
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/qwen2.5_vl_3b/qwen2.5_vl_3b_run_from_bin.py
+++ b/models/qwen2.5_vl_3b/qwen2.5_vl_3b_run_from_bin.py
@@ -3241,7 +3241,7 @@ def process_image(image_path: str, size: int = 448) -> torch.Tensor:
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/qwen2.5_vl_3b/qwen2.5_vl_3b_test.py
+++ b/models/qwen2.5_vl_3b/qwen2.5_vl_3b_test.py
@@ -3142,7 +3142,7 @@ def process_image(image_path: str, size: int = 448) -> torch.Tensor:
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/smolvlm2/smolvlm2_run_from_bin.py
+++ b/models/smolvlm2/smolvlm2_run_from_bin.py
@@ -593,7 +593,7 @@ def build_input_ids(tokenizer, prompt: str, has_image: bool = True) -> list:
 # =============================================================================
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/smolvlm2/smolvlm2_test.py
+++ b/models/smolvlm2/smolvlm2_test.py
@@ -1534,7 +1534,7 @@ def build_input_ids(tokenizer, prompt: str, has_image: bool = True) -> list:
 # =============================================================================
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/models/swin/swin_test.py
+++ b/models/swin/swin_test.py
@@ -1639,7 +1639,7 @@ def preprocess_image(image_path: str) -> torch.Tensor:
 
 def _clock_ns_default_for_device(device: str) -> float:
     """Return default clock period (ns) for FPGA type — mirrors user_hw_test.py."""
-    if device == "kintex7":                       return 5.1594
+    if device == "kintex7":                       return 1000 / (1066 / 5.375)
     if device in ("rk", "puzhi"):                 return 3.0
     if device in ("bittware", "bittware_256"):     return 3.3333
     if device == "alveo":                          return 4.0

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -554,6 +554,7 @@ class UnifiedEngine:
         self.h2c_device = DMA_DEVICE_H2C
         self.c2h_device = DMA_DEVICE_C2H
         self.user_device = DMA_DEVICE_USER
+        self._user_fd: Optional[int] = None
         if BASE_ADDR is None:
             BASE_ADDR = UE_0_BASE_ADDR
 
@@ -849,6 +850,20 @@ class UnifiedEngine:
         """Read 32-bit register using AXI-Lite user interface"""
         return self.user_read_reg32(address)
 
+    def _get_user_fd(self) -> int:
+        """Return one lazily opened AXI-Lite descriptor for this engine."""
+        if self._user_fd is None:
+            self._user_fd = os.open(self.user_device, os.O_RDWR)
+        return self._user_fd
+
+    def __del__(self):
+        fd = getattr(self, "_user_fd", None)
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
     def user_write_reg32(self, address: int, value: int):
         """
         Write 32-bit register via /dev/xdma0_user (AXI-Lite interface)
@@ -858,21 +873,18 @@ class UnifiedEngine:
             value: 32-bit value to write
         """
         try:
-            fd = os.open(DMA_DEVICE_USER, os.O_RDWR)
-            try:
-                # Subtract base address to get offset within the BAR
-                offset = address + self._base_addr - AXI_LITE_TRANSLATION_OFFSET
-                data_bytes = struct.pack('I', value & 0xFFFFFFFF)
-                # Use pwrite to write at offset (device doesn't support lseek)
-                os.pwrite(fd, data_bytes, offset)
-            finally:
-                os.close(fd)
+            fd = self._get_user_fd()
+            # Subtract base address to get offset within the BAR
+            offset = address + self._base_addr - AXI_LITE_TRANSLATION_OFFSET
+            data_bytes = struct.pack('I', value & 0xFFFFFFFF)
+            # Use pwrite to write at offset (device doesn't support lseek)
+            os.pwrite(fd, data_bytes, offset)
         except PermissionError as e:
-            print(f"Permission denied: {DMA_DEVICE_USER}")
+            print(f"Permission denied: {self.user_device}")
             print(f"  Error: {e}")
-            print(f"  Run with sudo or: sudo chmod 666 {DMA_DEVICE_USER}")
+            print(f"  Run with sudo or: sudo chmod 666 {self.user_device}")
         except FileNotFoundError as e:
-            print(f"Device not found: {DMA_DEVICE_USER}")
+            print(f"Device not found: {self.user_device}")
             print(f"  Error: {e}")
             print(f"  Ensure XDMA driver is loaded")
         except OSError as e:
@@ -889,24 +901,21 @@ class UnifiedEngine:
             32-bit register value, or 0 on error
         """
         try:
-            fd = os.open(DMA_DEVICE_USER, os.O_RDONLY)
-            try:
-                # Subtract base address to get offset within the BAR
-                offset = address + self._base_addr - AXI_LITE_TRANSLATION_OFFSET
-                # Use pread to read at offset (device doesn't support lseek)
-                data_bytes = os.pread(fd, 4, offset)
-                if len(data_bytes) == 4:
-                    return struct.unpack('I', data_bytes)[0]
-                return 0
-            finally:
-                os.close(fd)
+            fd = self._get_user_fd()
+            # Subtract base address to get offset within the BAR
+            offset = address + self._base_addr - AXI_LITE_TRANSLATION_OFFSET
+            # Use pread to read at offset (device doesn't support lseek)
+            data_bytes = os.pread(fd, 4, offset)
+            if len(data_bytes) == 4:
+                return struct.unpack('I', data_bytes)[0]
+            return 0
         except PermissionError as e:
-            print(f"Permission denied: {DMA_DEVICE_USER}")
+            print(f"Permission denied: {self.user_device}")
             print(f"  Error: {e}")
-            print(f"  Run with sudo or: sudo chmod 666 {DMA_DEVICE_USER}")
+            print(f"  Run with sudo or: sudo chmod 666 {self.user_device}")
             return 0
         except FileNotFoundError as e:
-            print(f"Device not found: {DMA_DEVICE_USER}")
+            print(f"Device not found: {self.user_device}")
             print(f"  Error: {e}")
             print(f"  Ensure XDMA driver is loaded")
             return 0
@@ -922,22 +931,24 @@ class UnifiedEngine:
         # axi_top.sv UE_QUEUE_FIFO_DATA: queue_busy is bit [8].
         return ((queue_reg >> 8) & 0x1) == 1
 
-    def wait_queue(self, timeout_seconds: float = 5.0):
+    def wait_queue(self, timeout_seconds: float = 5.0, poll_interval_seconds: float = 0.001):
         """
         Wait for queue to finish
 
         Args:
-            timeout_seconds: Maximum time to wait in seconds (default: 10.0)
+            timeout_seconds: Maximum time to wait in seconds.
+            poll_interval_seconds: Delay between status reads. The 1 ms default avoids
+                adding up to 10 ms of completion-detection latency to every decoded token.
         """
-        start_time = time.time()
+        start_time = time.monotonic()
         iteration = 0
 
         while self.is_queue_busy():
-            time.sleep(0.01)  # 0.01s sleep
+            time.sleep(poll_interval_seconds)
             iteration += 1
 
             # Check timeout
-            elapsed = time.time() - start_time
+            elapsed = time.monotonic() - start_time
             if elapsed >= timeout_seconds:
                 print(f"Error: wait_queue() timed out after {timeout_seconds:.1f} seconds ({iteration} iterations)")
                 return
@@ -7030,6 +7041,7 @@ class UnifiedEngine:
         gpr_scratch_addr: int = None,
         gpr_identity_addr: int = None,
         q_scale: float = None,
+        q_pre_scaled: bool = False,
     ) -> int:
         """Scaled dot-product attention with explicit batch and aligned KV length.
 
@@ -7038,6 +7050,8 @@ class UnifiedEngine:
         folds the query scaling elsewhere (e.g. Gemma folds it into ``q_norm`` and
         passes ``q_scale=1.0`` for no additional rescale). A runtime
         ``gpr_scale_reg`` still overrides this baked scalar on the dynamic path.
+        ``q_pre_scaled=True`` skips the Q multiply entirely when the caller has
+        already applied the same scalar after RoPE.
 
         Runtime-``head_dim`` extension (all optional, dynamic path only):
           * ``gpr_head_dim_reg`` — head_dim as a runtime register (drives the score/PV matmul K/N and,
@@ -7079,6 +7093,7 @@ class UnifiedEngine:
                 SCRATCH_DRAM_ADDR=SCRATCH_DRAM_ADDR,
                 IDENTITY_DRAM_ADDR=IDENTITY_DRAM_ADDR,
                 q_scale=q_scale,
+                q_pre_scaled=q_pre_scaled,
             )
         if any(g is not None for g in _addr_gprs) and (gpr_batch_reg is None or gpr_aligned_seq_len_reg is None):
             raise ValueError("unified_attention_core: gpr_*_addr require both gpr_batch_reg and gpr_aligned_seq_len_reg")
@@ -7105,6 +7120,7 @@ class UnifiedEngine:
             gpr_scratch_addr=gpr_scratch_addr,
             gpr_identity_addr=gpr_identity_addr,
             q_scale=q_scale,
+            q_pre_scaled=q_pre_scaled,
         )
 
     def unified_attention_core_legacy(
@@ -7120,6 +7136,7 @@ class UnifiedEngine:
         SCRATCH_DRAM_ADDR: int,
         IDENTITY_DRAM_ADDR: int = None,
         q_scale: float = None,
+        q_pre_scaled: bool = False,
     ) -> int:
         bytes_per_element = 2
         if batch <= 0 or aligned_seq_len <= 0 or head_dim <= 0:
@@ -7140,20 +7157,24 @@ class UnifiedEngine:
             OUTPUT_DRAM_ADDR=v_t_dram_addr,
             IDENTITY_DRAM_ADDR=IDENTITY_DRAM_ADDR,
         )
-        total_flops = self.eltwise_core_dram(
-            M=batch,
-            N=head_dim,
-            dram_a=Q_DRAM_ADDR,
-            dram_b=None,
-            dram_out=scaled_q_dram_addr,
-            mode=UE_MODE.MUL_BROADCAST,
-            scalar=(q_scale if q_scale is not None else 1.0 / math.sqrt(head_dim)),
-        )
+        if q_pre_scaled:
+            total_flops = 0
+        else:
+            total_flops = self.eltwise_core_dram(
+                M=batch,
+                N=head_dim,
+                dram_a=Q_DRAM_ADDR,
+                dram_b=None,
+                dram_out=scaled_q_dram_addr,
+                mode=UE_MODE.MUL_BROADCAST,
+                scalar=(q_scale if q_scale is not None else 1.0 / math.sqrt(head_dim)),
+            )
+        score_q_dram_addr = Q_DRAM_ADDR if q_pre_scaled else scaled_q_dram_addr
         total_flops += self.matmat_mul_core(
             M=batch,
             K=head_dim,
             N=aligned_seq_len,
-            A_DRAM_ADDR=scaled_q_dram_addr,
+            A_DRAM_ADDR=score_q_dram_addr,
             B_DRAM_ADDR=K_DRAM_ADDR,
             OUTPUT_DRAM_ADDR=score_dram_addr,
             softmax_enable=True,
@@ -7195,6 +7216,7 @@ class UnifiedEngine:
         gpr_scratch_addr: int = None,
         gpr_identity_addr: int = None,
         q_scale: float = None,
+        q_pre_scaled: bool = False,
     ) -> int:
         bytes_per_element = 2
         if batch > aligned_seq_len:
@@ -7255,25 +7277,30 @@ class UnifiedEngine:
             gpr_out_addr=v_t_reg,
             gpr_identity_addr=gpr_identity_addr,
         )
-        total_flops = self.eltwise_core_dram(
-            M=batch,
-            N=head_dim,
-            dram_a=Q_DRAM_ADDR,
-            dram_b=None,
-            dram_out=scaled_q_dram_addr,
-            mode=UE_MODE.MUL_BROADCAST,
-            scalar=(q_scale if q_scale is not None else 1.0 / math.sqrt(head_dim)),
-            gpr_M_reg=gpr_batch_reg,
-            gpr_N_reg=sub_hd_n_reg,   # runtime head_dim -> dynamic eltwise; else N-baked PBI broadcast
-            gpr_a_addr=gpr_q_addr,
-            gpr_out_addr=scaled_q_reg,
-            gpr_scalar_reg=gpr_scale_reg,   # runtime scale override (host-primed); None -> baked scalar
-        )
+        if q_pre_scaled:
+            total_flops = 0
+        else:
+            total_flops = self.eltwise_core_dram(
+                M=batch,
+                N=head_dim,
+                dram_a=Q_DRAM_ADDR,
+                dram_b=None,
+                dram_out=scaled_q_dram_addr,
+                mode=UE_MODE.MUL_BROADCAST,
+                scalar=(q_scale if q_scale is not None else 1.0 / math.sqrt(head_dim)),
+                gpr_M_reg=gpr_batch_reg,
+                gpr_N_reg=sub_hd_n_reg,   # runtime head_dim -> dynamic eltwise; else N-baked PBI broadcast
+                gpr_a_addr=gpr_q_addr,
+                gpr_out_addr=scaled_q_reg,
+                gpr_scalar_reg=gpr_scale_reg,   # runtime scale override (host-primed); None -> baked scalar
+            )
+        score_q_dram_addr = Q_DRAM_ADDR if q_pre_scaled else scaled_q_dram_addr
+        score_q_reg = gpr_q_addr if q_pre_scaled else scaled_q_reg
         total_flops += self.matmat_mul_core(
             M=batch,
             K=head_dim,
             N=aligned_seq_len,
-            A_DRAM_ADDR=scaled_q_dram_addr,
+            A_DRAM_ADDR=score_q_dram_addr,
             B_DRAM_ADDR=K_DRAM_ADDR,
             OUTPUT_DRAM_ADDR=score_dram_addr,
             softmax_enable=True,
@@ -7282,7 +7309,7 @@ class UnifiedEngine:
             gpr_M_reg=gpr_batch_reg,
             gpr_K_reg=head_dim_reg,
             gpr_N_reg=gpr_aligned_seq_len_reg,
-            gpr_a_addr=scaled_q_reg,
+            gpr_a_addr=score_q_reg,
             gpr_b_addr=gpr_k_addr,
             gpr_out_addr=score_reg,
             gpr_c_addr=gpr_bias_addr,

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -5693,14 +5693,14 @@ if __name__ == "__main__":
     _seed_probe = torch.randn(4, dtype=torch.bfloat16)
     _RNG_STATE_START = _rng_state_fingerprint()
 
-    # kintex7 operates at 208 Mhz = 4.8077 ns
+    # kintex7 operates at 1066 / 5.375 MHz = 198.33 MHz = 5.0422 ns
     # kintex7_systolic operates at 149.614035 MHz = 6683 ps.
     # alveo operates at 180 Mhz = 5.5556 ns
     # kintex ultrascale+ operates at 333 Mhz = 3.0 ns
     # bittware board operates at 300 Mhz = 3.3333 ns
     clock = None
     if args.device == "kintex7":
-        clock = 1000 / 208
+        clock = 1000 / (1066 / 5.375)
     elif args.device == "kintex7_systolic":
         clock = 1000 / 149.61403
     elif args.device == "rk" or args.device == "puzhi":

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -5497,11 +5497,11 @@ def gemma3_inference_test() -> None:
         if ue.legacy:
             prefill_seq_len = len(ue.prefill_seq) - 1
             matmatmul_tag = "_matmatmul" if ue.matmatmul else ""
-            rel_path = f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.bin"
+            rel_path = f"gemma3_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.bin"
         elif ue.matmatmul:
-            rel_path = "gemma3_bin/gemma3_matmatmul_instruction.bin"
+            rel_path = "gemma3_bin/gemma3_matmatmul_program.bin"
         else:
-            rel_path = "gemma3_bin/gemma3_instruction.bin"
+            rel_path = "gemma3_bin/gemma3_program.bin"
         return os.path.join(ue.script_dir, rel_path)
 
     def _assert_result(label: str, result: dict) -> None:
@@ -5591,11 +5591,11 @@ def gemma3_if8_inference_test() -> None:
         if ue.legacy:
             prefill_seq_len = len(ue.prefill_seq) - 1
             matmatmul_tag = "_matmatmul" if ue.matmatmul else ""
-            rel_path = f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_instruction.bin"
+            rel_path = f"gemma3_if8_bin/gemma3_legacy{matmatmul_tag}_{prefill_seq_len}_program.bin"
         elif ue.matmatmul:
-            rel_path = "gemma3_if8_bin/gemma3_matmatmul_instruction.bin"
+            rel_path = "gemma3_if8_bin/gemma3_matmatmul_program.bin"
         else:
-            rel_path = "gemma3_if8_bin/gemma3_instruction.bin"
+            rel_path = "gemma3_if8_bin/gemma3_program.bin"
         return os.path.join(ue.script_dir, rel_path)
 
     def _assert_result(label: str, result: dict) -> None:


### PR DESCRIPTION
## Summary
This PR adds a `--matmatmul` command-line flag to enable alternative matmul kernel selection for the Llama 3.2 1B decoder, mirroring functionality from the Gemma3 implementation. The change allows users to switch between two quantized matmul strategies with different performance/precision tradeoffs.

## Key Changes

- **New `matmatmul` parameter**: Added to `Llama32_1b_UnifiedEngine.__init__()` to control decoder matmul kernel selection
  - `False` (default): Uses `quantized_matmat_core` for streaming IF4 dot product (1-pass, faster)
  - `True`: Uses `matmat_mul_core` with dequantize-to-bf16 in URAM (2-pass, higher precision)

- **New `decoder_matmat_mul_core()` helper function**: Dispatches between the two matmul kernels based on the `matmatmul` flag, with support for `force_stream` override

- **Updated all decoder matmul calls**: Replaced direct `quantized_matmat_core()` calls with `decoder_matmat_mul_core()` throughout the decoder program compilation, including:
  - Q/K/V projections
  - Attention output projection
  - MLP gate/up/down projections
  - LM head (with special handling for folded repetition-penalty bias)

- **Cache path tagging**: Added `_instruction_paths()` method to generate mode-specific bin/meta file paths, ensuring different compile modes don't reuse stale cached binaries

- **Command-line interface**: Added `--matmatmul` flag to the argument parser with detailed help text explaining the kernel differences

- **Compile feedback**: Added informational print statement showing which matmul kernel path is being used

## Implementation Details

The dual-kernel dispatch is transparent to the rest of the codebase — both kernels read the same IF4 weights and produce compatible outputs. The choice affects only the internal computation strategy:
- Streaming path: Unpacks FP4→BF16 inline through the DOT_PRODUCT unit
- Dequantize path: Dequantizes entire weight matrix to BF16 in URAM first, then performs BF16 dot

The LM head matmul specially preserves support for the on-FPGA repetition-penalty bias folding, which works with both kernel paths.

https://claude.ai/code/session_019BznfBq9vCLoorio7TuKoW