### PR TITLE
Optimize Gemma4 FPGA LM execution

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_refactor.py
+++ b/models/gemma4_e2b/gemma4_e2b_refactor.py
@@ -79,7 +79,7 @@ VISION_QUANT_PRECISION = "if4"
 # lets the vision encoder bin be compiled once for a fixed shape.
 VISION_CANONICAL_SIZE = (896, 896)   # (width, height) for PIL.Image.resize
 VISION_FIXED_NUM_PATCHES = 2520
-LM_PROGRAM_CACHE_VERSION = 10
+LM_PROGRAM_CACHE_VERSION = 16
 
 # Shipped sample image for VLM mode (same as gemma4_e2b_test.py's DEFAULT_IMAGE):
 # repo test_samples/yosemite.jpg, two folders up from this script.
@@ -1040,7 +1040,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         non_layer = [
             (s["key"], f"{s['key']}_SIZE", s["attr"])
             for s in self._cfg["layers"]["non_layer"]
-            if s["key"] not in ("ROPE_LOCAL", "ROPE_GLOBAL")  # RoPE loaded via _load_rope_host()
+            if s["key"] not in ("ROPE_LOCAL", "ROPE_GLOBAL")  # loaded via _load_rope_host()
         ]
 
         last_structure_key = self._cfg["layers"]["structure"][-1]["key"]
@@ -1196,8 +1196,15 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         # GEMMA4_PENALTY is temporarily rejected.
         self.PENALTY_BIAS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
 
-        # Per-layer input injection buffers
-        # PER_LAYER_INPUTS_DRAM: holds per_layer_inputs for all layers: MAX_CONTEXT_SIZE x 35 x 256 x 2 bytes
+        # Per-layer input preparation + injection buffers.  The host uploads
+        # only token-indexed rows from embed_tokens_per_layer; FPGA performs
+        # model projection, RMSNorm, add and scaling into PER_LAYER_INPUTS_DRAM.
+        pli_elements = self.MAX_CONTEXT_SIZE * self.LAYER_SIZE * self.per_layer_input_dim
+        self.PER_LAYER_EMBED_DRAM = self.allocate_tensor_dram(
+            pli_elements * self.bytes_per_element)
+        self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(
+            pli_elements * self.bytes_per_element)
+        # Final layout is [token, layer, dim], consumed by injection blocks.
         self.PER_LAYER_INPUTS_DRAM = self.allocate_tensor_dram(self.MAX_CONTEXT_SIZE * self.LAYER_SIZE * self.per_layer_input_dim * self.bytes_per_element)
         # Intermediate DRAMs for per-layer injection
         self.LAYER0_PER_LAYER_GATE_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.per_layer_input_dim * self.bytes_per_element)
@@ -2466,9 +2473,9 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         seq_len=1), but the row count is applied indirectly through gpr_seq_len
         at runtime, so a single captured program is valid for any prompt length:
           * gate / projection matmuls read M from gpr_seq_len (M= is template);
-          * per_layer_input is packed [layer, token, dim] with a seq_len row
-            stride, so its per-layer base is computed from gpr_seq_len and the
-            gate*per_layer_input multiply runs as a per-row ISA loop;
+          * per_layer_input is packed [token, layer, dim], so a layer slice
+            starts at its offset within token 0 and advances by one complete
+            token stride in the gate*per_layer_input ISA loop;
           * the fused rms_norm + residual + layer_scalar step is a plain per-row
             ISA loop — one row resident at a time, no chunking / SRAM reuse.
         """
@@ -2485,18 +2492,17 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
             OUTPUT_DRAM_ADDR=self.LAYER0_PER_LAYER_GATE_OUTPUT_DRAM,
             gelu_enable=True, gpr_M_reg=self.gpr_seq_len)
 
-        # gated = gate * per_layer_input[layer_idx], per-row (runtime trip count).
-        # per_layer_input[layer] base = PER_LAYER_INPUTS_DRAM + layer*seq_len*dim*bpe,
-        # computed from gpr_seq_len; a running pointer walks one row per iteration.
+        # gated = gate * per_layer_input[token, layer_idx], per row. Prepared
+        # inputs stay token-major, so the pointer starts at the layer slice and
+        # advances by the full 35*dim token stride.
         gate_dram = self.LAYER0_PER_LAYER_GATE_OUTPUT_DRAM
         # eltwise operands must live in different URAM banks (split at 0x80000):
         # A in URAM_A (<0x80000), B in URAM_B (>=0x80000).
         sram_a, sram_b = 0x10000, 0x80000
         _pli = self.alloc_isa_reg()
-        self.generate_instruction_reg_mul_imm(_pli, self.gpr_seq_len,
-            ue_35bit_addr_shifter(layer_idx * dim * bpe))
-        self.generate_instruction_add_imm(_pli,
-            ue_35bit_addr_shifter(self.PER_LAYER_INPUTS_DRAM), _pli)
+        self.generate_instruction_add_set(
+            _pli, ue_35bit_addr_shifter(
+                self.PER_LAYER_INPUTS_DRAM + layer_idx * dim * bpe))
         _r = self.alloc_isa_reg()
         self.generate_instruction_add_set(_r, 0)
         self.loop_start(loop_cnt=M_tmpl, gpr_loop_cnt=self.gpr_seq_len)
@@ -2517,7 +2523,8 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         self.sram_to_accelerator_memory(sram_address=sram_a, accelerator_dram_address=0,
                                         element_size=dim, general_reg_src=self.TMP_REG)
         # advance per_layer_input pointer by one row
-        self.generate_instruction_add_imm(_pli, ue_35bit_addr_shifter(dim * bpe), _pli)
+        self.generate_instruction_add_imm(
+            _pli, ue_35bit_addr_shifter(self.LAYER_SIZE * dim * bpe), _pli)
         self.generate_instruction_add_inc(_r)
         self.loop_end()
         self.release_isa_reg()  # _r
@@ -2692,6 +2699,8 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
             kwargs.pop("is_B_quantized", None)
             return self.quantized_matmat_core(**kwargs)
         prefill_t0 = time.perf_counter()
+        total_flops += self._compile_per_layer_input_prepare(M=seq_len)
+        _checkpoint("per_layer_prepare")
         for layer_idx in range(layer_size):
             if layer_idx > 0 and layer_idx % 10 == 0:
                 _original_print(f"    prefill layer {layer_idx}/{layer_size} ({time.perf_counter()-prefill_t0:.1f}s)")
@@ -2933,6 +2942,75 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         _SILENT_MODE = False
         return None, total_flops
 
+    def _lookup_per_layer_embeddings(self, token_ids) -> torch.Tensor:
+        """Return lightweight token-indexed rows as [token, layer, dim]."""
+        tid_t = torch.tensor(token_ids, dtype=torch.long)
+        if hasattr(self, '_mm_types') and self._mm_types is not None:
+            mm_mask = torch.tensor(self._mm_types[:len(token_ids)])
+            tid_t = tid_t.clone()
+            tid_t[(mm_mask == 1) | (mm_mask == 3)] = 0
+        return self.embed_tokens_per_layer_weight[tid_t].reshape(
+            len(token_ids), self.LAYER_SIZE, self.per_layer_input_dim).contiguous()
+
+    def _compile_per_layer_input_prepare(self, M: int,
+                                         layer_count: int | None = None) -> int:
+        """Prepare Gemma4 per-layer inputs entirely on FPGA.
+
+        Computes embedding @ model_projection, then for every token/layer
+        applies projection scale, 256-wide RMSNorm, adds the host-uploaded
+        token-indexed embedding row, applies input scale, and stores the final
+        [token, layer, dim] layout consumed by the injection blocks.
+        """
+        # The exact M is known at compile time (prefill is prompt-length keyed;
+        # decode is M=1), so use the proven fixed-shape BF16 core.  Do not feed
+        # gpr_seq_len into the post-processing loop: that unnecessary dynamic
+        # loop was the source of the non-terminating full-model program.
+        total_flops = self.matmat_mul_core_legacy(
+            M=M, K=self.vector_length,
+            N=self.LAYER_SIZE * self.per_layer_input_dim,
+            A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+            B_DRAM_ADDR=self.DRAM_ADDR_PER_LAYER_MODEL_PROJ,
+            OUTPUT_DRAM_ADDR=self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM)
+        bpe = self.bytes_per_element
+        dim = self.per_layer_input_dim
+        if layer_count is None:
+            layer_count = self.LAYER_SIZE
+        if not 1 <= layer_count <= self.LAYER_SIZE:
+            raise ValueError(f"layer_count must be 1..{self.LAYER_SIZE}, got {layer_count}")
+        if layer_count != self.LAYER_SIZE:
+            # The projection is complete by design; the diagnostic layer_count
+            # only limits comparison, not the bulk preparation itself.
+            layer_count = self.LAYER_SIZE
+        rows = M * self.LAYER_SIZE
+        elements = rows * dim
+
+        # Projection scale is positive and cancels exactly in RMSNorm. Applying
+        # it before a BF16 cast changes only rounding noise, while omitting it
+        # lets the complete [M,35,256] tensor use one proven bulk norm kernel.
+        total_flops += self.rms_norm_core_dram(
+            M=rows, N=dim,
+            A_DRAM_ADDR=self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM,
+            OUTPUT_DRAM_ADDR=self.PER_LAYER_INPUTS_DRAM,
+            GAMMA_DRAM_ADDR=self.DRAM_ADDR_PER_LAYER_PROJ_NORM)
+        self.eltwise_core_dram(
+            M=rows, N=dim,
+            dram_a=self.PER_LAYER_INPUTS_DRAM,
+            dram_b=self.PER_LAYER_EMBED_DRAM,
+            dram_out=self.PER_LAYER_INPUTS_DRAM,
+            mode=UE_MODE.ELTWISE_ADD)
+
+        # Scale in SRAM-sized contiguous chunks; no nested PBI loops.
+        chunk_elements = (0x80000 - 0x10000) // bpe
+        for off in range(0, elements, chunk_elements):
+            take = min(chunk_elements, elements - off)
+            addr = self.PER_LAYER_INPUTS_DRAM + off * bpe
+            self.accelerator_memory_to_sram(addr, 0x10000, take)
+            self.broadcast_mul(self._per_layer_input_scale,
+                               0x10000, 0x10000, take)
+            self.sram_to_accelerator_memory(0x10000, addr, take)
+        total_flops += M * layer_count * dim * 10
+        return total_flops
+
     def _compute_per_layer_inputs(self, token_ids, embedding_tensor: torch.Tensor) -> torch.Tensor:
         """Compute per-layer inputs on host side.
         Args:
