### PR TITLE
Gemma4 E2B: context length up to 4096

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_config.json
+++ b/models/gemma4_e2b/gemma4_e2b_config.json
@@ -20,7 +20,7 @@
     "per_layer_input_dim": 256
   },
   "model": {
-    "max_context_size": 1024,
+    "max_context_size": 4096,
     "prefill_max_seq_len": 512,
     "max_prefill_seq_len": 512,
     "sliding_window": 512,

--- a/models/gemma4_e2b/gemma4_e2b_lm.py
+++ b/models/gemma4_e2b/gemma4_e2b_lm.py
@@ -123,7 +123,10 @@ class Gemma4LMMixin:
         rope_cfg = self._cfg["special"]["rope"]
         theta = rope_theta if rope_theta is not None else rope_cfg["theta"]
         local_base = rope_local_base if rope_local_base is not None else rope_cfg["local_base"]
-        num_rope_positions = rope_cfg["num_positions"]
+        # RoPE must cover every position up to the context limit. Derive the
+        # count from MAX_CONTEXT_SIZE (falling back to the config value when it is
+        # larger) so raising the context never silently runs past the table.
+        num_rope_positions = max(int(rope_cfg["num_positions"]), int(self.MAX_CONTEXT_SIZE))
         partial_rotary_factor = rope_cfg["partial_rotary_factor_global"]
 
         # LOCAL RoPE: head_dim_sliding=256, full rotation, D=128
@@ -134,9 +137,11 @@ class Gemma4LMMixin:
         cos_local = freqs_local.cos().to(torch.bfloat16)
         sin_local = freqs_local.sin().to(torch.bfloat16)
         rope_local = torch.cat([cos_local, cos_local, -sin_local, sin_local], dim=1)
-        sz = self.weight_defs["ROPE_LOCAL_SIZE"]
+        # Size the table to the actual data (num_rope_positions x head_dim_sliding*2
+        # bf16); the baked ROPE_LOCAL_SIZE region only fits 1024 positions and would
+        # truncate anything larger.
         raw = rope_local.contiguous().view(torch.uint8).numpy().tobytes()
-        raw = (raw + b"\x00" * sz)[:sz]
+        sz = len(raw)
         addr = self.allocate_params_dram(sz)
         self.dma_write(DMA_DEVICE_H2C, addr, raw, sz)
         self.DRAM_ADDR_ROPE_LOCAL = addr
@@ -149,9 +154,10 @@ class Gemma4LMMixin:
         cos_global = freqs_global.cos().to(torch.bfloat16)
         sin_global = freqs_global.sin().to(torch.bfloat16)
         rope_global = torch.cat([cos_global, cos_global, -sin_global, sin_global], dim=1)
-        sz = self.weight_defs["ROPE_GLOBAL_SIZE"]
+        # Size to the actual data (num_rope_positions x rotary_dims*2 bf16); see the
+        # ROPE_LOCAL note above on why the baked region size would truncate.
         raw = rope_global.contiguous().view(torch.uint8).numpy().tobytes()
-        raw = (raw + b"\x00" * sz)[:sz]
+        sz = len(raw)
         addr = self.allocate_params_dram(sz)
         self.dma_write(DMA_DEVICE_H2C, addr, raw, sz)
         self.DRAM_ADDR_ROPE_GLOBAL = addr
@@ -317,13 +323,21 @@ class Gemma4LMMixin:
         global-attention rows use 512 elements, matching unified attention's
         contiguous K/V layout directly.
         """
-        seq_len = self.MAX_CONTEXT_SIZE
+        # Per-token work length. Every LM intermediate (norms, projections, MLP,
+        # attention staging, per-layer input prep) only ever holds up to
+        # `prefill_seq_len` rows: prefill processes at most `max_prefill_seq_len`
+        # tokens per pass (run_prefill asserts this) and decode processes one.
+        # Sizing these buffers by the work length instead of MAX_CONTEXT_SIZE keeps
+        # the tensor-DRAM footprint flat as the context grows (e.g. 1024 -> 4096);
+        # only the KV cache (below) genuinely scales with MAX_CONTEXT_SIZE, and the
+        # attention scratch/bias buffers scale with `attention_aligned_seq_len`.
+        prefill_seq_len = min(self.max_prefill_seq_len, self.MAX_CONTEXT_SIZE)
+        seq_len = prefill_seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len = ((q_seq_len + 63) // 64) * 64
-        # Unified attention scratch/bias buffers are largest during prefill,
-        # but decode can still require MAX_CONTEXT_SIZE KV rows. Size the
-        # shared attention buffers for the larger aligned dimension.
-        prefill_seq_len = min(self.max_prefill_seq_len, self.MAX_CONTEXT_SIZE)
+        # Unified attention scratch/bias buffers are largest during prefill, but
+        # decode can still require MAX_CONTEXT_SIZE KV rows. Size the shared
+        # attention buffers for the larger aligned dimension.
         prefill_q_seq_len = prefill_seq_len * self.group_size
         prefill_aligned_seq_len = ((prefill_q_seq_len + 63) // 64) * 64
         decode_aligned_seq_len = ((self.MAX_CONTEXT_SIZE + 63) // 64) * 64
@@ -424,13 +438,18 @@ class Gemma4LMMixin:
         # Per-layer input preparation + injection buffers.  The host uploads
         # only token-indexed rows from embed_tokens_per_layer; FPGA performs
         # model projection, RMSNorm, add and scaling into PER_LAYER_INPUTS_DRAM.
-        pli_elements = self.MAX_CONTEXT_SIZE * self.LAYER_SIZE * self.per_layer_input_dim
+        # All three are per-pass work buffers: prefill fills up to prefill_seq_len
+        # tokens ([token, layer, dim]); decode recomputes the single current token
+        # at the base each step (see the decode per-layer prep, which writes with
+        # OUTPUT_DRAM_ADDR=PER_LAYER_INPUTS_DRAM). So size by the work length, not
+        # MAX_CONTEXT_SIZE.
+        pli_elements = seq_len * self.LAYER_SIZE * self.per_layer_input_dim
         self.PER_LAYER_EMBED_DRAM = self.allocate_tensor_dram(
             pli_elements * self.bytes_per_element)
         self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(
             pli_elements * self.bytes_per_element)
         # Final layout is [token, layer, dim], consumed by injection blocks.
-        self.PER_LAYER_INPUTS_DRAM = self.allocate_tensor_dram(self.MAX_CONTEXT_SIZE * self.LAYER_SIZE * self.per_layer_input_dim * self.bytes_per_element)
+        self.PER_LAYER_INPUTS_DRAM = self.allocate_tensor_dram(pli_elements * self.bytes_per_element)
         # Intermediate DRAMs for per-layer injection
         self.LAYER0_PER_LAYER_GATE_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.per_layer_input_dim * self.bytes_per_element)
         self.LAYER0_PER_LAYER_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * self.bytes_per_element)


### PR DESCRIPTION
## Summary

Enable Gemma4 E2B to run at context lengths up to **4096** (configurable via `max_context_size`), keeping prefill/sliding window at 512. Two commits:

**`context length 4096`**
- **Per-token buffer decoupling** (`gemma4_e2b_lm.py::tensor_init`): per-token / per-layer work buffers (norms, projections, MLP, attention staging, and all three per-layer-input buffers) are now sized by `prefill_seq_len` instead of `MAX_CONTEXT_SIZE`. Only the KV cache scales with context; the attention scratch/bias buffers are unchanged (already at the 4096-aligned prefill extent). Net effect: tensor DRAM at ctx 4096 is **280 MB** — actually *lower* than the 313 MB at ctx 1024 — so it fits the fixed 480 MiB tensor region.
- **RoPE table sizing** (`_load_rope_host`): position count is now `max(config num_positions, MAX_CONTEXT_SIZE)` and the table is allocated to its exact byte size, removing the previous fixed 1 MiB region that silently **truncated RoPE at 1024 positions** (the root cause of degeneration once decode crossed ~1024).
- `gemma4_e2b_config.json`: `max_context_size` 1024 → 4096.

**`rk run performance`**
- Adds the `rk` column to `gemma4_e2b_performance.md`.

## 2 GB DRAM layout fit (ctx 4096)

| Region | Budget | Used @ 4096 |
|---|---:|---:|
| Tensor DRAM (`0xE1000000–0xFF000000`) | 480 MiB | 280.0 MB |
| Params (weights + RoPE) | 1552 MiB | 1544.4 MB |
| LM ISA | 10 MiB | 4.6 MB |

512-bit vs 256-bit AXI width changes no DRAM sizing (nothing in the model or shared cores is rounded to the AXI beat).

## Hardware verification

- **kintex7**: decoded coherently well past the old 1024-position boundary (~3700 tokens).
- **rk_256**: ran end-to-end to the full 4096-token context cap. Perf numbers + a known greedy-repetition note are in a PR comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
