### PR TITLE
Clarify decoder-only matmatmul control

### DIFF
--- a/models/llama3.2_1b/README.md
+++ b/models/llama3.2_1b/README.md
@@ -38,6 +38,9 @@ python models/llama3.2_1b/llama3.2_1b_test.py --prompt "What is 2+2?" --two-pass
 # IF8 A/B: test one-pass streaming instead of its measured-faster dequantize/BF16 default
 python models/llama3.2_1b/llama3.2_1b_IF8.py --prompt "What is 2+2?" --stream-prefill
 
+# Decoder-only A/B: use dequantize/BF16 matmuls instead of the faster streaming decoder
+python models/llama3.2_1b/llama3.2_1b_test.py --prompt "What is 2+2?" --decoder-matmatmul
+
 # Override the board clock when needed (Kintex-7 default: 5.0422 ns / 198.33 MHz)
 python models/llama3.2_1b/llama3.2_1b_test.py --cycle 5.0422
 ```
@@ -61,7 +64,9 @@ The default minimal wrapper removes the tokenizer's automatically injected 25-to
 system/date block. The prefill compiler keeps layer state in one recurrent DRAM
 buffer and scales the full query tensor once. IF4 uses the one-pass streaming
 matmul; IF8 follows Gemma IF8 and uses the measured-faster dequantize/BF16
-matmul. Use `--standard-chat-template` when the dated system metadata is required.
+matmul. `--decoder-matmatmul` affects only decoder projections; the legacy
+`--matmatmul` spelling remains accepted as an alias. Use
+`--standard-chat-template` when the dated system metadata is required.
 
 ## Measured decode performance
 

--- a/models/llama3.2_1b/llama3.2_1b_IF8.py
+++ b/models/llama3.2_1b/llama3.2_1b_IF8.py
@@ -394,7 +394,8 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
     """
 
     def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None,
-                 matmatmul: bool = False, stream_prefill: bool = False):
+                 decoder_matmatmul: bool = False, stream_prefill: bool = False,
+                 matmatmul: bool | None = None):
         # Full 4 GB DRAM layout (mirrors qwen3_1.7b): the default split reserves only
         # 512 MB for the tensor region, which overflows at max_context_size=4096
         # (attention + activation buffers in tensor_init scale with context). The
@@ -408,11 +409,16 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             program_dram_base=0xE0000000,
         )
         self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
-        # Decode matmul kernel select (mirrors gemma3's --matmatmul):
+        # ``matmatmul`` is the legacy constructor keyword. It has always selected
+        # only the decoder kernel; retain it as an alias without letting the old
+        # ambiguous name leak into the execution logic.
+        if matmatmul is not None:
+            decoder_matmatmul = bool(matmatmul)
+        # Decode matmul kernel select (mirrors gemma3's --decoder-matmatmul):
         #   False (default) -> quantized_matmat_core: 1-pass streaming IF8 dot.
         #   True            -> matmat_mul_core(is_B_quantized=True): dequantize B to bf16
         #                      in URAM, then bf16 dot (2 passes over the weight bytes).
-        self.matmatmul = matmatmul
+        self.decoder_matmatmul = decoder_matmatmul
         # IF8 prefill is fastest through the dequantize-to-BF16 matmul on the
         # current hardware. Keep the IF4 one-pass streaming path available for
         # A/B testing, but do not make its 8-bit bandwidth penalty the default.
@@ -697,7 +703,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
         # buffer, eliminating the old OUTPUT->INPUT inter-layer copy.
         layer_input_addr = self.LAYER0_OUTPUT_DRAM
 
-        def prefill_matmat_mul_core(M: int, K: int, N: int, **kwargs) -> int:
+        def prefill_projection_core(M: int, K: int, N: int, **kwargs) -> int:
             """Select the measured-fast IF8 prefill kernel or streaming A/B path."""
             if self.stream_prefill:
                 kwargs.pop("is_B_quantized", None)
@@ -712,16 +718,16 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             if profile:
                 _checkpoint(f"L{layer_idx}_pre_norm")
 
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
             # v_proj writes to interleaved temp (T, 512); per-head KV cache populated below.
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_V_PROJ_TEMP,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
@@ -910,7 +916,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             if profile:
                 _checkpoint(f"L{layer_idx}_attention")
 
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
+            total_flops += prefill_projection_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
@@ -934,11 +940,11 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                               gpr_M_reg=self.gpr_seq_len)
             if profile:
                 _checkpoint(f"L{layer_idx}_pre_ffn_norm")
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF8, silu_enable=True,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
@@ -953,7 +959,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             )
             if profile:
                 _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
+            total_flops += prefill_projection_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF8,
                 gpr_M_reg=self.gpr_seq_len)
@@ -998,20 +1004,20 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
             checkpoints.append([name, f"0x{resume:X}"])
 
-        def decoder_matmat_mul_core(K: int, N: int, force_stream: bool = False, **kwargs) -> int:
-            """Decode matmul dispatch — the llama mirror of gemma3's ``decoder_matmat_mul_core``.
+        def decoder_projection_core(K: int, N: int, force_stream: bool = False, **kwargs) -> int:
+            """Select the streaming or compatibility decoder projection kernel.
 
             Both paths read the SAME IF8 weight; they differ in how the dot is computed:
 
-            - default (``--matmatmul`` off) -> :meth:`quantized_matmat_core`: 1-pass streaming
+            - default (``--decoder-matmatmul`` off) -> :meth:`quantized_matmat_core`: 1-pass streaming
               quantized dot (inline if8->bf19 unpack straight through the DOT_PRODUCT unit).
-            - ``--matmatmul`` -> :meth:`matmat_mul_core` with ``is_B_quantized=True``:
+            - ``--decoder-matmatmul`` -> :meth:`matmat_mul_core` with ``is_B_quantized=True``:
               DEQUANTIZES B to bf16 in URAM, then a bf16 dot — two passes over the weight
               bytes, so ~2x the DRAM traffic (and ~2x slower) for higher-precision accumulate.
 
             ``force_stream`` pins an individual call to the streaming path regardless of the flag.
             """
-            if not self.matmatmul or force_stream:
+            if not self.decoder_matmatmul or force_stream:
                 kwargs.pop("is_B_quantized", None)
                 return self.quantized_matmat_core(M=1, K=K, N=N, **kwargs)
             m_reg = self.alloc_isa_reg()
@@ -1029,13 +1035,13 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
                 if profile:
                     _checkpoint(f"L{layer_idx}_pre_norm")
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim * self.group_size,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.head_dim * self.group_size,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF8, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF8, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF8, is_B_quantized=True)
                 if profile:
@@ -1153,7 +1159,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                     total_flops += attn_result or 0
                 if profile:
                     _checkpoint(f"L{layer_idx}_attention")
-                total_flops += decoder_matmat_mul_core(K=self.head_dim * self.group_size, N=self.vector_length,
+                total_flops += decoder_projection_core(K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF8, is_B_quantized=True)
 
@@ -1171,10 +1177,10 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_pre_ffn_norm")
 
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF8, silu_enable=True, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF8, is_B_quantized=True)
 
@@ -1185,7 +1191,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
 
-                total_flops += decoder_matmat_mul_core(K=self.mlp_elements, N=self.vector_length,
+                total_flops += decoder_projection_core(K=self.mlp_elements, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF8, is_B_quantized=True)
 
@@ -1203,10 +1209,11 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             penalty_kwargs = dict(C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N") \
                 if bool(getattr(self, "fpga_penalty", False)) else {}
             # LM head uses the same dual-kernel dispatch as the layer matmuls (mirrors gemma3):
-            # streaming IF8 by default, dequantize-to-bf16 dot under --matmatmul. Both kernels
+            # streaming IF8 by default, dequantize-to-bf16 dot under
+            # --decoder-matmatmul. Both kernels
             # honor the folded repetition-penalty bias (broadcast_N) and the argmax-only
             # write_back_disable, so the HW argmax still returns the penalized token id.
-            total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+            total_flops += decoder_projection_core(K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF8, is_B_quantized=True,
                 write_back_disable=True, **penalty_kwargs)
@@ -1226,7 +1233,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         bin_rel = paths_cfg.get("instruction_bin", "llama3.2_1b_if8_bin/programs.bin")
         meta_rel = paths_cfg.get("instruction_meta", "llama3.2_1b_if8_bin/programs.json")
-        tag = ("_matmatmul" if self.matmatmul else "")
+        tag = ("_decoder_matmatmul" if self.decoder_matmatmul else "")
         tag += ("_streamprefill" if self.stream_prefill else "")
         tag += ("" if bool(getattr(self, "fpga_penalty", False)) else "_puregreedy")
         if tag:
@@ -1244,7 +1251,8 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             with open(source_path, "rb") as source_file:
                 digest.update(source_file.read())
         digest.update(
-            f"layers={layer_size};matmatmul={self.matmatmul};stream_prefill={self.stream_prefill};"
+            f"layers={layer_size};decoder_matmatmul={self.decoder_matmatmul};"
+            f"stream_prefill={self.stream_prefill};"
             f"penalty={getattr(self, 'fpga_penalty', False)}".encode())
         return digest.hexdigest()
 
@@ -1276,7 +1284,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
         self._instruction_bin_path = instruction_bin_path
         self._instruction_meta_path = instruction_meta_path
         compiler_fingerprint = self._instruction_compiler_fingerprint(layer_size)
-        print(f"Decode matmul kernel: {'matmat_mul_core (dequantize->bf16 dot, 2-pass)' if self.matmatmul else 'quantized_matmat_core (streaming IF8, 1-pass)'}")
+        print(f"Decode matmul kernel: {'matmat_mul_core (dequantize->bf16 dot, 2-pass)' if self.decoder_matmatmul else 'quantized_matmat_core (streaming IF8, 1-pass)'}")
         print(f"Prefill matmul kernel: {'quantized_matmat_core (streaming IF8, 1-pass A/B)' if self.stream_prefill else 'matmat_mul_core (dequantize->bf16 dot, measured-fast IF8 default)'}")
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             try:
@@ -1835,7 +1843,8 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
     parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo, efinix).')
-    parser.add_argument('--matmatmul', action='store_true',
+    parser.add_argument('--decoder-matmatmul', '--matmatmul',
+                        dest='decoder_matmatmul', action='store_true',
                         help='Use matmat_mul_core for the decoder quantized matmats (incl. the LM head) '
                              'instead of the default quantized_matmat_core (streaming) path. Same IF8 '
                              'weights either way: matmat_mul_core dequantizes B to bf16 in URAM and does '
@@ -1898,8 +1907,12 @@ def main():
     ue = UnifiedEngine()
     ue.software_reset()
 
-    ue = Llama32_1b_IF8_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel,
-                                  matmatmul=args.matmatmul, stream_prefill=args.stream_prefill)
+    ue = Llama32_1b_IF8_UnifiedEngine(
+        script_dir=script_dir,
+        weights_bin=weights_bin_rel,
+        decoder_matmatmul=args.decoder_matmatmul,
+        stream_prefill=args.stream_prefill,
+    )
     cfg = _load_config(script_dir)
 
     if args.prompt is not None:

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -328,7 +328,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
     """
 
     def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None,
-                 matmatmul: bool = False, stream_prefill: bool = True):
+                 decoder_matmatmul: bool = False, stream_prefill: bool = True,
+                 matmatmul: bool | None = None):
         # Full 4 GB DRAM layout (mirrors qwen3_1.7b): the default split reserves only
         # 512 MB for the tensor region, which overflows at max_context_size=4096
         # (attention + activation buffers in tensor_init scale with context). The
@@ -342,11 +343,16 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             program_dram_base=0xE0000000,
         )
         self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
-        # Decode matmul kernel select (mirrors gemma3's --matmatmul):
+        # ``matmatmul`` is the legacy constructor keyword. It has always selected
+        # only the decoder kernel; retain it as an alias without letting the old
+        # ambiguous name leak into the execution logic.
+        if matmatmul is not None:
+            decoder_matmatmul = bool(matmatmul)
+        # Decode matmul kernel select (mirrors gemma3's --decoder-matmatmul):
         #   False (default) -> quantized_matmat_core: 1-pass streaming IF4 dot.
         #   True            -> matmat_mul_core(is_B_quantized=True): dequantize B to bf16
         #                      in URAM, then bf16 dot (2 passes over the weight bytes).
-        self.matmatmul = matmatmul
+        self.decoder_matmatmul = decoder_matmatmul
         self.stream_prefill = stream_prefill
         self._cfg = _load_config(self.script_dir)
         self.weight_defs = self._cfg["_weight_defs"]
@@ -628,7 +634,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         # buffer, eliminating the old OUTPUT->INPUT inter-layer copy.
         layer_input_addr = self.LAYER0_OUTPUT_DRAM
 
-        def prefill_matmat_mul_core(M: int, K: int, N: int, **kwargs) -> int:
+        def prefill_projection_core(M: int, K: int, N: int, **kwargs) -> int:
             """Select the one-pass streaming prefill kernel or compatibility fallback."""
             if self.stream_prefill:
                 kwargs.pop("is_B_quantized", None)
@@ -643,16 +649,16 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if profile:
                 _checkpoint(f"L{layer_idx}_pre_norm")
 
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.head_dim * self.group_size,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
             # v_proj writes to interleaved temp (T, 512); per-head KV cache populated below.
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.head_dim,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.head_dim,
                 A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_V_PROJ_TEMP,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -841,7 +847,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if profile:
                 _checkpoint(f"L{layer_idx}_attention")
 
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
+            total_flops += prefill_projection_core(M=seq_len, K=self.head_dim * self.group_size, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -865,11 +871,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                               gpr_M_reg=self.gpr_seq_len)
             if profile:
                 _checkpoint(f"L{layer_idx}_pre_ffn_norm")
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True,
                 gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
                 A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -884,7 +890,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             )
             if profile:
                 _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
-            total_flops += prefill_matmat_mul_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
+            total_flops += prefill_projection_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
                 A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
                 is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4,
                 gpr_M_reg=self.gpr_seq_len)
@@ -929,20 +935,20 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
             checkpoints.append([name, f"0x{resume:X}"])
 
-        def decoder_matmat_mul_core(K: int, N: int, force_stream: bool = False, **kwargs) -> int:
-            """Decode matmul dispatch — the llama mirror of gemma3's ``decoder_matmat_mul_core``.
+        def decoder_projection_core(K: int, N: int, force_stream: bool = False, **kwargs) -> int:
+            """Select the streaming or compatibility decoder projection kernel.
 
             Both paths read the SAME IF4 weight; they differ in how the dot is computed:
 
-            - default (``--matmatmul`` off) -> :meth:`quantized_matmat_core`: 1-pass streaming
+            - default (``--decoder-matmatmul`` off) -> :meth:`quantized_matmat_core`: 1-pass streaming
               quantized dot (inline fp4->bf19 unpack straight through the DOT_PRODUCT unit).
-            - ``--matmatmul`` -> :meth:`matmat_mul_core` with ``is_B_quantized=True``:
+            - ``--decoder-matmatmul`` -> :meth:`matmat_mul_core` with ``is_B_quantized=True``:
               DEQUANTIZES B to bf16 in URAM, then a bf16 dot — two passes over the weight
               bytes, so ~2x the DRAM traffic (and ~2x slower) for higher-precision accumulate.
 
             ``force_stream`` pins an individual call to the streaming path regardless of the flag.
             """
-            if not self.matmatmul or force_stream:
+            if not self.decoder_matmatmul or force_stream:
                 kwargs.pop("is_B_quantized", None)
                 return self.quantized_matmat_core(M=1, K=K, N=N, **kwargs)
             m_reg = self.alloc_isa_reg()
@@ -960,13 +966,13 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                               OUTPUT_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_PRE_NORM_GAMMA + layer_off)
                 if profile:
                     _checkpoint(f"L{layer_idx}_pre_norm")
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim * self.group_size,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.head_dim * self.group_size,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_Q_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_Q_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_K_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_K_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.head_dim,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.head_dim,
                     A_DRAM_ADDR=self.LAYER0_PRE_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_V_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
                 if profile:
@@ -1084,7 +1090,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     total_flops += attn_result or 0
                 if profile:
                     _checkpoint(f"L{layer_idx}_attention")
-                total_flops += decoder_matmat_mul_core(K=self.head_dim * self.group_size, N=self.vector_length,
+                total_flops += decoder_projection_core(K=self.head_dim * self.group_size, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
@@ -1102,10 +1108,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_pre_ffn_norm")
 
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True, is_B_quantized=True)
-                total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.mlp_elements,
+                total_flops += decoder_projection_core(K=self.vector_length, N=self.mlp_elements,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
@@ -1116,7 +1122,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
 
-                total_flops += decoder_matmat_mul_core(K=self.mlp_elements, N=self.vector_length,
+                total_flops += decoder_projection_core(K=self.mlp_elements, N=self.vector_length,
                     A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4, is_B_quantized=True)
 
@@ -1134,10 +1140,11 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             penalty_kwargs = dict(C_DRAM_ADDR=self.PENALTY_BIAS_DRAM, bias_mode="broadcast_N") \
                 if bool(getattr(self, "fpga_penalty", False)) else {}
             # LM head uses the same dual-kernel dispatch as the layer matmuls (mirrors gemma3):
-            # streaming IF4 by default, dequantize-to-bf16 dot under --matmatmul. Both kernels
+            # streaming IF4 by default, dequantize-to-bf16 dot under
+            # --decoder-matmatmul. Both kernels
             # honor the folded repetition-penalty bias (broadcast_N) and the argmax-only
             # write_back_disable, so the HW argmax still returns the penalized token id.
-            total_flops += decoder_matmat_mul_core(K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
+            total_flops += decoder_projection_core(K=self.vector_length, N=self.EMBEDDING_ELEMENTS,
                 A_DRAM_ADDR=self.OUTPUT_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_QUANT, OUTPUT_DRAM_ADDR=self.LOGITS_DRAM,
                 SCALE_DRAM_ADDR=self.DRAM_ADDR_LM_HEAD_SCALE, data_type=TYPE.IF4, is_B_quantized=True,
                 write_back_disable=True, **penalty_kwargs)
@@ -1157,7 +1164,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         paths_cfg = self._cfg.get("paths", {})
         bin_rel = paths_cfg.get("instruction_bin", "llama3.2_1b_bin/programs.bin")
         meta_rel = paths_cfg.get("instruction_meta", "llama3.2_1b_bin/programs.json")
-        tag = ("_matmatmul" if self.matmatmul else "")
+        tag = ("_decoder_matmatmul" if self.decoder_matmatmul else "")
         tag += ("" if self.stream_prefill else "_twopassprefill")
         tag += ("" if bool(getattr(self, "fpga_penalty", False)) else "_puregreedy")
         if tag:
@@ -1175,7 +1182,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             with open(source_path, "rb") as source_file:
                 digest.update(source_file.read())
         digest.update(
-            f"layers={layer_size};matmatmul={self.matmatmul};stream_prefill={self.stream_prefill};"
+            f"layers={layer_size};decoder_matmatmul={self.decoder_matmatmul};"
+            f"stream_prefill={self.stream_prefill};"
             f"penalty={getattr(self, 'fpga_penalty', False)}".encode())
         return digest.hexdigest()
 
@@ -1207,7 +1215,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self._instruction_bin_path = instruction_bin_path
         self._instruction_meta_path = instruction_meta_path
         compiler_fingerprint = self._instruction_compiler_fingerprint(layer_size)
-        print(f"Decode matmul kernel: {'matmat_mul_core (dequantize->bf16 dot, 2-pass)' if self.matmatmul else 'quantized_matmat_core (streaming IF4, 1-pass)'}")
+        print(f"Decode matmul kernel: {'matmat_mul_core (dequantize->bf16 dot, 2-pass)' if self.decoder_matmatmul else 'quantized_matmat_core (streaming IF4, 1-pass)'}")
+        print(f"Prefill matmul kernel: {'quantized_matmat_core (streaming IF4, measured-fast default)' if self.stream_prefill else 'matmat_mul_core (dequantize->bf16 dot, compatibility A/B)'}")
         if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             try:
                 with open(instruction_meta_path, "r") as meta_file:
@@ -1765,7 +1774,8 @@ def main():
     parser.add_argument('--dev', type=str, default='xdma0', help='DMA device name (default: xdma0)')
     parser.add_argument('--cycle', type=float, default=None, help='Clock cycle time in ns. Overrides --device default.')
     parser.add_argument('--device', type=str, default='kintex7', help='FPGA board profile (kintex7, rk, puzhi, bittware, bittware_256, alveo, efinix).')
-    parser.add_argument('--matmatmul', action='store_true',
+    parser.add_argument('--decoder-matmatmul', '--matmatmul',
+                        dest='decoder_matmatmul', action='store_true',
                         help='Use matmat_mul_core for the decoder quantized matmats (incl. the LM head) '
                              'instead of the default quantized_matmat_core (streaming) path. Same IF4 '
                              'weights either way: matmat_mul_core dequantizes B to bf16 in URAM and does '
@@ -1828,8 +1838,12 @@ def main():
     ue = UnifiedEngine()
     ue.software_reset()
     
-    ue = Llama32_1b_UnifiedEngine(script_dir=script_dir, weights_bin=weights_bin_rel,
-                                  matmatmul=args.matmatmul, stream_prefill=not args.two_pass_prefill)
+    ue = Llama32_1b_UnifiedEngine(
+        script_dir=script_dir,
+        weights_bin=weights_bin_rel,
+        decoder_matmatmul=args.decoder_matmatmul,
+        stream_prefill=not args.two_pass_prefill,
+    )
     cfg = _load_config(script_dir)
 
     if args.prompt is not None:


### PR DESCRIPTION
## Summary

This PR restores the Llama 3.2 1B maximum context to 4096 tokens and aligns the IF8 implementation with the optimized IF4 execution flow.

It also clarifies that `--matmatmul` was always a decoder-only option by introducing the explicit `--decoder-matmatmul` name while retaining `--matmatmul` as a compatibility alias.

## Changes

- Set `max_context_size` to 4096.
- Set RoPE `num_positions` to 4096.
- Applied the optimized IF4 execution flow to IF8:
  - Recurrent prefill layer buffer instead of inter-layer copies.
  - One query-scaling operation per layer.
  - Direct decoder attention reads from K/V caches.
  - Direct attention output placement.
  - Removed redundant decoder K/V history staging.
  - Removed decoder inter-layer hidden-state copies.
  - Prebuilt all position-dependent decoder dispatch entries.
  - Reused decoder bias buffers and embedding slices.
  - Added minimal chat-template support.
  - Added mode-specific program paths and compiler fingerprints.
  - Aligned profiling and performance-result reporting.
- Fixed profiled prefill to upload embeddings to the recurrent output buffer.
- Added parameter/tensor/program DRAM overlap checks.
- Renamed internal kernel dispatch helpers to clarify their roles:
  - `prefill_projection_core`
  - `decoder_projection_core`
- Added explicit `decoder_matmatmul` state and artifact tags.
- Added `--decoder-matmatmul`; legacy `--matmatmul` remains accepted.
- Updated the Llama 3.2 1B documentation and measured performance results.

## Root cause

The IF8 implementation had diverged from the optimized IF4 path and retained several redundant memory operations, including inter-layer copies, K/V history staging, repeated query scaling, per-token dispatch generation, and host-buffer reconstruction.

The previous `--matmatmul` name was also misleading: it only controlled decoder projections and never changed the prefill kernel.

Hardware profiling additionally showed that the best prefill kernel depends on weight precision:

- IF4 is faster with one-pass streaming prefill.
- IF8 is faster with dequantize-to-BF16 prefill, matching the Gemma IF8 implementation.

The precision-specific measured-fast defaults are therefore retained.

## Context and DRAM validation

Both IF4 and IF8 now use:

- Maximum decode context: 4096 tokens
- RoPE positions: 4096
- Maximum prefill execution: 128 tokens

Measured IF8 DRAM boundaries:

- Parameter end: `0x4CF9D000`
- Tensor start: `0x58000000`
- Tensor end: `0xBCE80400`
- Program start: `0xE0000000`

All regions fit without overlap.

## Hardware results

Test platform:

- Kintex-7
- Frequency: `1066 / 5.375 = 198.3256 MHz`
- Clock period: approximately `5.0422 ns`
- Hardware version: `0x884c96b9`
- Prompt: `x^2=-1`
- Executed prefill tokens: 14

### Final defaults

| Variant | Prefill latency | Prefill rate | Decode rate |
| --- | ---: | ---: | ---: |
| IF4 | 1,158.2 ms | 12.09 tok/s | 8.29 tok/s |
| IF8 | 1,349.8 ms | 10.38 tok/s | 4.55 tok/s |

### Prefill kernel comparison

| Variant and kernel | Prefill latency | Result |
| --- | ---: | --- |
| IF4 streaming | 1,158.6 ms | Fastest IF4 default |
| IF4 dequantize/BF16 | 1,273.6 ms | 9.9% slower |
| IF8 dequantize/BF16 | 1,350.2 ms | Fastest IF8 default |
| IF8 streaming | 2,231.3 ms | 39.5% higher latency |

### Decoder-only matmat comparison

`--decoder-matmatmul` does not alter prefill.

| IF4 decoder mode | Prefill | Decoder |
| --- | ---: | ---: |
| Streaming default | 1,158.6 ms | 118.3 ms/token |
| `--decoder-matmatmul` | 1,158.6 ms | 230.8 ms/token |

The legacy `--matmatmul` alias produced the same binary and measurements as `--decoder-matmatmul`.

## Validation

- Python syntax compilation passed for IF4, IF8, and runtime-only scripts.
- JSON configuration validation passed.
- IF4/IF8 structural method-parity check passed.
- CLI help and compatibility-alias checks passed.
- Git whitespace validation passed.
- Default IF4 and IF8 commands completed successfully on hardware.
- IF4 and IF8 profile modes completed successfully.
- Streaming and dequantize/BF16 A/B profiles completed successfully.
- Generated model weights, programs, and Python caches are not included in the commits.