@@ -2981,6 +3059,116 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         per_layer_inputs = ((per_layer_proj.float() + per_layer_embed.float()) * self._per_layer_input_scale).to(torch.bfloat16)
 
         return per_layer_inputs  # [seq_len, 35, 256]
+
+    def run_per_layer_prepare_test(self, M: int = 1, layer_count: int = 1) -> None:
+        """Isolate FPGA per-layer preparation and compare against host BF16."""
+        if M < 1:
+            raise ValueError(f"M must be positive, got {M}")
+        token_ids = tuple(self._cfg["default_prefill_tokens"][:M])
+        if len(token_ids) < M:
+            token_ids = token_ids + (token_ids[-1],) * (M - len(token_ids))
+        embedding = self.get_embedding_for_tokens(token_ids)
+        embed_rows = self._lookup_per_layer_embeddings(token_ids)
+        reference = self._compute_per_layer_inputs(token_ids, embedding)
+        reference = reference[:, :layer_count].permute(1, 0, 2).contiguous().float()
+
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding)
+        self.dma_to_accelerator_memory(
+            self.PER_LAYER_EMBED_DRAM,
+            embed_rows)
+
+        self.reset_program_dram_addr()
+        self.clear_inst_id()
+        self.clear_capture_buffer()
+        self.start_capture()
+        flops = self._compile_per_layer_input_prepare(
+            M=M, layer_count=layer_count)
+        self.generate_instruction_halt()
+        self.stop_capture()
+        program_addr = self.get_program_dram_addr()
+        program_bytes = self.get_capture_instruction_size_bytes()
+        self.write_captured_instructions_to_dram(program_addr)
+        self.allocate_program_dram(program_bytes)
+        self.clear_capture_buffer()
+        latency, flop_rate = self.program_execute(
+            program_addr, timeout=20.0, flops=flops)
+
+        actual_token_major = self.dma_from_accelerator_memory(
+            self.PER_LAYER_INPUTS_DRAM,
+            torch.Size([M, self.LAYER_SIZE, self.per_layer_input_dim])).float()
+        actual = actual_token_major[:, :layer_count].permute(1, 0, 2).contiguous()
+        diff = (actual - reference).abs()
+        cosine = torch.nn.functional.cosine_similarity(
+            actual.flatten(), reference.flatten(), dim=0).item()
+        print("\n=== Per-layer preparation isolated test ===")
+        print(f"shape: M={M}, layers={layer_count}, projection=BF16 1536->256/layer")
+        print(f"program: {program_bytes} bytes")
+        print(f"FPGA: {latency/1e3:.3f} ms, {flop_rate:.2f} GFLOPS")
+        print(f"error: max_abs={diff.max().item():.6g}, "
+              f"mean_abs={diff.mean().item():.6g}, cosine={cosine:.8f}")
+        if not torch.isfinite(actual).all() or cosine < 0.99:
+            raise AssertionError("FPGA per-layer preparation does not match host reference")
+        print("PASS")
+
+    def run_per_layer_projection_test(self, M: int = 1, dynamic: bool = False) -> None:
+        """Isolate the complete BF16 1536->8960 projection."""
+        if M < 1:
+            raise ValueError(f"M must be positive, got {M}")
+        token_ids = tuple(self._cfg["default_prefill_tokens"][:M])
+        if len(token_ids) < M:
+            token_ids = token_ids + (token_ids[-1],) * (M - len(token_ids))
+        embedding = self.get_embedding_for_tokens(token_ids)
+        reference = (embedding.float() @ self.per_layer_model_proj_weight.float().T).to(
+            torch.bfloat16).float()
+        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding)
+
+        self.reset_program_dram_addr()
+        self.clear_inst_id()
+        self.clear_capture_buffer()
+        self.start_capture()
+        if dynamic:
+            gpr_m = self.alloc_isa_reg()
+            self.generate_instruction_add_set(gpr_m, M)
+            flops = self.matmat_mul_core(
+                M=M, K=self.vector_length,
+                N=self.LAYER_SIZE * self.per_layer_input_dim,
+                A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+                B_DRAM_ADDR=self.DRAM_ADDR_PER_LAYER_MODEL_PROJ,
+                OUTPUT_DRAM_ADDR=self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM,
+                gpr_M_reg=gpr_m)
+            self.release_isa_reg()
+        else:
+            flops = self.matmat_mul_core_legacy(
+                M=M, K=self.vector_length,
+                N=self.LAYER_SIZE * self.per_layer_input_dim,
+                A_DRAM_ADDR=self.LAYER0_INPUT_DRAM,
+                B_DRAM_ADDR=self.DRAM_ADDR_PER_LAYER_MODEL_PROJ,
+                OUTPUT_DRAM_ADDR=self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM)
+        self.generate_instruction_halt()
+        self.stop_capture()
+        program_addr = self.get_program_dram_addr()
+        program_bytes = self.get_capture_instruction_size_bytes()
+        self.write_captured_instructions_to_dram(program_addr)
+        self.allocate_program_dram(program_bytes)
+        self.clear_capture_buffer()
+        latency, flop_rate = self.program_execute(
+            program_addr, timeout=20.0, flops=flops)
+        actual = self.dma_from_accelerator_memory(
+            self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM,
+            torch.Size([M, self.LAYER_SIZE * self.per_layer_input_dim])).float()
+        diff = (actual - reference).abs()
+        cosine = torch.nn.functional.cosine_similarity(
+            actual.flatten(), reference.flatten(), dim=0).item()
+        mode = "dynamic" if dynamic else "legacy"
+        print("\n=== Complete per-layer projection isolated test ===")
+        print(f"shape: M={M}, K={self.vector_length}, N={self.LAYER_SIZE * self.per_layer_input_dim}, core={mode}")
+        print(f"program: {program_bytes} bytes")
+        print(f"FPGA: {latency/1e3:.3f} ms, {flop_rate:.2f} GFLOPS")
+        print(f"error: max_abs={diff.max().item():.6g}, "
+              f"mean_abs={diff.mean().item():.6g}, cosine={cosine:.8f}")
+        if not torch.isfinite(actual).all() or cosine < 0.99:
+            raise AssertionError("complete FPGA per-layer projection does not match host")
+        print("PASS")
 
     def run_prefill(self, prefill_program_addr: int, prefill_seq=None, flops: int = None,
                     profile_checkpoints: list | None = None):
