### PR TITLE
Gemma4 E2B: update performance table (rk run)

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -11,28 +11,29 @@ weights, 35 LM layers, 16 vision layers, and 256 image soft tokens.
 Commands:
 
 ```bash
-python models/gemma4_e2b/gemma4_e2b_test.py --image --dev xdma0
-python models/gemma4_e2b/gemma4_e2b_test.py --image --profile --dev xdma0
+python models/gemma4_e2b/gemma4_e2b_test.py --image 
+python models/gemma4_e2b/gemma4_e2b_test.py --image --profile
+python models/gemma4_e2b/gemma4_e2b_test.py --image --prefill-kernel matmatmul
 ```
 
 ## Performance comparison
 
-| Metric | Legacy | Refactored streaming prefill | Refactored matmatmul prefill |
-|---|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 54.60 s | 54.85 s |
-| Vision end-to-end path | not reported | 55.81 s | 56.10 s |
-| Vision throughput | not reported | 20.86 GFLOPS | 20.76 GFLOPS |
-| Vision soft tokens | 256 | 256 | 256 |
-| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.63 s | 52.578 s |
-| LM prefill useful-work throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS |
-| Decode average throughput | 2.68 tok/s | 3.82 tok/s | 3.85 tok/s |
-| Decode peak first-token throughput | 2.86 tok/s | 4.07 tok/s | 4.01 tok/s |
-| Decode average hardware throughput | 13.42 GFLOPS | 19.11 GFLOPS | 19.20 GFLOPS |
-| Vision program section | 3.58 MiB | 3.03 MiB | 3.03 MiB |
-| Prefill program section | 5.71 MiB | 3.10 MiB | 3.21 MiB |
-| Combined program image | 10.37 MiB | 7.54 MiB | 7.67 MiB |
-| Weight image (`params.bin`) | 6.91 GiB | same | same |
+| Metric | Legacy | Refactored streaming prefill | Refactored matmatmul prefill | rk |
+|---|---:|---:|---:|---:|
+| Vision FPGA execution | 55.54 s | 54.60 s | 54.85 s | 32.56 s |
+| Vision end-to-end path | not reported | 55.81 s | 56.10 s | 33.03 s |
+| Vision throughput | not reported | 20.86 GFLOPS | 20.76 GFLOPS | 35.00 GFLOPS |
+| Vision soft tokens | 256 | 256 | 256 | 256 |
+| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 273 actual tokens |
+| LM prefill FPGA latency | 113.571 s | 51.63 s | 52.578 s | 32.544 s |
+| LM prefill useful-work throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 37.89 GFLOPS |
+| Decode average throughput | 2.68 tok/s | 3.82 tok/s | 3.85 tok/s | 6.00 tok/s |
+| Decode peak first-token throughput | 2.86 tok/s | 4.07 tok/s | 4.01 tok/s | 6.23 tok/s |
+| Decode average hardware throughput | 13.42 GFLOPS | 19.11 GFLOPS | 19.20 GFLOPS | 30.45 GFLOPS |
+| Vision program section | 3.58 MiB | 3.03 MiB | 3.03 MiB | / |
+| Prefill program section | 5.71 MiB | 3.10 MiB | 3.21 MiB | / |
+| Combined program image | 10.37 MiB | 7.54 MiB | 7.67 MiB | / |
+| Weight image (`params.bin`) | 6.91 GiB | same | same | / |
 
 ## Refactor optimizations
 


### PR DESCRIPTION
## Summary

Detached from #133. Updates `gemma4_e2b_performance.md` with the `rk` run column, keeping the docs change independent of the context-length code changes.

- Adds the `rk` column to `gemma4_e2b_performance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)