@@ -3078,13 +3266,14 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         print(f"[Prefill] uploading embeddings to FPGA DRAM...", flush=True)
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
 
-        # Compute per-layer inputs on host and DMA to FPGA
-        print(f"[Prefill] [host] computing per-layer inputs ({seq_len} tokens x {self.LAYER_SIZE} layers)...", flush=True)
-        per_layer_inputs = self._compute_per_layer_inputs(prefill_seq, embedding_tensor)  # [seq_len, 35, 256]
-        # Permute to [35, seq_len, 256] so each layer's data is contiguous in DRAM
-        per_layer_inputs_flat = per_layer_inputs.permute(1, 0, 2).contiguous()  # [35, seq_len, 256]
-        print(f"[Prefill] uploading per-layer inputs to FPGA DRAM...", flush=True)
-        self.dma_to_accelerator_memory(self.PER_LAYER_INPUTS_DRAM, per_layer_inputs_flat)
+        # Host performs only the runtime token-indexed lookup. Projection,
+        # normalization, add and scaling run on FPGA.
+        print(f"[Prefill] [host] looking up per-layer embedding rows...", flush=True)
+        per_layer_embed = self._lookup_per_layer_embeddings(prefill_seq)
+        print(f"[Prefill] uploading per-layer embedding rows to FPGA DRAM...", flush=True)
+        self.dma_to_accelerator_memory(
+            self.PER_LAYER_EMBED_DRAM,
+            per_layer_embed)
 
         # Clear multimodal state now that prefill's per-layer-inputs have been computed.
         # Decode reuses _compute_per_layer_inputs with seq_len=1, and if _mm_types
@@ -3239,6 +3428,8 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         self.generate_instruction_add_set(gpr_one, 1)
         gpr_group_size = self.alloc_isa_reg()
         self.generate_instruction_add_set(gpr_group_size, self.group_size)
+        total_flops += self._compile_per_layer_input_prepare(M=1)
+        _checkpoint("per_layer_prepare")
         # Iterate once (no bucket loop)
         for _bi_unused in [0]:
             seq_len = self.MAX_CONTEXT_SIZE  # template only — for FLOPs
@@ -3631,8 +3822,10 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
 
             embedding_tensor = self.get_embedding_for_tokens([token_id])
             self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
-            per_layer_inputs = self._compute_per_layer_inputs([token_id], embedding_tensor)
-            self.dma_to_accelerator_memory(self.PER_LAYER_INPUTS_DRAM, per_layer_inputs.permute(1, 0, 2).contiguous())
+            per_layer_embed = self._lookup_per_layer_embeddings([token_id])
+            self.dma_to_accelerator_memory(
+                self.PER_LAYER_EMBED_DRAM,
+                per_layer_embed)
 
             # Build BOTH decode bias matrices. unified_attention_core uses
             # bias_mode="full_matrix", and decoder batch is group_size Q heads.
@@ -3765,10 +3958,9 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         disk (gemma4_e2b_bin/programs.bin + programs.json). No DRAM is touched —
         run_gemma4() loads it.
 
-        Both programs are seq_len-agnostic (dynamic-PBI: row counts come from
-        gpr_seq_len / gpr_q_seq_len / gpr_aligned_seq_len at runtime), so the
-        cached image is valid for ANY prompt length up to max_prefill_seq_len.
-        Reused as-is whenever programs.bin exists — delete it to force a rebuild.
+        Decoder is seq_len-agnostic. Prefill contains one fixed-shape BF16
+        per-layer model projection, so its cached image is keyed by prompt
+        length; the remainder still uses dynamic-PBI row counts.
 
         set_prefill_seq() MUST have been called first (prefill needs the prompt).
         """
@@ -3787,10 +3979,11 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
             if (_cached_base == self._program_dram_base
                     and _cached_prefill_kernel == self.prefill_kernel
                     and _cached_decode_kernel == self.decode_kernel
+                    and _lm_meta.get("prefill_seq_len") == prefill_seq_len
                     and _cached_version == LM_PROGRAM_CACHE_VERSION):
                 print("[compile] reusing cached LM section "
                       f"(prefill={self.prefill_kernel}, decode={self.decode_kernel}; "
-                      "seq_len-agnostic).")
+                      f"seq_len={prefill_seq_len}).")
                 return
             print("[compile] cached LM section does not match requested configuration "
                   f"(base=0x{_cached_base:X}, prefill={_cached_prefill_kernel}, "
@@ -4005,8 +4198,10 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         aligned_seq_len = ((self.seq_len + 63) // 64) * 64
         emb = self.get_embedding_for_tokens([token_id])
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, emb)
-        pli = self._compute_per_layer_inputs([token_id], emb)
-        self.dma_to_accelerator_memory(self.PER_LAYER_INPUTS_DRAM, pli.permute(1, 0, 2).contiguous())
+        pli_embed = self._lookup_per_layer_embeddings([token_id])
+        self.dma_to_accelerator_memory(
+            self.PER_LAYER_EMBED_DRAM,
+            pli_embed)
         full_bias = torch.full((self.group_size, aligned_seq_len), -1e36, dtype=torch.bfloat16)
         full_bias[:, :self.seq_len] = 0.0
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_FULL_DRAM, full_bias)
@@ -4061,6 +4256,14 @@ default prompt: "x+3=5, what is x?"
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile bin with per-phase HALT checkpoints and run one '
                              'profiled decode step; print a per-phase HW-latency breakdown.')
+    parser.add_argument('--per-layer-prepare-test', type=int, metavar='M', default=None,
+                        help='Run only the isolated FPGA per-layer preparation for M tokens.')
+    parser.add_argument('--per-layer-prepare-layers', type=int, default=1,
+                        help='Number of 256-wide layer slices in the isolated test (default: 1).')
+    parser.add_argument('--per-layer-projection-test', type=int, metavar='M', default=None,
+                        help='Run only the complete BF16 1536->8960 FPGA projection for M tokens.')
+    parser.add_argument('--per-layer-projection-dynamic', action='store_true',
+                        help='Use dynamic matmat_mul_core in --per-layer-projection-test.')
     args = parser.parse_args()
     if args.vision_host and not args.image:
         parser.error("--vision-host requires --image")
@@ -4086,6 +4289,17 @@ default prompt: "x+3=5, what is x?"
         local_weights=args.local_weights,
         prefill_kernel=args.prefill_kernel,
         decode_kernel=args.decode_kernel)
+
+    if args.per_layer_prepare_test is not None:
+        ue.run_per_layer_prepare_test(
+            M=args.per_layer_prepare_test,
+            layer_count=args.per_layer_prepare_layers)
+        return
+    if args.per_layer_projection_test is not None:
+        ue.run_per_layer_projection_test(
+            M=args.per_layer_projection_test,
+            dynamic=args.per_layer_projection_dynamic)
+        return
 
     # Prompt first — the prefill program is compiled for its exact length.
     # VLM mode (--image): run the vision encoder on the FPGA now (separate bin

--- a/models/gemma4_e2b/gemma4_e2b_refactor.py
+++ b/models/gemma4_e2b/gemma4_e2b_refactor.py
@@ -79,7 +79,7 @@ VISION_QUANT_PRECISION = "if4"
 # lets the vision encoder bin be compiled once for a fixed shape.
 VISION_CANONICAL_SIZE = (896, 896)   # (width, height) for PIL.Image.resize
 VISION_FIXED_NUM_PATCHES = 2520
-LM_PROGRAM_CACHE_VERSION = 8
+LM_PROGRAM_CACHE_VERSION = 10
 
 # Shipped sample image for VLM mode (same as gemma4_e2b_test.py's DEFAULT_IMAGE):
 # repo test_samples/yosemite.jpg, two folders up from this script.
@@ -1085,8 +1085,13 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         print("Tokenizer loaded.")
 
     def tensor_init(self) -> None:
-        """Initialize hardware DRAM for gemma4 E2B model (layer-wise overlap except for kv cache).
-        KV cache uses max head_dim (512) for uniform sizing."""
+        """Initialize hardware DRAM for Gemma4 E2B model.
+
+        Unique KV slots are packed using their owning layer's actual head
+        dimension. Sliding-attention rows therefore use 256 elements and
+        global-attention rows use 512 elements, matching unified attention's
+        contiguous K/V layout directly.
+        """
         seq_len = self.MAX_CONTEXT_SIZE
         q_seq_len = seq_len * self.group_size
         aligned_seq_len = ((q_seq_len + 63) // 64) * 64
@@ -1104,18 +1109,36 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         # consume cache space (saves ~40 MB at MAX_CONTEXT_SIZE=1024).
         non_shared_layers = [l for l in range(self.LAYER_SIZE) if l not in self._kv_shared_map]
         self._kv_slot_for_layer = {}
+        self._kv_offset_for_layer = {}
+        self._kv_row_bytes_for_layer = {}
+        _kv_offset = 0
         for slot, l in enumerate(non_shared_layers):
             self._kv_slot_for_layer[l] = slot
+            _head_dim, _, _ = self._get_layer_attention_dims(l)
+            _row_bytes = _head_dim * self.bytes_per_element
+            self._kv_offset_for_layer[l] = _kv_offset
+            self._kv_row_bytes_for_layer[l] = _row_bytes
+            _kv_offset += self.MAX_CONTEXT_SIZE * _row_bytes
         for shared_l, ref_l in self._kv_shared_map.items():
             self._kv_slot_for_layer[shared_l] = self._kv_slot_for_layer[ref_l]
+            self._kv_offset_for_layer[shared_l] = self._kv_offset_for_layer[ref_l]
+            self._kv_row_bytes_for_layer[shared_l] = self._kv_row_bytes_for_layer[ref_l]
+            _shared_dim, _, _ = self._get_layer_attention_dims(shared_l)
+            if _shared_dim * self.bytes_per_element != self._kv_row_bytes_for_layer[ref_l]:
+                raise ValueError(
+                    f"KV-shared layer {shared_l} head_dim={_shared_dim} does not match "
+                    f"reference layer {ref_l} row size")
         self._num_kv_slots = len(non_shared_layers)
-        _kv_saved = (self.LAYER_SIZE - self._num_kv_slots) * self.MAX_CONTEXT_SIZE * self.k_size * 2  # K+V
-        print(f"KV cache: {self._num_kv_slots} unique slots (of {self.LAYER_SIZE} layers), saved {_kv_saved / (1024*1024):.1f} MB via KV sharing")
-        # Allocate shared memory for k v cache (k rope and v projection) and zero pad for decoder use:
-        # Uses max head_dim (512) = self.k_size for uniform sizing
-        self.LAYER0_V_DRAM = self.allocate_tensor_dram(self._num_kv_slots * self.MAX_CONTEXT_SIZE * self.k_size)
-        self.LAYER0_K_ROPE_DRAM = self.allocate_tensor_dram(self._num_kv_slots * self.MAX_CONTEXT_SIZE * self.k_size)
-        zero_pad = torch.zeros(self._num_kv_slots * self.MAX_CONTEXT_SIZE * self.k_size, dtype=torch.bfloat16)
+        self._kv_cache_bytes = _kv_offset
+        _uniform_bytes = self._num_kv_slots * self.MAX_CONTEXT_SIZE * self.k_size
+        _compact_saved = 2 * (_uniform_bytes - self._kv_cache_bytes)
+        print(
+            f"KV cache: {self._num_kv_slots} unique compact slots "
+            f"({self._kv_cache_bytes * 2 / (1024*1024):.1f} MB K+V, "
+            f"saved {_compact_saved / (1024*1024):.1f} MB vs padded slots)")
+        self.LAYER0_V_DRAM = self.allocate_tensor_dram(self._kv_cache_bytes)
+        self.LAYER0_K_ROPE_DRAM = self.allocate_tensor_dram(self._kv_cache_bytes)
+        zero_pad = torch.zeros(self._kv_cache_bytes // self.bytes_per_element, dtype=torch.bfloat16)
         self.dma_to_accelerator_memory(self.LAYER0_V_DRAM, zero_pad)
         self.dma_to_accelerator_memory(self.LAYER0_K_ROPE_DRAM, zero_pad)
         # Allocate memory for constant zero tensor, identity matrix, and bias:
@@ -2725,7 +2748,8 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                 # SRAM slot; the per-token read (FLASH_V, cur_k_size stride) and
                 # write (KV cache, k_size stride) addrs are register-computed, so
                 # the body is emitted once and hardware-looped over gpr_seq_len.
-                v_cache_base = self.LAYER0_V_DRAM + self._kv_slot_for_layer[layer_idx] * self.MAX_CONTEXT_SIZE * self.k_size
+                kv_row_bytes = self._kv_row_bytes_for_layer[layer_idx]
+                v_cache_base = self.LAYER0_V_DRAM + self._kv_offset_for_layer[layer_idx]
                 _vi = self.alloc_isa_reg()
                 self.generate_instruction_add_set(_vi, 0)
                 self.loop_start(loop_cnt=seq_len, gpr_loop_cnt=self.gpr_seq_len)
@@ -2733,7 +2757,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                 self.generate_instruction_add_imm(self.TMP_REG, ue_35bit_addr_shifter(self.LAYER0_FLASH_V_DRAM), self.TMP_REG)
                 self.accelerator_memory_to_sram(accelerator_dram_address=0, sram_address=0x10000, element_size=cur_k_size, general_reg_src=self.TMP_REG)
                 self.rms_norm_core(0x10000, 0x10000, cur_k_size)  # no gamma
-                self.generate_instruction_reg_mul_imm(self.TMP_REG, _vi, ue_35bit_addr_shifter(self.k_size))
+                self.generate_instruction_reg_mul_imm(self.TMP_REG, _vi, ue_35bit_addr_shifter(kv_row_bytes))
                 self.generate_instruction_add_imm(self.TMP_REG, ue_35bit_addr_shifter(v_cache_base), self.TMP_REG)
                 self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=0, element_size=cur_k_size, general_reg_src=self.TMP_REG)
                 self.generate_instruction_add_inc(_vi)
@@ -2762,7 +2786,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
             rope_bytes = rope_n * bpe
             sin_addr = ROPE_WEIGHT_ADDR + rope_n * bpe
             q_rows = seq_len * self.group_size
-            kv_slot_off = self._kv_slot_for_layer[layer_idx] * self.MAX_CONTEXT_SIZE * self.k_size
+            kv_slot_off = self._kv_offset_for_layer[layer_idx]
             k_cache_base = self.LAYER0_K_ROPE_DRAM + kv_slot_off
             v_cache_base = self.LAYER0_V_DRAM + kv_slot_off
             K_TMP = self.LAYER0_MLP_MULT_DRAM     # contiguous K rope scratch
@@ -2797,11 +2821,11 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                 self._emit_strided_copy_pbi(self.LAYER0_Q_NORM_DRAM + rope_bytes, self.LAYER0_FLASH_Q_DRAM + rope_bytes, non_rot, head_bytes, head_bytes, q_rows, self.gpr_q_seq_len)
             # Spread the contiguous K rope result into the k_size-strided KV cache.
             if non_shared:
-                self._emit_strided_copy_pbi(K_TMP, k_cache_base, cur_head_dim, head_bytes, self.k_size, seq_len, self.gpr_seq_len)
+                self._emit_strided_copy_pbi(K_TMP, k_cache_base, cur_head_dim, head_bytes, head_bytes, seq_len, self.gpr_seq_len)
             _checkpoint(f"L{layer_idx}_rope")
             # GQA dup: read KV cache (k_size stride) → scatter group_size copies to FLASH (cur_head_dim stride).
-            self._emit_gqa_duplicate_pbi(k_cache_base, self.LAYER0_FLASH_K_DRAM, cur_head_dim, seq_len, self.gpr_seq_len, src_row_bytes=self.k_size)
-            self._emit_gqa_duplicate_pbi(v_cache_base, self.LAYER0_FLASH_V_DRAM, cur_head_dim, seq_len, self.gpr_seq_len, src_row_bytes=self.k_size)
+            self._emit_gqa_duplicate_pbi(k_cache_base, self.LAYER0_FLASH_K_DRAM, cur_head_dim, seq_len, self.gpr_seq_len, src_row_bytes=head_bytes)
+            self._emit_gqa_duplicate_pbi(v_cache_base, self.LAYER0_FLASH_V_DRAM, cur_head_dim, seq_len, self.gpr_seq_len, src_row_bytes=head_bytes)
             _checkpoint(f"L{layer_idx}_kv_gather")
 
             # Gemma4 uses scaling=1.0 (no 1/sqrt(d) in attention scores), so pass
@@ -3012,8 +3036,11 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
         # attention I @ V^T step). Idempotent for LM-only runs.
         from user_dma_core import UE_VECTOR_SIZE as _UE_VS
         num_slots = getattr(self, "_num_kv_slots", self.LAYER_SIZE)
-        kv_slot_elems = num_slots * self.MAX_CONTEXT_SIZE * self.head_dim
-        kv_zero_pad = torch.zeros(kv_slot_elems, dtype=torch.bfloat16)
+        kv_cache_bytes = getattr(
+            self, "_kv_cache_bytes",
+            num_slots * self.MAX_CONTEXT_SIZE * self.head_dim * self.bytes_per_element)
+        kv_zero_pad = torch.zeros(
+            kv_cache_bytes // self.bytes_per_element, dtype=torch.bfloat16)
         self.dma_to_accelerator_memory(self.LAYER0_V_DRAM, kv_zero_pad)
         self.dma_to_accelerator_memory(self.LAYER0_K_ROPE_DRAM, kv_zero_pad)
         _pre_align = ((self.max_prefill_seq_len * self.group_size + 63) // 64) * 64
@@ -3266,9 +3293,10 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                     # V norm (Gemma4: normalize V without learnable scale)
                     self.rms_norm_core(0x10000, 0x10000, cur_k_size)  # no gamma
                     # V scatter to V cache at decode_pos via reg_mul_imm + add_imm.
-                    # Address = LAYER0_V_DRAM + slot * MAX_CTX * k_size + gpr_seq_len * k_size.
-                    _v_slot_base = self.LAYER0_V_DRAM + self._kv_slot_for_layer[layer_idx] * self.MAX_CONTEXT_SIZE * self.k_size
-                    self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(self.k_size))
+                    # Compact cache row stride equals this layer's head dimension.
+                    _kv_row_bytes = self._kv_row_bytes_for_layer[layer_idx]
+                    _v_slot_base = self.LAYER0_V_DRAM + self._kv_offset_for_layer[layer_idx]
+                    self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(_kv_row_bytes))
                     self.generate_instruction_add_imm(self.TMP_REG, ue_35bit_addr_shifter(_v_slot_base), self.TMP_REG)
                     self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=0, element_size=cur_k_size, general_reg_src=self.TMP_REG)
                     # RMS norm on K
@@ -3286,7 +3314,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                 ROPE_WEIGHT_ADDR = self.DRAM_ADDR_ROPE_GLOBAL if layer_idx in self._rope_global_layers else self.DRAM_ADDR_ROPE_LOCAL
                 rope_row = 2 * rope_n * self.bytes_per_element  # full cos+sin pair stride per token (rope_n*2 values * 2 bytes)
 
-                kv_slot_off_local = self._kv_slot_for_layer[layer_idx] * self.MAX_CONTEXT_SIZE * self.k_size
+                kv_slot_off_local = self._kv_offset_for_layer[layer_idx]
                 k_rope_base = self.LAYER0_K_ROPE_DRAM + kv_slot_off_local
 
                 if layer_idx not in self._kv_shared_map:
@@ -3302,7 +3330,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                         output_dram_addr=self.LAYER0_K_DRAM,         # scratch, not cache
                         gr_weight_dram=self.TMP_REG)
                     # Copy rotated dims from scratch into K cache at decode_pos.
-                    self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(self.k_size))
+                    self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(self._kv_row_bytes_for_layer[layer_idx]))
                     self.generate_instruction_add_imm(self.TMP_REG, ue_35bit_addr_shifter(k_rope_base), self.TMP_REG)
                     self.accelerator_memcpy(self.LAYER0_K_DRAM, 0, rope_n * self.bytes_per_element, gr_dst_addr=self.TMP_REG)
 
@@ -3330,7 +3358,7 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                         src = self.LAYER0_K_NORM_DRAM + rope_n * self.bytes_per_element
                         k_cache_nrot_base = k_rope_base + rope_n * self.bytes_per_element
                         self.accelerator_memory_to_sram(src, 0x10000, remaining)
-                        self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(self.k_size))
+                        self.generate_instruction_reg_mul_imm(self.TMP_REG, self.gpr_seq_len, ue_35bit_addr_shifter(self._kv_row_bytes_for_layer[layer_idx]))
                         self.generate_instruction_add_imm(self.TMP_REG, ue_35bit_addr_shifter(k_cache_nrot_base), self.TMP_REG)
                         self.sram_to_accelerator_memory(0x10000, 0, remaining, general_reg_src=self.TMP_REG)
 
@@ -3340,21 +3368,13 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                 _checkpoint(f"L{layer_idx}_rope")
 
                 # K/V cache reads — KV-shared layers point at the source layer's cache.
-                kv_slot_off_read = self._kv_slot_for_layer[kv_layer_for_attn] * self.MAX_CONTEXT_SIZE * self.k_size
+                kv_slot_off_read = self._kv_offset_for_layer[kv_layer_for_attn]
                 kv_k_base = self.LAYER0_K_ROPE_DRAM + kv_slot_off_read
                 kv_v_base = self.LAYER0_V_DRAM + kv_slot_off_read
 
-                # Gather this layer's K/V into the FIXED FLASH_K/V buffers. Runtime
-                # trip count is the aligned decode context length; cache rows past
-                # decode_pos are zero and the full-matrix bias masks them.
-                _dhb = cur_head_dim * self.bytes_per_element
-                self._emit_strided_copy_pbi(
-                    kv_k_base, self.LAYER0_FLASH_K_DRAM, cur_head_dim,
-                    self.k_size, _dhb, self.MAX_CONTEXT_SIZE, self.gpr_aligned_seq_len, sram_addr=0x10000)
-                self._emit_strided_copy_pbi(
-                    kv_v_base, self.LAYER0_FLASH_V_DRAM, cur_head_dim,
-                    self.k_size, _dhb, self.MAX_CONTEXT_SIZE, self.gpr_aligned_seq_len, sram_addr=0x20000)
-
+                # Compact per-slot rows already satisfy unified attention's
+                # [aligned_seq_len, head_dim] contract. Read the cache directly;
+                # zero-initialized future rows cover alignment padding.
                 _checkpoint(f"L{layer_idx}_kv_gather")
 
                 # unified_attention_core uses bias_mode="full_matrix"; run_decoder
@@ -3367,8 +3387,8 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                     aligned_seq_len=seq_len,
                     head_dim=cur_head_dim,
                     Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
+                    K_DRAM_ADDR=kv_k_base,
+                    V_DRAM_ADDR=kv_v_base,
                     BIAS_DRAM_ADDR=bias_addr_layer,
                     OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
                     SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
@@ -3387,24 +3407,37 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                     data_type=TYPE.IF4,
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off,
                     )
-                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM,
-                              OUTPUT_DRAM_ADDR=self.LAYER0_POST_ATTN_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_POST_NORM_GAMMA + layer_off,
-                              gpr_M_reg=gpr_one)
+                # Decode-only fused attention residual and FFN pre-normalization.
+                _vec_a = 0x10000
+                _vec_b = 0x90000
+                self.accelerator_memory_to_sram(
+                    self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, _vec_a, self.vector_length)
+                self.accelerator_memory_to_sram(
+                    self.DRAM_ADDR_LAYER0_POST_NORM_GAMMA + layer_off,
+                    _vec_b, self.vector_length)
+                self.rms_norm_core(_vec_a, _vec_a, self.vector_length, _vec_b)
+                total_flops += 4 * self.vector_length
 
                 # Attention residual: use layer_input_addr (LAYER0_OUTPUT_DRAM
                 # for layers > 0, LAYER0_INPUT_DRAM for layer 0) — same source
                 # as the pre-norm above. This avoids the LAYER0_OUTPUT → LAYER0_INPUT
                 # copy that used to run at the top of every layer.
-                self.accelerator_memory_to_sram(accelerator_dram_address=layer_input_addr, sram_address=0x10000, element_size=self.vector_length)
-                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
-                self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
-                self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
+                self.accelerator_memory_to_sram(
+                    layer_input_addr, _vec_b, self.vector_length)
+                self.eltwise_add_core(_vec_a, _vec_b, _vec_a, self.vector_length)
+                self.sram_to_accelerator_memory(
+                    _vec_a, self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                    self.vector_length)
+                self.accelerator_memory_to_sram(
+                    self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off,
+                    _vec_b, self.vector_length)
+                self.rms_norm_core(_vec_a, _vec_a, self.vector_length, _vec_b)
+                total_flops += 4 * self.vector_length
+                self.sram_to_accelerator_memory(
+                    _vec_a, self.LAYER0_PRE_MLP_NORM_DRAM,
+                    self.vector_length)
 
                 _checkpoint(f"L{layer_idx}_o_proj")
-
-                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
-                              OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off,
-                              gpr_M_reg=gpr_one)
 
                 total_flops += _projection_core(M=1, K=self.vector_length, N=cur_mlp,
                     A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM,
@@ -3436,14 +3469,22 @@ class Gemma4_UnifiedEngine(UnifiedEngine):
                     SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off,
                     gpr_M_reg=gpr_one,
                     )
-                total_flops += self.rms_norm_core_dram(M=1, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
-                              OUTPUT_DRAM_ADDR=self.LAYER0_POST_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_POST_FFW_NORM_GAMMA + layer_off,
-                              gpr_M_reg=gpr_one)
-
-                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, sram_address=0x10000, element_size=self.vector_length)
-                self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_MLP_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
-                self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
-                self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, element_size=self.vector_length)
+                # Decode-only fused MLP post-normalization + residual. Keep the
+                # normalized MLP-down vector in SRAM through the residual add,
+                # removing the post-MLP-norm DRAM write/read pair.
+                self.accelerator_memory_to_sram(
+                    self.LAYER0_MLP_DOWN_DRAM, _vec_a, self.vector_length)
+                self.accelerator_memory_to_sram(
+                    self.DRAM_ADDR_LAYER0_POST_FFW_NORM_GAMMA + layer_off,
+                    _vec_b, self.vector_length)
+                self.rms_norm_core(_vec_a, _vec_a, self.vector_length, _vec_b)
+                total_flops += 4 * self.vector_length
+                self.accelerator_memory_to_sram(
+                    self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                    _vec_b, self.vector_length)
+                self.eltwise_add_core(_vec_a, _vec_b, _vec_a, self.vector_length)
+                self.sram_to_accelerator_memory(
+                    _vec_a, self.LAYER0_OUTPUT_DRAM, self.vector_length)
 
                 _checkpoint(f"L{layer_idx}_mlp")
 

--- a/models/gemma4_e2b/gemma4_performance.md
+++ b/models/gemma4_e2b/gemma4_performance.md
@@ -1,6 +1,6 @@
 # Gemma4 E2B Performance
 
-## Baseline
+## Performance
 
 Measured on p620 using the Kintex-7 target (`xdma0`, 198.3256 MHz), IF4 LM
 weights, the default Yosemite image, and a 1,024-token context. Host vision was
@@ -9,57 +9,46 @@ used to isolate LM performance:
 ```bash
 python models/gemma4_e2b/gemma4_e2b_refactor.py --image --vision-host
 python models/gemma4_e2b/gemma4_e2b_refactor.py --image --vision-host --profile
-python models/gemma4_e2b/gemma4_e2b_refactor.py --image --vision-host \
-  --prefill-kernel matmatmul --decode-kernel streaming
-python models/gemma4_e2b/gemma4_e2b_refactor.py --image --vision-host \
-  --prefill-kernel streaming --decode-kernel streaming
 ```
 
 The VLM prompt contains 273 tokens: 256 image soft tokens and 17 text/special
 tokens. Prefill executes 272 tokens.
 
-| Measurement | Baseline | Matmatmul prefill + streaming decode | Streaming prefill + streaming decode | Streaming MLP down |
-|---|---:|---:|---:|---:|
-| Host vision, complete path | 6.90 s | 6.94 s | 6.89 s | 6.89 s |
-| Host vision, model forward | 4.38 s | 4.37 s | 4.38 s | 4.38 s |
-| LM profile compile | 0.60 s | 0.61 s | 0.60 s | 0.60 s |
-| Prefill host preparation | 0.08 s | — | — | — |
-| Prefill FPGA execution | 51.948 s | 51.947 s | 51.332 s | 51.332 s |
-| Prefill wall time | 52.11 s | 52.11 s | 51.49 s | 51.49 s |
-| Prefill throughput | 5.22 tok/s | 5.22 tok/s | 5.28 tok/s | 5.28 tok/s |
-| Prefill FPGA throughput | 23.46 GFLOPS | 23.46 GFLOPS | 23.75 GFLOPS | 23.75 GFLOPS |
-| Decode first-token wall speed | 2.84 tok/s | 3.27 tok/s | 3.27 tok/s | 3.67 tok/s |
-| Decode first-token FPGA speed | 2.95 tok/s | — | — | — |
-| Decode average wall speed | 2.59 tok/s | 2.96 tok/s | 2.93 tok/s | 3.29 tok/s |
-| Decode average FPGA throughput | 13.29 GFLOPS | 15.32 GFLOPS | 15.13 GFLOPS | 17.10 GFLOPS |
-
-Baseline kernel setup:
-
-- Prefill: two-pass `matmat_mul_core` for all quantized projections.
-- Decode: streaming `quantized_matmat_core` for Q/K/V, O, MLP gate, and MLP up;
-  two-pass `matmat_mul_core` for MLP down and LM head.
-
-The **Matmatmul prefill + streaming decode** run preserves the baseline
-two-pass prefill while accelerating decode with streaming projections, except
-for wide MLP-down operations with `K=12,288`, which retain the two-pass core.
-
-The **Streaming prefill + streaming decode** run additionally converts all
-supported prefill projections to the one-pass streaming core while retaining
-the same `K=12,288` wide MLP-down fallback in both phases.
+| Measurement | Streaming MLP down | Compact KV direct attention |
+|---|---:|---:|
+| Host vision, complete path | 6.89 s | 6.93 s |
+| Host vision, model forward | 4.38 s | 4.38 s |
+| LM profile compile | 0.60 s | 0.59 s |
+| Prefill host preparation | — | 0.08 s |
+| Prefill FPGA execution | 51.332 s | 51.332 s |
+| Prefill wall time | 51.49 s | 51.47 s |
+| Prefill throughput | 5.28 tok/s | 5.28 tok/s |
+| Prefill FPGA throughput | 23.75 GFLOPS | 23.75 GFLOPS |
+| Decode first-token wall speed | 3.67 tok/s | 4.00 tok/s |
+| Decode first-token FPGA speed | 3.86 | 4.20 tok/s |
+| Decode average wall speed | 3.29 tok/s | 3.69 tok/s |
+| Decode average FPGA throughput | 17.10 GFLOPS | 19.29 GFLOPS |
 
 The **Streaming MLP down** run moves the decoder's wide `K=12,288` MLP-down
 projection from the two-pass core to the streaming core.
 
-Profiled FPGA phase breakdown:
+The **Compact KV direct attention** run retains decoder residual fusion and
+stores each unique KV slot at its actual 256- or 512-element row width. Decoder
+attention consumes these caches directly, eliminating the KV gather copies and
+reducing K+V cache storage from 30 MB to 18 MB.
 
-| Phase | Prefill | Decode, one token |
+Profiled FPGA decode breakdown at position 272:
+
+| Phase | Streaming MLP down | Compact KV direct attention |
 |---|---:|---:|
-| MLP | 35.401 s (68.1%) | 180.49 ms (53.3%) |
-| Attention | 9.257 s (17.8%) | 30.40 ms (9.0%) |
-| QKV/V projection | 3.332 s (6.4%) | 13.11 ms (3.9%) |
-| O projection | 3.048 s (5.9%) | 11.83 ms (3.5%) |
-| LM head | — | 70.26 ms (20.7%) |
-| KV gather | 64.57 ms (0.1%) | 20.48 ms (6.0%) |
-| Per-layer injection | 686.18 ms (1.3%) | 11.34 ms (3.3%) |
-| RoPE | 160.11 ms (0.3%) | 0.97 ms (0.3%) |
-| **Total** | **51.948 s** | **338.89 ms** |
+| MLP | 135.945 ms (52.5%) | 135.553 ms (57.0%) |
+| LM head | 34.761 ms (13.4%) | 34.762 ms (14.6%) |
+| Attention | 30.393 ms (11.7%) | 30.395 ms (12.8%) |
+| KV gather | 20.479 ms (7.9%) | 0.102 ms (0.0%, checkpoint only) |
+| QKV/V projection | 13.113 ms (5.1%) | 13.115 ms (5.5%) |
+| O projection | 11.832 ms (4.6%) | 11.747 ms (4.9%) |
+| Per-layer injection | 11.336 ms (4.4%) | 11.337 ms (4.8%) |
+| RoPE | 0.969 ms (0.4%) | 0.970 ms (0.4%) |
+| Tail add/increment | 0.003 ms (0.0%) | 0.003 ms (0.0%) |
+| **Total** | **258.831 ms (100.0%)** | **237.984 ms (100.0%)** |
+| **Decode FPGA throughput** | **3.86 tok/s** | **4.20 tok/s** |

--- a/models/gemma4_e2b/gemma4_performance.md
+++ b/models/gemma4_e2b/gemma4_performance.md
@@ -14,20 +14,20 @@ python models/gemma4_e2b/gemma4_e2b_refactor.py --image --vision-host --profile
 The VLM prompt contains 273 tokens: 256 image soft tokens and 17 text/special
 tokens. Prefill executes 272 tokens.
 
-| Measurement | Streaming MLP down | Compact KV direct attention |
-|---|---:|---:|
-| Host vision, complete path | 6.89 s | 6.93 s |
-| Host vision, model forward | 4.38 s | 4.38 s |
-| LM profile compile | 0.60 s | 0.59 s |
-| Prefill host preparation | — | 0.08 s |
-| Prefill FPGA execution | 51.332 s | 51.332 s |
-| Prefill wall time | 51.49 s | 51.47 s |
-| Prefill throughput | 5.28 tok/s | 5.28 tok/s |
-| Prefill FPGA throughput | 23.75 GFLOPS | 23.75 GFLOPS |
-| Decode first-token wall speed | 3.67 tok/s | 4.00 tok/s |
-| Decode first-token FPGA speed | 3.86 | 4.20 tok/s |
-| Decode average wall speed | 3.29 tok/s | 3.69 tok/s |
-| Decode average FPGA throughput | 17.10 GFLOPS | 19.29 GFLOPS |
+| Measurement | Streaming MLP down | Compact KV direct attention | FPGA per-layer preparation |
+|---|---:|---:|---:|
+| Host vision, complete path | 6.89 s | 6.93 s | 6.87 s |
+| Host vision, model forward | 4.38 s | 4.38 s | 4.38 s |
+| LM profile compile | 0.60 s | 0.59 s | 0.94 s |
+| Prefill host preparation | — | 0.08 s | 0.06 s |
+| Prefill FPGA execution | 51.332 s | 51.332 s | 51.653 s |
+| Prefill wall time | 51.49 s | 51.47 s | 51.76 s |
+| Prefill throughput | 5.28 tok/s | 5.28 tok/s | 5.27 tok/s |
+| Prefill FPGA throughput | 23.75 GFLOPS | 23.75 GFLOPS | 23.74 GFLOPS |
+| Decode first-token wall speed | 3.67 tok/s | 4.00 tok/s | 4.04 tok/s |
+| Decode first-token FPGA speed | 3.86 tok/s | 4.20 tok/s | 4.11 tok/s |
+| Decode average wall speed | 3.29 tok/s | 3.69 tok/s | 3.82 tok/s |
+| Decode average FPGA throughput | 17.10 GFLOPS | 19.29 GFLOPS | 18.97 GFLOPS |
 
 The **Streaming MLP down** run moves the decoder's wide `K=12,288` MLP-down
 projection from the two-pass core to the streaming core.
@@ -37,18 +37,24 @@ stores each unique KV slot at its actual 256- or 512-element row width. Decoder
 attention consumes these caches directly, eliminating the KV gather copies and
 reducing K+V cache storage from 30 MB to 18 MB.
 
+The **FPGA per-layer preparation** run additionally moves the shared BF16
+`1536 -> 8960` projection, 256-wide RMSNorm, per-layer embedding add, and input
+scaling onto the FPGA. The host performs only token-indexed row lookup and DMA;
+the FPGA preparation costs 321.035 ms per prefill and 5.530 ms per decode token.
+
 Profiled FPGA decode breakdown at position 272:
 
-| Phase | Streaming MLP down | Compact KV direct attention |
-|---|---:|---:|
-| MLP | 135.945 ms (52.5%) | 135.553 ms (57.0%) |
-| LM head | 34.761 ms (13.4%) | 34.762 ms (14.6%) |
-| Attention | 30.393 ms (11.7%) | 30.395 ms (12.8%) |
-| KV gather | 20.479 ms (7.9%) | 0.102 ms (0.0%, checkpoint only) |
-| QKV/V projection | 13.113 ms (5.1%) | 13.115 ms (5.5%) |
-| O projection | 11.832 ms (4.6%) | 11.747 ms (4.9%) |
-| Per-layer injection | 11.336 ms (4.4%) | 11.337 ms (4.8%) |
-| RoPE | 0.969 ms (0.4%) | 0.970 ms (0.4%) |
-| Tail add/increment | 0.003 ms (0.0%) | 0.003 ms (0.0%) |
-| **Total** | **258.831 ms (100.0%)** | **237.984 ms (100.0%)** |
-| **Decode FPGA throughput** | **3.86 tok/s** | **4.20 tok/s** |
+| Phase | Streaming MLP down | Compact KV direct attention | FPGA per-layer preparation |
+|---|---:|---:|---:|
+| MLP | 135.945 ms (52.5%) | 135.553 ms (57.0%) | 135.546 ms (55.7%) |
+| LM head | 34.761 ms (13.4%) | 34.762 ms (14.6%) | 34.761 ms (14.3%) |
+| Attention | 30.393 ms (11.7%) | 30.395 ms (12.8%) | 30.393 ms (12.5%) |
+| KV gather | 20.479 ms (7.9%) | 0.102 ms (0.0%, checkpoint only) | 0.103 ms (0.0%, checkpoint only) |
+| QKV/V projection | 13.113 ms (5.1%) | 13.115 ms (5.5%) | 13.107 ms (5.4%) |
+| O projection | 11.832 ms (4.6%) | 11.747 ms (4.9%) | 11.745 ms (4.8%) |
+| Per-layer injection | 11.336 ms (4.4%) | 11.337 ms (4.8%) | 11.339 ms (4.7%) |
+| Per-layer preparation | — | — | 5.530 ms (2.3%) |
+| RoPE | 0.969 ms (0.4%) | 0.970 ms (0.4%) | 0.969 ms (0.4%) |
+| Tail add/increment | 0.003 ms (0.0%) | 0.003 ms (0.0%) | 0.003 ms (0.0%) |
+| **Total** | **258.831 ms (100.0%)** | **237.984 ms (100.0%)** | **243.495 ms (100.0%)** |
+| **Decode FPGA throughput** | **3.86 tok/s** | **4.20 tok/s** | **4.11 tok/s** |


### PR DESCRIPTION
Moves Gemma4 per-layer input preparation onto FPGA for prefill and decode, retains compact direct KV attention, and records hardware performance. The host now performs token-indexed row lookup and DMA while FPGA executes projection, normalization, embedding addition, and scaling.