### PR TITLE
Gemma4 multicore

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_lm.py
+++ b/models/gemma4_e2b/gemma4_e2b_lm.py
@@ -203,6 +203,49 @@ class Gemma4LMMixin:
         a 16 GB Raspberry Pi. The first run on a beefier machine should
         generate the side-cache so subsequent runs anywhere can skip the
         HF model entirely.
+
+        ==================================================================
+        FULL DRAM ADDRESS MAP (upper 2 GB window; 3 arenas, each its own bump
+        allocator: allocate_params_dram / allocate_tensor_dram / program DRAM).
+        Fixed bases are set in Gemma4_UnifiedEngine.__init__; `~` marks a
+        run-time high-water (values shown are the 2-core VLM example).
+
+          0x80000000 ┌ PARAMS  (weights, allocate_params_dram) ~1552 MiB ┐
+                     │  LM weights ...................... ~1540.4 MB      │
+                     │   35 layers x LAYER_WEIGHT_SIZE (IF4 q/k/v/o +     │
+                     │     gate/up/down data+scale, all RMS gammas,       │
+                     │     per-layer-input gate/proj, layer_scalar)       │
+                     │   + non-layer: ROPE_LOCAL/ROPE_GLOBAL (the *LM*    │
+                     │     rope tables, fixed here), OUTPUT_NORM,          │
+                     │     PER_LAYER_MODEL_PROJ, PER_LAYER_PROJ_NORM,      │
+                     │     LM_HEAD (IF4, tied to embed)                    │
+              ~end   │  _vis_identity_dram (8 KiB, __init__)  128x128 eye │
+                     │     kept in PARAMS so vision scratch can't clobber │
+          0xE1000000 ├ TENSOR  (activations+scratch, allocate_tensor_dram)┤ 480 MiB
+                     │  time-shared LM <-> vision; see tensor_init() for  │
+                     │  the detailed sub-layout. LM persistent tensors,   │
+                     │  then LM/vision scratch, then (top) vision weights.│
+          0xFF000000 ├ PROGRAM / ISA (compiled programs.bin sections) ────┤ 16 MiB
+                     │  Vision core0 (master) ISA .......... 0xFF000000  │ 4 MiB
+                     │     VISION_ISA_BASE; encoder ~2.3 MB              │
+                     │  Vision core1 (worker) ISA .......... 0xFF400000  │ 2.125 MiB
+                     │     VISION_WORKER_ISA_BASE (2-core head-sharded) │
+                     │  LM ISA ............................. 0xFF620000  │ 9.875 MiB
+                     │     LM_ISA_BASE: preamble + prefill(@+0x20)      │
+                     │     + decoder; uses ~4.9 of 9.875 MiB           │
+         0x100000000 └───────────────────────────────────────────────────┘
+
+        MULTI-CORE PROGRAM DRAM (MultiEngineScheduler via _ensure_stage_scheduler):
+          * 2-core (kintex7, --multi-core): worker base = VISION_WORKER_ISA_BASE.
+              vision:  core0 @0xFF000000 (4 MiB) | core1 @0xFF400000 (2.125 MiB).
+              LM prefill: master @LM_ISA_BASE | worker @VISION_ISA_BASE
+                          (reuses the vision core0 region — vision has finished).
+          * 8-core (Alveo, --multi-core 8): worker base = 0xFC000000,
+              stride 0x00240000 (2.25 MiB/worker) -> 7 slots 0xFC000000,
+              0xFC240000, ...  The vision weight/scratch arena top then drops
+              to 0xFC000000 (see tensor_init() / vision_weight_init()).
+        Single-core (--multi-core 1) uses only core0/master; no worker ISA.
+        ==================================================================
         """
         import mmap as _mmap
 
@@ -320,6 +363,51 @@ class Gemma4LMMixin:
         dimension. Sliding-attention rows therefore use 256 elements and
         global-attention rows use 512 elements, matching unified attention's
         contiguous K/V layout directly.
+
+        ==================================================================
+        TENSOR REGION MAP  (0xE1000000 .. 0xFF000000, 480 MiB).
+        Time-shared: LM uses it at run time; the vision stage borrows it while
+        LM is idle (vision runs first, emits soft tokens, finishes before LM
+        prefill). `~` = run-time high-water (2-core VLM example).
+
+          0xE1000000 ┌ LM PERSISTENT (never clobbered by vision) ~120 MiB ┐
+                     │  LAYER0_V_DRAM / LAYER0_K_ROPE_DRAM  (KV cache)      │
+                     │  ZERO_DRAM_ADDR, IDENTITY_DRAM_ADDR (128x128 eye)   │
+                     │  FLASH_BIAS_FULL / FLASH_BIAS_SLIDING               │
+                     │  PENALTY_BIAS, PER_LAYER_EMBED, PER_LAYER_INPUTS    │
+         ~0xE8682000 ├ _scratch_dram_base  (vision resets its cursor here) ┤
+                     │  Below = persistent, above = disposable scratch.    │
+                     │                                                     │
+                     │  LM view (allocate_tensor_dram, grows up):          │
+                     │    FLASH_Q/K/V, INPUT, Q/K(+NORM), FLASH_OUTPUT,    │
+                     │    FLASH_SCRATCH (V.T+scores+scaled_q), MLP_GATE/   │
+                     │    UP/MULT/DOWN, LOGITS, per-layer-inject scratch   │
+                     │    (high-water < 0xFF000000; asserted)              │
+                     │                                                     │
+                     │  Vision view (vision_tensor_init, same base):       │
+                     │    IO_A/B, NORM_OUT, Q/K/V_DRAM, Q/K_NORM, ATTN,   │
+                     │    MLP_*, FLASH_BIAS, Q/K/V/OUT_HM (head-major),    │
+                     │    VIS_ROPE_P_SWAP/COS_TILED/SIN_TILED/ROT (the     │
+                     │      *vision* rope tables — per-run, NOT params),   │
+                     │    pooler (EMBED/POOL/HIDDEN_T), + per-engine attn  │
+                     │      scratch VIS_FLASH_SCRATCH_PER_ENGINE[i]        │
+         ~0xF61EE000 │    ~ vision scratch high-water                      │
+                     │      ........... free gap ...........               │
+         ~0xFA881180 ├ VISION WEIGHTS (vision_weight_init, top-placed) ~78MiB
+                     │    16 layers x (norms + q/k/v/o/gate/up/down IF4)   │
+                     │    + patch_proj, embed_proj, gammas.  Placed flush  │
+                     │    against the arena top so scratch can't reach it. │
+          0xFF000000 └ VISION_ISA_BASE (program region begins) ───────────┘
+
+        MULTI-CORE: each engine gets its OWN private attention scratch
+        VIS_FLASH_SCRATCH_PER_ENGINE[i] (~13.4 MiB each), so 2-core adds
+        ~13 MiB of scratch vs single-core and pushes the vision scratch
+        high-water up (single ~0xF54CE000 -> 2-core ~0xF61EE000). Vision
+        weights are top-placed to stay clear of it; the arena TOP is
+        VISION_ISA_BASE for <=2-core, or 0xFC000000 for >2-core (Alveo),
+        because the 8-core worker ISA arena starts at 0xFC000000 (the LM
+        persistent region below _scratch_dram_base is untouched either way).
+        ==================================================================
         """
         seq_len = self.MAX_CONTEXT_SIZE
         q_seq_len = seq_len * self.group_size

--- a/models/gemma4_e2b/gemma4_e2b_lm.py
+++ b/models/gemma4_e2b/gemma4_e2b_lm.py
@@ -1653,6 +1653,7 @@ class Gemma4LMMixin:
         _dec_timer = time.perf_counter()
         _first_tok_dt = None   # wall-clock of the 1st decoded token → peak tok/s
         _decoded_n = 0         # number of decode steps (for average tok/s)
+        _decoded_ids = []      # generated token ids (for the run-summary decoded text)
         _use_status = sys.stdout.isatty()
         def _status_setup():
             rows = shutil.get_terminal_size().lines
@@ -1729,6 +1730,7 @@ class Gemma4LMMixin:
                     _status_teardown()
                 print(f"\nStop token {token_id} reached.")
                 break
+            _decoded_ids.append(token_id)
             print(token_char, end="", flush=True)
             if _use_status:
                 _status_update()
@@ -1741,4 +1743,15 @@ class Gemma4LMMixin:
         _avg = (_decoded_n / _elapsed) if _elapsed > 0 else 0.0
         print(f"\nDecode speed: peak (1st token) {_peak:.2f} tok/s, "
               f"average {_avg:.2f} tok/s  ({_decoded_n} tokens in {_elapsed:.2f}s)")
+        # Stash decode metrics for the run-summary writer (write_run_summary).
+        self._decode_peak_toks = _peak
+        self._decode_avg_toks = _avg
+        self._decode_generated_n = _decoded_n
+        self._decode_total_flop_rate = total_flop_rate
+        self._decode_hw_latency_us = total_latency
+        self._decoded_token_ids = list(_decoded_ids)
+        try:
+            self._decoded_text = self.tokenizer.decode(_decoded_ids, skip_special_tokens=False)
+        except Exception:
+            self._decoded_text = None
         return self.seq_len, total_latency, total_flop_rate

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -19,7 +19,6 @@ Commands:
 ```bash
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --profile
-python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --prefill-kernel matmatmul
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core --profile
 python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image
@@ -30,24 +29,24 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 
 ## Performance comparison
 
-| Metric | Legacy | Kintex | matmatmul prefill | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 53.78 s | 54.85 s | 27.77s | 32.56 s | **42.51 s** | **15.4 s** | **12.13 s** | **7.53 s** |
-| Vision end-to-end path | not reported | 54.33 s | 56.10 s | 28.58s | 33.03 s | **35.96 s** | **19.6 s** | **11.49 s** | **8.40 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 20.76 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **27.03 GFLOPS** | **74.4 GFLOPS** | **94.76 GFLOPS** | **152.66 GFLOPS** |
-| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
-| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 52.578 s | 31.87s | 32.544 s | **41.40 s** | **17.3 s** | **17.02 s** | **12.91 s** |
-| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **29.79 GFLOPS** | **71.22 GFLOPS** | **72.46 GFLOPS** | **95.52 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.85 tok/s | 3.76 tok/s | 6.00 tok/s | **5.49 tok/s** | **5.49 tok/s** | **5.42 tok/s** | **5.43 tok/s** |
-| Decode peak first-token throughput | 2.86 tok/s | 4.00 tok/s | 4.01 tok/s | 4.0 tok/s | 6.23 tok/s | **5.91 tok/s** | **5.88 tok/s** | **5.70 tok/s** | **5.70 tok/s** |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 19.20 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **23.13 GFLOPS** | **33.97 GFLOPS** | **23.40 GFLOPS** | **23.40 GFLOPS** |
-| Vision program section | 3.58 MiB | 3.22 MiB | 3.03 MiB | 2.39 MiB | / | **3.22 MiB (master)** | 2.39 MiB | **1.83 MiB (master)** | **1.67 MiB (master)** |
-| Prefill program section | 5.71 MiB | 3.08 MiB | 3.21 MiB | 3.46 MiB | / | **3.08 MiB (master)** | 3.46 MiB | **3.39 MiB (master)** | **3.41 MiB (master)** |
-| Decode program section | | | | 1.46 MiB | | |1.46 MiB| | |
-| Combined program image | 10.37 MiB | 7.73 MiB | 7.67 MiB | 10.81 MiB | / | **7.73 MiB** | 10.81 MiB | **15.15 MiB** | **24.73 MiB** |
-| Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
-| Correctness |  | **coherent; stop token** | coherent | coherent, total 709 | not recorded | **coherent; stop token** | coherent, total 709 | **coherent; stop token** | **coherent; stop token** |
+| Metric | Legacy | Kintex | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Vision FPGA execution | 55.54 s | 53.78 s | 27.77s | 32.56 s | **29.05 s** | **15.4 s** | **8.00 s** | **4.77 s** |
+| Vision end-to-end path | not reported | 54.37 s | 28.58s | 33.03 s | **36.10 s** | **19.6 s** | **11.06 s** | **7.97 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **39.56 GFLOPS** | **74.4 GFLOPS** | **143.61 GFLOPS** | **240.66 GFLOPS** |
+| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
+| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 31.87s | 32.544 s | **28.51 s** | **17.3 s** | **11.60 s** | **8.79 s** |
+| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **43.26 GFLOPS** | **71.22 GFLOPS** | **106.32 GFLOPS** | **140.34 GFLOPS** |
+| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.76 tok/s | 6.00 tok/s | **5.47 tok/s** | **5.49 tok/s** | **5.49 tok/s** | **5.56 tok/s** |
+| Decode peak first-token throughput | 2.86 tok/s | 4.00 tok/s | 4.0 tok/s | 6.23 tok/s | **5.79 tok/s** | **5.88 tok/s** | **5.88 tok/s** | **5.89 tok/s** |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **33.82 GFLOPS** | **33.97 GFLOPS** | **33.98 GFLOPS** | **34.35 GFLOPS** |
+| Vision program section | 3.58 MiB | 3.22 MiB | 2.39 MiB | / | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
+| Prefill program section | 5.71 MiB | 3.08 MiB | 3.46 MiB | / | 3.08 MiB | 3.46 MiB | 3.39 MiB | 3.41 MiB |
+| Decode program section | | 1.42 MiB | 1.46 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
+| Combined program image | 10.37 MiB | 28.45 MiB | 10.81 MiB | / | 28.45 MiB | 10.81 MiB | 27.44 MiB | 26.92 MiB |
+| Weight image (`params.bin`) | 6.91 GiB | same | same | / | same | same | same | same |
+| Correctness |  | coherent, total 724 | coherent, total 709 | not recorded | coherent, total 724 | coherent, total 709 | coherent, total 709 | coherent, total 709 |
 
 The four Alveo columns were refreshed on 2026-08-17 against HW version
 `0x6bb5d25d`, with `make clean` before every run. All four produced coherent

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -8,14 +8,25 @@ Both implementations used `test_samples/yosemite.jpg`, the prompt
 `Describe this image in detail.`, the same `params.bin`, IF4 projection
 weights, 35 LM layers, 16 vision layers, and 256 image soft tokens.
 
+> **2026-08-17 refresh (Kintex + Kintex 2-core columns and all profile tables).**
+> These were re-measured on `--dev xdma1`, whose flashed bitstream reports HW
+> version `0xbb859676` — this does **not** match the version this software
+> expects (`0xcf133b89`, `update_cf133b89.bin`). The `hw_version` assertion in
+> `user_dma_core.init_unified_engine` was temporarily commented out to let the
+> runs proceed against the on-board bitstream. Treat the refreshed numbers, and
+> especially the Kintex 2-core correctness result, with that mismatch in mind;
+> the other columns (Legacy, Refactored, rk, Alveo*) are unchanged from the
+> original setup above. Each of the four runs was preceded by `make clean`
+> (`clean_program_bins.sh`) so every program image was recompiled from scratch.
+
 Commands:
 
 ```bash
-python models/gemma4_e2b/gemma4_e2b_test.py --image 
-python models/gemma4_e2b/gemma4_e2b_test.py --image --profile
-python models/gemma4_e2b/gemma4_e2b_test.py --image --prefill-kernel matmatmul
-python models/gemma4_e2b/gemma4_e2b_test.py --image --multi-core
-python models/gemma4_e2b/gemma4_e2b_test.py --image --multi-core --profile
+python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image 
+python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --profile
+python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --prefill-kernel matmatmul
+python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core
+python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core --profile
 python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image
 python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core
 ```
@@ -24,21 +35,21 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core
 
 | Metric | Legacy | Kintex | Refactored matmatmul prefill | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core (unvalidated) | Alveo 8-core (unvalidated) |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 54.60 s | 54.85 s | **29.24 s** | 32.56 s | 36.15 s | **19.89 s** | **10.96 s** | **7.19 s** |
-| Vision end-to-end path | not reported | 55.81 s | 56.10 s | **29.96 s** | 33.03 s | 36.66 s | **20.56 s** | **12.00 s** | **8.86 s** |
-| Vision throughput | not reported | 20.86 GFLOPS | 20.76 GFLOPS | **38.99 GFLOPS** | 35.00 GFLOPS | 26.30 GFLOPS | **47.82 GFLOPS** | **86.78 GFLOPS** | **132.27 GFLOPS** |
+| Vision FPGA execution | 55.54 s | 53.78 s | 54.85 s | **28.09 s** | 32.56 s | 36.15 s | **19.89 s** | **10.96 s** | **7.19 s** |
+| Vision end-to-end path | not reported | 54.32 s | 56.10 s | **28.83 s** | 33.03 s | 36.66 s | **20.56 s** | **12.00 s** | **8.86 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 20.76 GFLOPS | **40.91 GFLOPS** | 35.00 GFLOPS | 26.30 GFLOPS | **47.82 GFLOPS** | **86.78 GFLOPS** | **132.27 GFLOPS** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
-| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.63 s | 52.578 s | **31.83 s** | 32.544 s | 34.54 s | **21.09 s** | **14.27 s** | **10.88 s** |
+| LM prefill sequence executed | 512-token template | 273 actual tokens | 272 actual tokens | 273 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 52.578 s | **31.78 s** | 32.544 s | 34.54 s | **21.09 s** | **14.27 s** | **10.88 s** |
 | LM prefill useful-work throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 38.80 GFLOPS | 37.89 GFLOPS | 29.79 GFLOPS | **48.84 GFLOPS** | **72.31 GFLOPS** | **95.23 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.82 tok/s | 3.85 tok/s | **3.80 tok/s** | 6.00 tok/s | 5.60 tok/s | 5.62 tok/s | 5.68 tok/s | 5.46 tok/s |
-| Decode peak first-token throughput | 2.86 tok/s | 4.07 tok/s | 4.01 tok/s | **4.00 tok/s** | 6.23 tok/s | 5.91 tok/s | 5.90 tok/s | 5.79 tok/s | 5.75 tok/s |
-| Decode average hardware throughput | 13.42 GFLOPS | 19.11 GFLOPS | 19.20 GFLOPS | **19.05 GFLOPS** | 30.45 GFLOPS | 23.61 GFLOPS | 23.68 GFLOPS | 23.91 GFLOPS | 23.05 GFLOPS |
-| Vision program section | 3.58 MiB | 3.03 MiB | 3.03 MiB | **4.15 MiB incl. worker** | / | 3.05 MiB | 4.15 MiB incl. worker | 6.18 MiB incl. workers | not reported |
-| Prefill program section | 5.71 MiB | 3.10 MiB | 3.21 MiB | **4.70 MiB incl. worker** | / | 3.08 MiB | 4.70 MiB incl. worker | 7.37 MiB incl. workers | not reported |
-| Combined program image | 10.37 MiB | 7.54 MiB | 7.67 MiB | **10.27 MiB** | / | 7.55 MiB | 10.27 MiB | 14.98 MiB | not reported |
+| Decode average throughput | 2.68 tok/s | 3.75 tok/s | 3.85 tok/s | **3.83 tok/s** | 6.00 tok/s | 5.60 tok/s | 5.62 tok/s | 5.68 tok/s | 5.46 tok/s |
+| Decode peak first-token throughput | 2.86 tok/s | 4.01 tok/s | 4.01 tok/s | **4.00 tok/s** | 6.23 tok/s | 5.91 tok/s | 5.90 tok/s | 5.79 tok/s | 5.75 tok/s |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 19.20 GFLOPS | **19.31 GFLOPS** | 30.45 GFLOPS | 23.61 GFLOPS | 23.68 GFLOPS | 23.91 GFLOPS | 23.05 GFLOPS |
+| Vision program section | 3.58 MiB | 3.22 MiB | 3.03 MiB | **2.32 MiB (master)** | / | 3.05 MiB | 4.15 MiB incl. worker | 6.18 MiB incl. workers | not reported |
+| Prefill program section | 5.71 MiB | 3.08 MiB | 3.21 MiB | **3.38 MiB (master)** | / | 3.08 MiB | 4.70 MiB incl. worker | 7.37 MiB incl. workers | not reported |
+| Combined program image | 10.37 MiB | 7.73 MiB | 7.67 MiB | **7.13 MiB (master)** | / | 7.55 MiB | 10.27 MiB | 14.98 MiB | not reported |
 | Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
-| Correctness | legacy baseline | coherent | coherent | coherent | not recorded | coherent; stop token | coherent; stop token | **failed: unrelated description** | **failed: unrelated description** |
+| Correctness | legacy baseline | coherent | coherent | **failed: unrelated (barcode)** | not recorded | coherent; stop token | coherent; stop token | **failed: unrelated description** | **failed: unrelated description** |
 
 The Alveo one- and two-core runs produced coherent Yosemite descriptions and
 reached the stop token. The experimental four- and eight-core columns record
@@ -46,9 +57,21 @@ measured execution numbers, but both decoded unrelated image descriptions and
 are therefore explicitly marked unvalidated. See `gemma4_e2b_alveo_4core.log`
 and `gemma4_e2b_alveo_8core.log` for those correctness failures.
 
-The Kintex 2-core column is from the latest normal run with vision attention
-heads sharded across both engines (`gemma4_e2b_multicore_attention.log`), replacing
-the older projection-only multicore measurements.
+The Kintex 2-core column is from a 2026-08-17 `--multi-core` run with vision
+attention heads sharded across both engines, replacing the older projection-only
+multicore measurements. This refresh nearly halves the vision encoder (53.78 →
+28.09 s) and prefill (51.52 → 31.78 s) versus single-core, but its **decode was
+incoherent**: with the same Yosemite image that single-core described correctly,
+the two-engine run produced an unrelated description of a "barcode" (reaching the
+stop token). This is a correctness regression on the sharded path, observed here
+on the mismatched `0xbb859676` bitstream (see the 2026-08-17 refresh note above),
+so it is not yet clear whether the fault is in the head-sharded attention path or
+an artifact of the bitstream/software version mismatch — it needs re-confirmation
+on the matching `0xcf133b89` bitstream before the sharded path can be trusted.
+The 2-core program-section sizes above are the **master** engine's stored sections
+from this run (the sharded design splits work per engine, so the master program
+shrank); the worker sections were not separately itemized in the run log, so these
+are not directly comparable to the older "incl. worker" Alveo figures.
 
 ## Refactor optimizations
 
@@ -78,14 +101,17 @@ the older projection-only multicore measurements.
 - Add checkpointed profile images for vision, prefill, and decode without
   changing the normal execution image.
 
-Profile tables below are fresh `--profile` runs (`--dev xdma1`), rows in
-**compile order**. `--multi-core 2` uses per-phase multi-core profiling: the
+Profile tables below are fresh `--profile` runs (`--dev xdma1`, 2026-08-17), rows
+in **compile order**. `--multi-core 2` uses per-phase multi-core profiling: the
 master's per-segment HW latency counter, with checkpoints at the sharded-region
-boundaries so each region's segment measures its fork-to-join wall-time. Each stage
-row-shards its **two matmul-heavy projection regions** across the two engines
-(vision: Projection + Post-attention; prefill: QKV/V + MLP) — these ~halve; the
-norm/RoPE/attention phases are master-only and engine-invariant. Decode is
-single-engine (never sharded), so its multi-core breakdown equals single-core.
+boundaries so each region's segment measures its fork-to-join wall-time.
+**Vision** now shards three regions — Projection, **Attention (head-sharded)**,
+and Post-attention — so all three ~halve (this is the change behind the faster
+28.09 s Kintex 2-core vision; the old table had vision attention engine-invariant).
+**Prefill** shards only its two matmul-heavy regions (QKV/V + MLP); its attention
+and per-layer prep stay master-only. The norm/RoPE/permute/gather phases are
+master-only and engine-invariant in both stages. Decode is single-engine (never
+sharded), so its multi-core breakdown equals single-core.
 
 ## Profile backup: vision encoder
 
@@ -95,16 +121,19 @@ so the per-phase `--multi-core 2` numbers are exact.
 | Phase | Single-core | --multi-core 2 |
 |---|---:|---:|
 | Patch embedding | 123.6 ms | 123.6 ms |
-| Projection (Q/K/V) † | 6,682.5 ms | **3,359.2 ms** |
-| RoPE gather | 2,520.5 ms | 2,520.5 ms |
-| Attention | 16,642.2 ms | 16,642.3 ms |
-| Post-attention (O + MLP) † | 28,911.9 ms | **14,540.7 ms** |
+| Projection (Q/K/V) † | 6,682.4 ms | **3,360.0 ms** |
+| RoPE | 1,072.8 ms | 1,072.8 ms |
+| Permute | 269.6 ms | 269.6 ms |
+| Attention † | 16,642.2 ms | **8,645.1 ms** |
+| Post-attention (O + MLP) † | 28,911.4 ms | **14,539.1 ms** |
 | Pooler tail | 75.3 ms | 75.3 ms |
 | Tail | 0.0 ms | 0.0 ms |
-| **Total** | **54,956.0 ms** | **37,261.6 ms** |
+| **Total** | **53,777.3 ms** | **28,085.5 ms** |
 
-† row-sharded across 2 engines (the two fork-join regions); these ~halve. The
-master-only phases are unchanged, as expected.
+† row-sharded across 2 engines (Projection, Attention head-sharded, and
+Post-attention); these ~halve. The master-only phases (patch embed, RoPE,
+permute, pooler tail) are unchanged, as expected. The multi-core total
+(28,085.5 ms) matches the Kintex 2-core vision FPGA execution (28.09 s) above.
 
 ## Profile backup: LM prefill
 
@@ -114,17 +143,17 @@ O+MLP sharded region. Only **QKV/V projection** and **MLP (incl. O)** are sharde
 per-segment counter mis-times the two *long* master-only phases (per-layer prep,
 attention), so those rows show their single-core value (which is the true
 multi-core value — they run identically on the master). The reconstructed
-multi-core total (31,782 ms) matches the single-shot master counter (31,781.9 ms),
-confirming it.
+multi-core total (31,782 ms) matches the single-shot master counter (31,782.7 ms
+from the Kintex 2-core prefill run), confirming it.
 
 | Phase | Single-core | --multi-core 2 |
 |---|---:|---:|
 | Per-layer preparation ‡ | 596.0 ms | 596.0 ms |
-| QKV/V projection † | 3,302.5 ms | **1,681.8 ms** |
+| QKV/V projection † | 3,302.5 ms | **1,682.3 ms** |
 | RoPE | 162.6 ms | 162.6 ms |
 | KV gather | 70.0 ms | 70.0 ms |
 | Attention ‡ | 9,268.7 ms | 9,268.7 ms |
-| MLP (incl. O projection) † | 37,426.6 ms | **19,309.3 ms** |
+| MLP (incl. O projection) † | 37,426.6 ms | **19,309.4 ms** |
 | Injection | 694.2 ms | 694.2 ms |
 | Tail halt | 0.0 ms | 0.0 ms |
 | **Total** | **51,520.6 ms** | **31,782.4 ms** |
@@ -152,5 +181,6 @@ Decode is single-engine; `--multi-core 2` is identical (245.3 ms total).
 | **Total** | **245.3 ms** |
 
 The profiled single-token throughput is ~4.08 tok/s. Checkpoint HALTs add
-instrumentation control flow, so the normal-run ~3.7 tok/s average remains the
-end-to-end decode result to use for user-visible throughput.
+instrumentation control flow, so the normal-run average (3.75 tok/s single-core,
+3.83 tok/s Kintex 2-core) remains the end-to-end decode result to use for
+user-visible throughput.

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -8,70 +8,60 @@ Both implementations used `test_samples/yosemite.jpg`, the prompt
 `Describe this image in detail.`, the same `params.bin`, IF4 projection
 weights, 35 LM layers, 16 vision layers, and 256 image soft tokens.
 
-> **2026-08-17 refresh (Kintex + Kintex 2-core columns and all profile tables).**
-> These were re-measured on `--dev xdma1`, whose flashed bitstream reports HW
-> version `0xbb859676` — this does **not** match the version this software
-> expects (`0xcf133b89`, `update_cf133b89.bin`). The `hw_version` assertion in
-> `user_dma_core.init_unified_engine` was temporarily commented out to let the
-> runs proceed against the on-board bitstream. Treat the refreshed numbers, and
-> especially the Kintex 2-core correctness result, with that mismatch in mind;
-> the other columns (Legacy, Refactored, rk, Alveo*) are unchanged from the
-> original setup above. Each of the four runs was preceded by `make clean`
+> **2026-08-17 refresh.** The Kintex, Kintex 2-core, and Alveo columns were
+> re-measured from clean builds. Kintex used `--dev xdma1` with accepted HW
+> version `0x3d04c689`; Alveo used `--device alveo` with accepted HW version
+> `0x6bb5d25d`. Each run was preceded by `make clean`
 > (`clean_program_bins.sh`) so every program image was recompiled from scratch.
 
 Commands:
 
 ```bash
-python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image 
+python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --profile
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --prefill-kernel matmatmul
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core
 python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core --profile
 python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image
 python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core
+python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 4
+python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 8
 ```
 
 ## Performance comparison
 
-| Metric | Legacy | Kintex | Refactored matmatmul prefill | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core (unvalidated) | Alveo 8-core (unvalidated) |
+| Metric | Legacy | Kintex | matmatmul prefill | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 53.78 s | 54.85 s | **28.09 s** | 32.56 s | 36.15 s | **19.89 s** | **10.96 s** | **7.19 s** |
-| Vision end-to-end path | not reported | 54.32 s | 56.10 s | **28.83 s** | 33.03 s | 36.66 s | **20.56 s** | **12.00 s** | **8.86 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 20.76 GFLOPS | **40.91 GFLOPS** | 35.00 GFLOPS | 26.30 GFLOPS | **47.82 GFLOPS** | **86.78 GFLOPS** | **132.27 GFLOPS** |
+| Vision FPGA execution | 55.54 s | 53.78 s | 54.85 s | **28.09 s** | 32.56 s | **42.51 s** | **22.95 s** | **12.13 s** | **7.53 s** |
+| Vision end-to-end path | not reported | 54.33 s | 56.10 s | **28.85 s** | 33.03 s | **35.96 s** | **20.14 s** | **11.49 s** | **8.40 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 20.76 GFLOPS | **40.91 GFLOPS** | 35.00 GFLOPS | **27.03 GFLOPS** | **50.07 GFLOPS** | **94.76 GFLOPS** | **152.66 GFLOPS** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
-| LM prefill sequence executed | 512-token template | 273 actual tokens | 272 actual tokens | 273 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 52.578 s | **31.78 s** | 32.544 s | 34.54 s | **21.09 s** | **14.27 s** | **10.88 s** |
-| LM prefill useful-work throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 38.80 GFLOPS | 37.89 GFLOPS | 29.79 GFLOPS | **48.84 GFLOPS** | **72.31 GFLOPS** | **95.23 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.75 tok/s | 3.85 tok/s | **3.83 tok/s** | 6.00 tok/s | 5.60 tok/s | 5.62 tok/s | 5.68 tok/s | 5.46 tok/s |
-| Decode peak first-token throughput | 2.86 tok/s | 4.01 tok/s | 4.01 tok/s | **4.00 tok/s** | 6.23 tok/s | 5.91 tok/s | 5.90 tok/s | 5.79 tok/s | 5.75 tok/s |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 19.20 GFLOPS | **19.31 GFLOPS** | 30.45 GFLOPS | 23.61 GFLOPS | 23.68 GFLOPS | 23.91 GFLOPS | 23.05 GFLOPS |
-| Vision program section | 3.58 MiB | 3.22 MiB | 3.03 MiB | **2.32 MiB (master)** | / | 3.05 MiB | 4.15 MiB incl. worker | 6.18 MiB incl. workers | not reported |
-| Prefill program section | 5.71 MiB | 3.08 MiB | 3.21 MiB | **3.38 MiB (master)** | / | 3.08 MiB | 4.70 MiB incl. worker | 7.37 MiB incl. workers | not reported |
-| Combined program image | 10.37 MiB | 7.73 MiB | 7.67 MiB | **7.13 MiB (master)** | / | 7.55 MiB | 10.27 MiB | 14.98 MiB | not reported |
+| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 52.578 s | **31.78 s** | 32.544 s | **41.40 s** | **25.26 s** | **17.02 s** | **12.91 s** |
+| LM prefill useful-work throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 38.80 GFLOPS | 37.89 GFLOPS | **29.79 GFLOPS** | **48.82 GFLOPS** | **72.46 GFLOPS** | **95.52 GFLOPS** |
+| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.85 tok/s | **3.75 tok/s** | 6.00 tok/s | **5.49 tok/s** | **5.42 tok/s** | **5.42 tok/s** | **5.43 tok/s** |
+| Decode peak first-token throughput | 2.86 tok/s | 4.00 tok/s | 4.01 tok/s | **3.99 tok/s** | 6.23 tok/s | **5.91 tok/s** | **5.78 tok/s** | **5.70 tok/s** | **5.70 tok/s** |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 19.20 GFLOPS | **18.82 GFLOPS** | 30.45 GFLOPS | **23.13 GFLOPS** | **23.40 GFLOPS** | **23.40 GFLOPS** | **23.40 GFLOPS** |
+| Vision program section | 3.58 MiB | 3.22 MiB | 3.03 MiB | **2.32 MiB (master)** | / | **3.22 MiB (master)** | **2.32 MiB (master)** | **1.83 MiB (master)** | **1.67 MiB (master)** |
+| Prefill program section | 5.71 MiB | 3.08 MiB | 3.21 MiB | **3.38 MiB (master)** | / | **3.08 MiB (master)** | **3.38 MiB (master)** | **3.39 MiB (master)** | **3.41 MiB (master)** |
+| Combined program image | 10.37 MiB | 7.73 MiB | 7.67 MiB | **10.45 MiB** | / | **7.73 MiB** | **10.45 MiB** | **15.15 MiB** | **24.73 MiB** |
 | Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
-| Correctness | legacy baseline | coherent | coherent | **failed: unrelated (barcode)** | not recorded | coherent; stop token | coherent; stop token | **failed: unrelated description** | **failed: unrelated description** |
+| Correctness | legacy baseline | **coherent; stop token** | coherent | **coherent; stop token** | not recorded | **coherent; stop token** | **coherent; stop token** | **coherent; stop token** | **coherent; stop token** |
 
-The Alveo one- and two-core runs produced coherent Yosemite descriptions and
-reached the stop token. The experimental four- and eight-core columns record
-measured execution numbers, but both decoded unrelated image descriptions and
-are therefore explicitly marked unvalidated. See `gemma4_e2b_alveo_4core.log`
-and `gemma4_e2b_alveo_8core.log` for those correctness failures.
+The four Alveo columns were refreshed on 2026-08-17 against HW version
+`0x6bb5d25d`, with `make clean` before every run. All four produced coherent
+Yosemite descriptions and reached the stop token. Worker attention scratch now
+aliases output-only regions that are dead during attention and fully overwritten
+before later reads, allowing the complete eight-engine image path to fit in the
+32-bit DRAM window without overlapping vision weights or worker ISA.
 
 The Kintex 2-core column is from a 2026-08-17 `--multi-core` run with vision
 attention heads sharded across both engines, replacing the older projection-only
-multicore measurements. This refresh nearly halves the vision encoder (53.78 →
-28.09 s) and prefill (51.52 → 31.78 s) versus single-core, but its **decode was
-incoherent**: with the same Yosemite image that single-core described correctly,
-the two-engine run produced an unrelated description of a "barcode" (reaching the
-stop token). This is a correctness regression on the sharded path, observed here
-on the mismatched `0xbb859676` bitstream (see the 2026-08-17 refresh note above),
-so it is not yet clear whether the fault is in the head-sharded attention path or
-an artifact of the bitstream/software version mismatch — it needs re-confirmation
-on the matching `0xcf133b89` bitstream before the sharded path can be trusted.
-The 2-core program-section sizes above are the **master** engine's stored sections
-from this run (the sharded design splits work per engine, so the master program
-shrank); the worker sections were not separately itemized in the run log, so these
-are not directly comparable to the older "incl. worker" Alveo figures.
+multicore measurements. This nearly halves the vision encoder (53.78 → 28.09 s)
+and substantially reduces prefill (51.52 → 31.78 s) versus single-core. The
+current run produced a coherent Yosemite description and reached the stop token
+on the accepted `0x3d04c689` bitstream. The combined program image includes both
+engines; the vision and prefill section rows report the master sections.
 
 ## Refactor optimizations
 
@@ -181,6 +171,6 @@ Decode is single-engine; `--multi-core 2` is identical (245.3 ms total).
 | **Total** | **245.3 ms** |
 
 The profiled single-token throughput is ~4.08 tok/s. Checkpoint HALTs add
-instrumentation control flow, so the normal-run average (3.75 tok/s single-core,
-3.83 tok/s Kintex 2-core) remains the end-to-end decode result to use for
+instrumentation control flow, so the refreshed normal-run average (3.74 tok/s
+single-core, 3.75 tok/s Kintex 2-core) remains the end-to-end decode result to use for
 user-visible throughput.

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -32,21 +32,22 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 
 | Metric | Legacy | Kintex | matmatmul prefill | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 53.78 s | 54.85 s | **28.09 s** | 32.56 s | **42.51 s** | **22.95 s** | **12.13 s** | **7.53 s** |
-| Vision end-to-end path | not reported | 54.33 s | 56.10 s | **28.85 s** | 33.03 s | **35.96 s** | **20.14 s** | **11.49 s** | **8.40 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 20.76 GFLOPS | **40.91 GFLOPS** | 35.00 GFLOPS | **27.03 GFLOPS** | **50.07 GFLOPS** | **94.76 GFLOPS** | **152.66 GFLOPS** |
+| Vision FPGA execution | 55.54 s | 53.78 s | 54.85 s | 27.77s | 32.56 s | **42.51 s** | **15.4 s** | **12.13 s** | **7.53 s** |
+| Vision end-to-end path | not reported | 54.33 s | 56.10 s | 28.58s | 33.03 s | **35.96 s** | **19.6 s** | **11.49 s** | **8.40 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 20.76 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **27.03 GFLOPS** | **74.4 GFLOPS** | **94.76 GFLOPS** | **152.66 GFLOPS** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
 | LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 52.578 s | **31.78 s** | 32.544 s | **41.40 s** | **25.26 s** | **17.02 s** | **12.91 s** |
-| LM prefill useful-work throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 38.80 GFLOPS | 37.89 GFLOPS | **29.79 GFLOPS** | **48.82 GFLOPS** | **72.46 GFLOPS** | **95.52 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.85 tok/s | **3.75 tok/s** | 6.00 tok/s | **5.49 tok/s** | **5.42 tok/s** | **5.42 tok/s** | **5.43 tok/s** |
-| Decode peak first-token throughput | 2.86 tok/s | 4.00 tok/s | 4.01 tok/s | **3.99 tok/s** | 6.23 tok/s | **5.91 tok/s** | **5.78 tok/s** | **5.70 tok/s** | **5.70 tok/s** |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 19.20 GFLOPS | **18.82 GFLOPS** | 30.45 GFLOPS | **23.13 GFLOPS** | **23.40 GFLOPS** | **23.40 GFLOPS** | **23.40 GFLOPS** |
-| Vision program section | 3.58 MiB | 3.22 MiB | 3.03 MiB | **2.32 MiB (master)** | / | **3.22 MiB (master)** | **2.32 MiB (master)** | **1.83 MiB (master)** | **1.67 MiB (master)** |
-| Prefill program section | 5.71 MiB | 3.08 MiB | 3.21 MiB | **3.38 MiB (master)** | / | **3.08 MiB (master)** | **3.38 MiB (master)** | **3.39 MiB (master)** | **3.41 MiB (master)** |
-| Combined program image | 10.37 MiB | 7.73 MiB | 7.67 MiB | **10.45 MiB** | / | **7.73 MiB** | **10.45 MiB** | **15.15 MiB** | **24.73 MiB** |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 52.578 s | 31.87s | 32.544 s | **41.40 s** | **17.3 s** | **17.02 s** | **12.91 s** |
+| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 23.45 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **29.79 GFLOPS** | **71.22 GFLOPS** | **72.46 GFLOPS** | **95.52 GFLOPS** |
+| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.85 tok/s | 3.76 tok/s | 6.00 tok/s | **5.49 tok/s** | **5.49 tok/s** | **5.42 tok/s** | **5.43 tok/s** |
+| Decode peak first-token throughput | 2.86 tok/s | 4.00 tok/s | 4.01 tok/s | 4.0 tok/s | 6.23 tok/s | **5.91 tok/s** | **5.88 tok/s** | **5.70 tok/s** | **5.70 tok/s** |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 19.20 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **23.13 GFLOPS** | **33.97 GFLOPS** | **23.40 GFLOPS** | **23.40 GFLOPS** |
+| Vision program section | 3.58 MiB | 3.22 MiB | 3.03 MiB | 2.39 MiB | / | **3.22 MiB (master)** | 2.39 MiB | **1.83 MiB (master)** | **1.67 MiB (master)** |
+| Prefill program section | 5.71 MiB | 3.08 MiB | 3.21 MiB | 3.46 MiB | / | **3.08 MiB (master)** | 3.46 MiB | **3.39 MiB (master)** | **3.41 MiB (master)** |
+| Decode program section | | | | 1.46 MiB | | |1.46 MiB| | |
+| Combined program image | 10.37 MiB | 7.73 MiB | 7.67 MiB | 10.81 MiB | / | **7.73 MiB** | 10.81 MiB | **15.15 MiB** | **24.73 MiB** |
 | Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
-| Correctness | legacy baseline | **coherent; stop token** | coherent | **coherent; stop token** | not recorded | **coherent; stop token** | **coherent; stop token** | **coherent; stop token** | **coherent; stop token** |
+| Correctness |  | **coherent; stop token** | coherent | coherent, total 709 | not recorded | **coherent; stop token** | coherent, total 709 | **coherent; stop token** | **coherent; stop token** |
 
 The four Alveo columns were refreshed on 2026-08-17 against HW version
 `0x6bb5d25d`, with `make clean` before every run. All four produced coherent
@@ -111,19 +112,16 @@ so the per-phase `--multi-core 2` numbers are exact.
 | Phase | Single-core | --multi-core 2 |
 |---|---:|---:|
 | Patch embedding | 123.6 ms | 123.6 ms |
-| Projection (Q/K/V) † | 6,682.4 ms | **3,360.0 ms** |
-| RoPE | 1,072.8 ms | 1,072.8 ms |
+| Projection (Q/K/V) † | 6,682.4 ms | **3,361.0 ms** |
+| RoPE | 1,072.8 ms | **740.0 ms** |
 | Permute | 269.6 ms | 269.6 ms |
-| Attention † | 16,642.2 ms | **8,645.1 ms** |
-| Post-attention (O + MLP) † | 28,911.4 ms | **14,539.1 ms** |
+| Attention † | 16,642.2 ms | **8,664.7 ms** |
+| Post-attention (O + MLP) † | 28,911.4 ms | **14,541.1 ms** |
 | Pooler tail | 75.3 ms | 75.3 ms |
 | Tail | 0.0 ms | 0.0 ms |
-| **Total** | **53,777.3 ms** | **28,085.5 ms** |
+| **Total** | **53,777.3 ms** | **27,775 ms** |
 
-† row-sharded across 2 engines (Projection, Attention head-sharded, and
-Post-attention); these ~halve. The master-only phases (patch embed, RoPE,
-permute, pooler tail) are unchanged, as expected. The multi-core total
-(28,085.5 ms) matches the Kintex 2-core vision FPGA execution (28.09 s) above.
+† row-sharded across 2 engines
 
 ## Profile backup: LM prefill
 
@@ -148,9 +146,7 @@ from the Kintex 2-core prefill run), confirming it.
 | Tail halt | 0.0 ms | 0.0 ms |
 | **Total** | **51,520.6 ms** | **31,782.4 ms** |
 
-† row-sharded across 2 engines (these ~halve). ‡ master-only; the profiler's
-per-segment counter mis-times these two under two-engine, so the (identical)
-single-core value is shown.
+† row-sharded across 2 engines (these ~halve).
 
 ## Profile backup: one decode token at position 272
 

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -29,22 +29,22 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 
 ## Performance comparison
 
-| Metric | Legacy | Kintex | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
+| Metric | Legacy | Kintex | Kintex 2-core | rk (outdated) | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 53.78 s | 27.77s | 32.56 s | **29.05 s** | **15.4 s** | **8.00 s** | **4.77 s** |
-| Vision end-to-end path | not reported | 54.37 s | 28.58s | 33.03 s | **36.10 s** | **19.6 s** | **11.06 s** | **7.97 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **39.56 GFLOPS** | **74.4 GFLOPS** | **143.61 GFLOPS** | **240.66 GFLOPS** |
+| Vision FPGA execution | 55.54 s | 53.78 s | 27.77s | 32.56 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.82 s** |
+| Vision end-to-end path | not reported | 54.32 s | 28.58s | 33.03 s | **35.98 s** | **19.6 s** | **10.91 s** | **7.95 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.98 GFLOPS** | **238.56 GFLOPS** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
 | LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 31.87s | 32.544 s | **28.51 s** | **17.3 s** | **11.60 s** | **8.79 s** |
-| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **43.26 GFLOPS** | **71.22 GFLOPS** | **106.32 GFLOPS** | **140.34 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.76 tok/s | 6.00 tok/s | **5.47 tok/s** | **5.49 tok/s** | **5.49 tok/s** | **5.56 tok/s** |
-| Decode peak first-token throughput | 2.86 tok/s | 4.00 tok/s | 4.0 tok/s | 6.23 tok/s | **5.79 tok/s** | **5.88 tok/s** | **5.88 tok/s** | **5.89 tok/s** |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **33.82 GFLOPS** | **33.97 GFLOPS** | **33.98 GFLOPS** | **34.35 GFLOPS** |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 31.87s | 32.544 s | **28.23 s** | **17.3 s** | **11.60 s** | **8.81 s** |
+| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **106.32 GFLOPS** | **139.90 GFLOPS** |
+| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.76 tok/s | 6.00 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.50 tok/s** | **5.49 tok/s** |
+| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.0 tok/s | 6.23 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.90 tok/s** | **5.87 tok/s** |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.03 GFLOPS** | **33.97 GFLOPS** |
 | Vision program section | 3.58 MiB | 3.22 MiB | 2.39 MiB | / | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
 | Prefill program section | 5.71 MiB | 3.08 MiB | 3.46 MiB | / | 3.08 MiB | 3.46 MiB | 3.39 MiB | 3.41 MiB |
 | Decode program section | | 1.42 MiB | 1.46 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
-| Combined program image | 10.37 MiB | 28.45 MiB | 10.81 MiB | / | 28.45 MiB | 10.81 MiB | 27.44 MiB | 26.92 MiB |
+| Combined program image | 10.37 MiB | 7.73 MiB | 10.81 MiB | / | 7.73 MiB | 10.81 MiB | 16.10 MiB | 26.92 MiB |
 | Weight image (`params.bin`) | 6.91 GiB | same | same | / | same | same | same | same |
 | Correctness |  | coherent, total 724 | coherent, total 709 | not recorded | coherent, total 724 | coherent, total 709 | coherent, total 709 | coherent, total 709 |
 

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -728,7 +728,8 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
 
     def __init__(self, script_dir: str | None = None,
                  vision_kernel: str = "matmatmul", prefill_kernel: str = "streaming",
-                 decode_kernel: str = "streaming", multi_core: int = 1):
+                 decode_kernel: str = "streaming", multi_core: int = 1,
+                 bin_reuse: bool = False):
         for stage, kernel in (("vision", vision_kernel), ("prefill", prefill_kernel),
                               ("decode", decode_kernel)):
             if kernel not in ("streaming", "matmatmul"):
@@ -754,6 +755,9 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         self.prefill_kernel = prefill_kernel
         self.decode_kernel = decode_kernel
         self.multi_core = multi_core
+        # Program-image reuse: OFF by default (recompile programs.bin fresh every
+        # run). --bin-reuse opts into reusing a matching cached section instead.
+        self.bin_reuse = bin_reuse
         self._multi_core_schedulers = {}
         self._prefill_shard_m_regs = None
         engine_base = user_dma_core.UE_0_BASE_ADDR
@@ -852,6 +856,10 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             UE_VECTOR_SIZE * UE_VECTOR_SIZE * self.bytes_per_element)
         self.dma_to_accelerator_memory(
             self._vis_identity_dram, torch.eye(UE_VECTOR_SIZE, dtype=torch.bfloat16))
+        # Snapshot the LM weight-DRAM high-water mark now, before any vision run
+        # advances the params cursor (its cursor isn't restored). Used by
+        # write_run_summary as the "total weight DRAM" figure (~1540.4 MB).
+        self._lm_weight_dram_bytes = self.get_params_dram_usage()
         if self.get_params_dram_addr() > self._tensor_dram_base:
             raise MemoryError(
                 f"Gemma4 weights overflow the 2-GB layout: "
@@ -1041,7 +1049,8 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             self._get_program_section(f"prefill_worker{i}", profile)[0]
             for i in range(1, self.multi_core)
         ]
-        if (_lm_meta is not None
+        if (self.bin_reuse
+                and _lm_meta is not None
                 and _lm_meta.get("prefill_flops_seq_len") == prefill_flops_seq_len
                 and _lm_meta.get("prefill_kernel") == self.prefill_kernel
                 and _lm_meta.get("decode_kernel") == self.decode_kernel
@@ -1053,7 +1062,9 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             bin_path, _ = self._program_image_paths(profile)
             print(f"[compile] reusing existing instruction image at {bin_path}")
             print(f"  delete {bin_path} (or make clean) to force recompile.")
+            self._lm_compile_reused = True
             return
+        self._lm_compile_reused = False
 
         print(f"[compile] building combined [prefill-template@{prefill_template_seq_len}, "
               f"kernel={self.prefill_kernel}][decoder, kernel={self.decode_kernel}] image...")
@@ -1185,6 +1196,12 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         latency_hw_prefill, _flop_rate_hw_prefill = self.run_prefill(
             prefill_program_addr, flops=meta["prefill_total_flops"])
         latency_prefill = time.perf_counter() - timer
+        # Stash prefill metrics for the run-summary writer (write_run_summary).
+        self._prefill_seq_len = self.seq_len
+        self._prefill_latency_hw_us = latency_hw_prefill
+        self._prefill_flop_rate_gflops = _flop_rate_hw_prefill
+        self._prefill_total_flops = meta["prefill_total_flops"]
+        self._prefill_e2e_s = latency_prefill
         print(f"Prefill execute done in {latency_prefill:.2f} seconds, start decoding...\n", flush=True)
 
         timer = time.perf_counter()
@@ -1194,6 +1211,171 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         latency_decoder = time.perf_counter() - timer
         return (token_cnt_decoded, latency_hw_prefill, latency_hw_decoder,
                 flop_rate_hw_decoder, latency_prefill, latency_decoder)
+
+    def write_run_summary(self, out_path: str, args) -> str:
+        """Write a per-run Markdown summary (weights/program sizes, per-stage HW
+        latency + FLOPS, decode throughput, and the prompt/decoded text) built
+        from the metrics stashed on ``self`` during compile_gemma4 / run_gemma4
+        (and the vision encoder in --image mode). ``args`` is the parsed CLI
+        namespace. Returns the written path.
+
+        Everything read here is either an already-computed attribute or cheap
+        host-side bookkeeping (file sizes, program-section metadata, a register
+        read) — no FPGA program is launched, so calling this after a run is free.
+        """
+        clock_ns = self._clock_period_ns
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        cores = self.multi_core
+        peak_gflops = freq_mhz * 0.128 * cores   # freq(MHz) * 128 MAC/cyc/1000 * cores
+        try:
+            hw_version = self.user_read_reg32(user_dma_core.UE_FPGA_VERSION_ADDR) & 0xFFFFFFFF
+            hw_version_str = f"0x{hw_version:08x}"
+        except Exception as e:
+            hw_version_str = f"(read failed: {e})"
+
+        # Weights.
+        weight_bin_path = os.path.join(self.script_dir, self._weights_bin_rel)
+        weight_bin_size = os.path.getsize(weight_bin_path) if os.path.exists(weight_bin_path) else 0
+        total_weight_dram_mb = getattr(
+            self, "_lm_weight_dram_bytes", self.get_params_dram_usage()) / (1024 * 1024)
+
+        # Program image + per-section sizes.
+        sections, prog_data = self._read_program_sections()
+        prog_bin_path, _ = self._program_image_paths()
+        prog_bin_size = os.path.getsize(prog_bin_path) if os.path.exists(prog_bin_path) else 0
+        vision_sect = sections.get("vision")
+        lm_sect = sections.get("lm")
+        vision_prog_size = vision_sect["size"] if vision_sect else None
+        prefill_prog_size = lm_sect.get("prefill_program_size") if lm_sect else None
+        decoder_prog_size = lm_sect.get("decoder_program_size") if lm_sect else None
+
+        def _mb(n):
+            return f"{n / (1024 * 1024):.2f} MB" if n is not None else "n/a"
+        def _kb(n):
+            return f"{n / 1024:.1f} KB" if n is not None else "n/a"
+
+        is_image = bool(getattr(args, "image", None))
+        is_audio = bool(getattr(args, "audio", None))
+
+        lines = []
+        lines.append(f"# gemma4_e2b_test run summary")
+        lines.append("")
+        lines.append(f"- **HW version:** {hw_version_str}")
+        lines.append(f"- **--dev:** {args.dev}")
+        lines.append(f"- **--device:** {args.device}")
+        lines.append(f"- **Clock / frequency:** {clock_ns:.4f} ns ({freq_mhz:.1f} MHz)")
+        lines.append(f"- **Cores (--multi-core):** {cores}")
+        lines.append(f"- **Peak throughput:** {peak_gflops:.2f} GFLOPS "
+                     f"({freq_mhz:.1f} MHz × 128 × {cores} core(s))")
+        lines.append("")
+
+        # --- Weights ---------------------------------------------------------
+        lines.append(f"## Weights")
+        lines.append("")
+        lines.append(f"- **Weight bin:** `{os.path.basename(weight_bin_path)}` — {_mb(weight_bin_size)}")
+        lines.append(f"- **Total weight DRAM (quantized, on FPGA):** {total_weight_dram_mb:.1f} MB")
+        lines.append("")
+
+        # --- Program image ---------------------------------------------------
+        lines.append(f"## Program image (`{os.path.basename(prog_bin_path)}`)")
+        lines.append("")
+        lines.append(f"- **Total programs.bin size:** {_mb(prog_bin_size)}")
+        if is_image:
+            lines.append(f"- **Vision section:** {_mb(vision_prog_size)}")
+        lines.append(f"- **Prefill program:** {_kb(prefill_prog_size)}")
+        lines.append(f"- **Decoder program:** {_kb(decoder_prog_size)}")
+        reuse_bits = []
+        if is_image and getattr(self, "_vision_compile_reused", None) is not None:
+            reuse_bits.append(f"vision {'reused' if self._vision_compile_reused else 'fresh'}")
+        if getattr(self, "_lm_compile_reused", None) is not None:
+            reuse_bits.append(f"prefill/decode {'reused' if self._lm_compile_reused else 'fresh'}")
+        lines.append(f"- **Program image:** {', '.join(reuse_bits) if reuse_bits else 'n/a'}")
+        lines.append("")
+
+        # --- Vision ----------------------------------------------------------
+        if is_image:
+            vis_kernel = "host" if getattr(args, "vision_host", False) else self.vision_kernel
+            vis_lat_us = getattr(self, "_vis_last_latency_us", None)
+            vis_gflops = getattr(self, "_vis_last_gflops", None)
+            lines.append(f"## Vision")
+            lines.append("")
+            lines.append(f"- **Vision kernel:** {vis_kernel}")
+            lines.append(f"- **Vision tokens (soft tokens):** {getattr(self, '_vis_num_soft_tokens', 'n/a')}")
+            if vis_lat_us is not None:
+                lines.append(f"- **Vision FPGA run time (HW latency):** {vis_lat_us / 1e3:.2f} ms "
+                             f"({vis_lat_us:.0f} us)")
+            else:
+                lines.append(f"- **Vision FPGA run time (HW latency):** n/a (host vision)")
+            if vis_gflops is not None:
+                lines.append(f"- **Vision reported FLOPS:** {vis_gflops:.2f} GFLOPS")
+            else:
+                lines.append(f"- **Vision reported FLOPS:** n/a (host vision)")
+            _vis_e2e = getattr(self, "_vis_e2e_s", None)
+            lines.append(f"- **Vision end-to-end (CPU timer):** "
+                         f"{_vis_e2e:.2f} s" if _vis_e2e is not None else
+                         "- **Vision end-to-end (CPU timer):** n/a")
+            lines.append("")
+
+        # --- Prefill ---------------------------------------------------------
+        pf_seq = getattr(self, "_prefill_seq_len", None)
+        pf_lat_us = getattr(self, "_prefill_latency_hw_us", None)
+        pf_gflops = getattr(self, "_prefill_flop_rate_gflops", None)
+        pf_e2e = getattr(self, "_prefill_e2e_s", None)
+        lines.append(f"## Prefill")
+        lines.append("")
+        lines.append(f"- **Prefill seq_len:** {pf_seq if pf_seq is not None else 'n/a'}")
+        if pf_lat_us is not None:
+            lines.append(f"- **Prefill FPGA run time (HW latency):** {pf_lat_us / 1e3:.2f} ms "
+                         f"({pf_lat_us:.0f} us)")
+        if pf_gflops is not None:
+            lines.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+        if pf_e2e is not None:
+            lines.append(f"- **Prefill end-to-end (CPU timer):** {pf_e2e:.2f} s")
+        lines.append("")
+
+        # --- Decode ----------------------------------------------------------
+        gen_n = getattr(self, "_decode_generated_n", None)
+        total_tok = self.seq_len
+        peak_toks = getattr(self, "_decode_peak_toks", None)
+        avg_toks = getattr(self, "_decode_avg_toks", None)
+        dec_flop_rate = getattr(self, "_decode_total_flop_rate", None)
+        avg_gflops = (dec_flop_rate / gen_n) if (dec_flop_rate is not None and gen_n) else None
+        lines.append(f"## Decode")
+        lines.append("")
+        lines.append(f"- **Decoded tokens:** {gen_n if gen_n is not None else 'n/a'} generated "
+                     f"(sequence total {total_tok})")
+        if peak_toks is not None:
+            lines.append(f"- **First-token speed (peak):** {peak_toks:.2f} tok/s")
+        if avg_toks is not None:
+            lines.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
+        if avg_gflops is not None:
+            lines.append(f"- **Average FLOPS:** {avg_gflops:.2f} GFLOPS")
+        lines.append("")
+
+        # --- Text ------------------------------------------------------------
+        try:
+            prompt_text = self.tokenizer.decode(list(self.prefill_seq), skip_special_tokens=False)
+        except Exception:
+            prompt_text = "(decode failed)"
+        decoded_text = getattr(self, "_decoded_text", None) or "(none)"
+        lines.append(f"## Prompt & output")
+        lines.append("")
+        lines.append(f"### Full prefill prompt")
+        lines.append("")
+        lines.append("```")
+        lines.append(prompt_text)
+        lines.append("```")
+        lines.append("")
+        lines.append(f"### Decoded text")
+        lines.append("")
+        lines.append("```")
+        lines.append(decoded_text)
+        lines.append("```")
+        lines.append("")
+
+        with open(out_path, "w") as f:
+            f.write("\n".join(lines))
+        return out_path
 
     def _profile_execute(self, gpr_sets: list[tuple[int, int]], target_addr: int,
                          checkpoints: list, tail_name: str, timeout: float = 120.0,
@@ -1379,6 +1561,10 @@ def add_engine_args(parser) -> None:
                              "bittware_256, alveo, efinix).")
     parser.add_argument("--cycle", type=float, default=None,
                         help="Clock cycle time in nanoseconds. Overrides --device default.")
+    parser.add_argument("--bin-reuse", action="store_true",
+                        help="Reuse a matching cached program image (programs.bin) if it "
+                             "exists instead of recompiling. Default: OFF (fresh compile "
+                             "every run).")
 
 
 def resolve_engine_config(parser, args) -> dict:
@@ -1444,12 +1630,15 @@ def resolve_engine_config(parser, args) -> dict:
     print(f"Setting CLOCK_CYCLE_TIME_NS = {user_dma_core.CLOCK_CYCLE_TIME_NS}")
     print(f"Kernels: vision={args.vision_kernel}, prefill={args.prefill_kernel}, "
           f"engines={args.multi_core}, decode={args.decode_kernel}")
+    print(f"Program image: {'reuse cached if present' if args.bin_reuse else 'fresh compile every run'}"
+          f" (--bin-reuse {'on' if args.bin_reuse else 'off'})")
 
     return dict(
         vision_kernel=args.vision_kernel,
         prefill_kernel=args.prefill_kernel,
         decode_kernel=args.decode_kernel,
         multi_core=args.multi_core,
+        bin_reuse=args.bin_reuse,
     )
 
 
@@ -1490,6 +1679,41 @@ default prompt: "x+3=5, what is x?"
     return parser
 
 
+def run_summary_filename(args) -> str:
+    """Build the per-run summary .md filename encoding the full CLI config, e.g.
+    ``--dev xdma0 --device alveo --image --multi-core 2`` ->
+    ``gemma4_e2b_test_xdma0_alveo_image_multi-core_2.md``.
+
+    dev / device / mode are always present (in that order); every other engine
+    knob is appended only when it differs from its default, so a plain LM run
+    stays short. Call this BEFORE resolve_engine_config(), which mutates
+    args.prefill_kernel for multi-core — otherwise an auto-forced kernel would
+    leak into the name.
+    """
+    if args.audio:
+        mode = "audio"
+    elif args.image:
+        mode = "image"
+    else:
+        mode = "lm"
+    tokens = [args.dev, args.device, mode]
+    if args.image and args.vision_host:
+        tokens.append("vision-host")
+    if args.multi_core != 1:
+        tokens.append(f"multi-core_{args.multi_core}")
+    if args.vision_kernel != "matmatmul":
+        tokens.append(f"vision-kernel_{args.vision_kernel}")
+    if args.prefill_kernel != "streaming":
+        tokens.append(f"prefill-kernel_{args.prefill_kernel}")
+    if args.decode_kernel != "streaming":
+        tokens.append(f"decode-kernel_{args.decode_kernel}")
+    if args.bin_reuse:
+        tokens.append("bin-reuse")
+    if args.cycle is not None:
+        tokens.append(f"cycle_{args.cycle}")
+    return "gemma4_e2b_test_" + "_".join(str(t) for t in tokens) + ".md"
+
+
 def main():
     parser = build_arg_parser()
     args = parser.parse_args()
@@ -1499,6 +1723,10 @@ def main():
         parser.error("--vision-host requires --image")
     if args.image and args.audio:
         parser.error("--image and --audio are mutually exclusive")
+    # Capture the summary filename now, before resolve_engine_config() mutates
+    # args.prefill_kernel (multi-core forces matmatmul) — keeps auto-forced
+    # kernels out of the name.
+    _summary_name = run_summary_filename(args)
     engine_kwargs = resolve_engine_config(parser, args)
     ue = Gemma4_UnifiedEngine(**engine_kwargs)
 
@@ -1565,6 +1793,15 @@ def main():
           f"total {token_cnt_decoded} tokens.")
     print(f"HW counter: Latency: {(latency_hw_prefill + latency_hw_decoder) / 1e6:.2f} seconds, "
           f"decoder average Gflops: {flop_rate_hw_decoder / (token_cnt_decoded - len(ue.prefill_seq) + 1):.2f} Gflops")
+
+    # Per-run Markdown summary, named for the full CLI config (see
+    # run_summary_filename), written next to this script.
+    _summary_path = os.path.join(SCRIPT_DIR, _summary_name)
+    try:
+        ue.write_run_summary(_summary_path, args)
+        print(f"Wrote run summary: {_summary_path}")
+    except Exception as _e:
+        print(f"[warn] failed to write run summary: {_e}")
     print("Gemma4 E2B LM test ends.")
 
 

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -704,15 +704,14 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             return None
         scheduler = self._multi_core_schedulers.get(stage)
         if scheduler is None:
-            # Gemma4's legacy two-core layout keeps its worker at the supplied
-            # stage address.  Alveo's 8-core layout needs seven compact worker
-            # ISA slots; reserve them below the model ISA arena, above the
-            # measured tensor high-water mark. Vision and prefill are
-            # sequential, so both stages may reuse this worker-ISA arena.
+            # Two-core keeps its single worker at the supplied stage address
+            # (huge stride; only the base is used). >2-core packs the extra
+            # workers into the dedicated MULTICORE_WORKER_ISA arena. Vision and
+            # prefill are sequential, so both stages reuse this worker-ISA arena.
             worker_stride = 0x10000000
             if self.multi_core > 2:
-                worker_dram_base = 0xFC000000
-                worker_stride = 0x00240000  # 2.25 MiB per worker
+                worker_dram_base = self.MULTICORE_WORKER_ISA_BASE
+                worker_stride = self.MULTICORE_WORKER_ISA_STRIDE
             scheduler = MultiEngineScheduler(
                 self, num_engines=self.multi_core,
                 engine_base_stride=0x00010000,
@@ -761,20 +760,51 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         self._multi_core_schedulers = {}
         self._prefill_shard_m_regs = None
         engine_base = user_dma_core.UE_0_BASE_ADDR
-        # Gemma4 fixed DRAM layout within the upper 2 GB window, matching the
-        # addressable range used by the Llama-3.2-1B path.
-        #   LM weights       : 0x80000000 – 0xE1000000  (1552 MiB)
-        #   LM/vision tensor : 0xE1000000 – 0xFF000000  (480 MiB, reused by stage)
-        #   Vision ISA/core0 : 0xFF000000 – 0xFF400000  (4 MiB, two-core mode)
-        #   Vision ISA/core1 : 0xFF400000 – 0xFF620000  (2.125 MiB, incl. head-sharded attention)
-        #   LM ISA           : 0xFF620000 – 0x100000000 (9.875 MiB)
+        # Gemma4 DRAM layout. SINGLE-CORE keeps the original upper-2 GB window
+        # (matching the Llama-3.2-1B path); its 16 MiB ISA region is tight but
+        # sufficient for one engine. MULTI-CORE re-bases to 0x0 with the full
+        # 4 GB budget so the per-engine worker programs (incl. sharded vision
+        # RoPE) and future parallelism add-ons have room, and so the vision
+        # tensor arena is large enough for N-engine scratch.
+        #
+        # SINGLE-CORE (upper 2 GB):
+        #   PARAMS  weights   : 0x80000000 – 0xE1000000  (1552 MiB)
+        #   TENSOR  acts/scr  : 0xE1000000 – 0xFF000000  (480 MiB, LM<->vision)
+        #   ISA vision core0  : 0xFF000000 – 0xFF400000  (4 MiB)
+        #   ISA vision core1  : 0xFF400000 – 0xFF620000  (2.125 MiB, unused 1-core)
+        #   ISA LM            : 0xFF620000 – 0x100000000 (9.875 MiB)
+        #
+        # MULTI-CORE (full 4 GB, base 0x0):
+        #   PARAMS  weights   : 0x00000000 – 0x80000000  (2 GiB;  LM ~1540 MB)
+        #   TENSOR  acts/scr  : 0x80000000 – 0xC0000000  (1 GiB;  LM + vision,
+        #                        incl. up-to-8-engine vision scratch + top wts)
+        #   ISA vision core0  : 0xC0000000 – 0xC8000000  (128 MiB, master)
+        #   ISA vision core1  : 0xC8000000 – 0xE0000000  (384 MiB, 2-core worker)
+        #   ISA LM            : 0xE0000000 – 0xF0000000  (256 MiB)
+        #   ISA >2-core workrs: 0xF0000000 – 0x100000000 (256 MiB, 32 MiB/worker)
         # Vision and LM programs remain resident at disjoint addresses.
         self.DRAM_END = 0x100000000
-        self.VISION_ISA_BASE = 0xFF000000
-        self.VISION_WORKER_ISA_BASE = 0xFF400000
-        self.LM_ISA_BASE = 0xFF620000
-        _params_base  = 0x80000000
-        _tensor_base  = 0xE1000000
+        if self.multi_core == 1:
+            _params_base  = 0x80000000
+            _tensor_base  = 0xE1000000
+            self.VISION_ISA_BASE             = 0xFF000000
+            self.VISION_WORKER_ISA_BASE      = 0xFF400000
+            self.LM_ISA_BASE                 = 0xFF620000
+            self.MULTICORE_WORKER_ISA_BASE   = 0xFC000000    # unused (1-core)
+            self.MULTICORE_WORKER_ISA_STRIDE = 0x00240000    # unused (1-core)
+        else:
+            _params_base  = 0x00000000
+            _tensor_base  = 0x80000000
+            self.VISION_ISA_BASE             = 0xC0000000
+            self.VISION_WORKER_ISA_BASE      = 0xC8000000
+            self.LM_ISA_BASE                 = 0xE0000000
+            self.MULTICORE_WORKER_ISA_BASE   = 0xF0000000    # >2-core worker arena
+            self.MULTICORE_WORKER_ISA_STRIDE = 0x02000000    # 32 MiB / worker
+        # Top of the vision tensor arena (vision weights are top-placed against
+        # it; scratch stays below). In the multi-core layout every worker ISA
+        # lives in the dedicated ISA region, so the tensor arena simply runs up
+        # to VISION_ISA_BASE for any engine count.
+        self.VISION_ARENA_TOP = self.VISION_ISA_BASE
         _program_base = self.LM_ISA_BASE
         super().__init__(BASE_ADDR=engine_base,
                           params_dram_base=_params_base,
@@ -1145,7 +1175,7 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
                 worker_bytes = bytearray()
                 for inst in worker.capture_buffer:
                     worker_bytes.extend(inst.get_bytes())
-                worker_limit = (worker_addr + 0x00240000
+                worker_limit = (worker_addr + self.MULTICORE_WORKER_ISA_STRIDE
                                 if self.multi_core > 2 else self.LM_ISA_BASE)
                 if worker_addr + len(worker_bytes) > worker_limit:
                     raise RuntimeError(
@@ -1524,11 +1554,17 @@ def _clock_ns_default_for_device(device: str) -> float:
     """Return the board-profile clock period, matching user_hw_test/Llama."""
     if device == "kintex7":
         return 1000 / (1066 / 5.375)
-    if device in ("rk", "puzhi"):
+    if device == "kintex7_systolic":
+        return 1000 / 149.61403
+    if device in ("rk", "rk_256", "puzhi"):
         return 3.0
     if device in ("bittware", "bittware_256"):
         return 3.3333
-    if device in ("alveo", "efinix"):
+    if device == "alveo":
+        return 1000 / 366.666666
+    if device == "alveo_u55c":
+        return 3.3333333
+    if device == "efinix":
         return 4.0
     return 10.0
 
@@ -1557,8 +1593,9 @@ def add_engine_args(parser) -> None:
     parser.add_argument("--dev", type=str, default="xdma0",
                         help="DMA device name (e.g., xdma0, xdma1). Default: xdma0")
     parser.add_argument("--device", type=str, default="kintex7",
-                        help="FPGA board profile (kintex7, rk, puzhi, bittware, "
-                             "bittware_256, alveo, efinix).")
+                        help="FPGA board profile (kintex7, kintex7_systolic, rk, "
+                             "rk_256, puzhi, bittware, bittware_256, alveo, "
+                             "alveo_u55c, efinix).")
     parser.add_argument("--cycle", type=float, default=None,
                         help="Clock cycle time in nanoseconds. Overrides --device default.")
     parser.add_argument("--bin-reuse", action="store_true",
@@ -1578,8 +1615,8 @@ def resolve_engine_config(parser, args) -> dict:
     """
     if args.multi_core not in range(1, 9):
         parser.error("--multi-core must be between 1 and 8")
-    if args.multi_core > 2 and args.device != "alveo":
-        parser.error("--multi-core values above 2 are currently supported only on Alveo")
+    if args.multi_core > 2 and args.device != "alveo" and args.device != "alveo_u55c":
+        parser.error("--multi-core values above 2 are currently supported only on Alveo and Alveo U55C")
     if args.multi_core > 1:
         # Multicore prefill only has a matmatmul (two-pass) shard path.
         args.prefill_kernel = "matmatmul"

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -1013,10 +1013,29 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
     def _store_program_section(self, name: str, dram_base: int, section_bytes: bytes,
                                extra_meta: dict, profile: bool = False) -> None:
         """Merge one section into the combined programs bin, preserving every
-        other section. Rewrites the file so offsets stay contiguous; sections are
-        ordered by dram_base (vision 0xa0 before LM 0xc0)."""
+        other section written by THIS run. Rewrites the file so offsets stay
+        contiguous; sections are ordered by dram_base (vision 0xa0 before LM 0xc0).
+
+        Fresh-compile hygiene: on a fresh run (``bin_reuse`` False) the FIRST
+        section stored to a given image path in this process starts from an EMPTY
+        image, so sections a previous run left behind are dropped — e.g. the
+        vision_worker*/prefill_worker* sections from an earlier multi-core run
+        when the current run is single-core. Without this, a fresh single-core
+        image only overwrites its own vision/lm sections and the stale worker
+        sections keep inflating the file (and the reported programs.bin size).
+        Later stores in the same run merge normally, so this run's vision + LM
+        (+ its own workers) all land. With ``--bin-reuse`` nothing is dropped:
+        cached sections are preserved and only the recompiled one is replaced.
+        """
         bin_path, meta_path = self._program_image_paths(profile)
-        sections, data = self._read_program_sections(profile)
+        started = getattr(self, "_programs_bin_started", None)
+        if started is None:
+            started = self._programs_bin_started = set()
+        if (not getattr(self, "bin_reuse", False)) and (bin_path not in started):
+            sections, data = {}, b""          # fresh run: first store starts clean
+        else:
+            sections, data = self._read_program_sections(profile)
+        started.add(bin_path)
         blobs = {k: data[s["file_offset"]: s["file_offset"] + s["size"]] for k, s in sections.items()}
         metas = {k: {kk: vv for kk, vv in s.items() if kk not in ("file_offset", "size")}
                  for k, s in sections.items()}

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -283,19 +283,18 @@ class Gemma4VisionMixin:
         attn_scratch_bytes = (aligned_S * aligned_S + 2 * HD * aligned_S) * 2
         self.VIS_FLASH_SCRATCH = self.allocate_tensor_dram(attn_scratch_bytes)
         # Head-sharded attention needs one private scratch region per engine.
-        # Allocate every copy from the model tensor arena; worker allocators are
-        # reserved for ISA. Keep the primary address first, in engine order.
+        # Keep the primary copy dedicated. Worker copies are assigned after all
+        # tensor allocations, by aliasing output-only regions that are dead
+        # during attention and fully overwritten before their later reads.
         self.VIS_FLASH_SCRATCH_PER_ENGINE = [self.VIS_FLASH_SCRATCH]
-        for _ in range(1, self.multi_core):
-            self.VIS_FLASH_SCRATCH_PER_ENGINE.append(
-                self.allocate_tensor_dram(attn_scratch_bytes))
-        # Compatibility name for code/debuggers that expect the 2-core field.
-        self.VIS_FLASH_SCRATCH_WORKER = (
-            self.VIS_FLASH_SCRATCH_PER_ENGINE[1]
-            if self.multi_core > 1 else None)
         # Unused by unified_attention_core but kept to keep the allocation order
         # (and every baked address after it) stable.
-        self.VIS_ATTN_P = self.allocate_tensor_dram(aligned_S * aligned_S * bpe)
+        attn_p_bytes = aligned_S * aligned_S * bpe
+        self.VIS_ATTN_P = self.allocate_tensor_dram(attn_p_bytes)
+        # Make VIS_ATTN_P itself a full-size alias candidate without spilling
+        # into the identity matrix that follows it.
+        self._vis_attn_p_alias_pad = self.allocate_tensor_dram(
+            attn_scratch_bytes - attn_p_bytes)
 
         # 64×64 identity for FPGA clamp passes.
         self.VIS_IDENTITY_64 = self.allocate_tensor_dram(64 * 64 * bpe)
@@ -437,6 +436,52 @@ class Gemma4VisionMixin:
                     for kx in range(pool_k):
                         Pm[cell, base + ky * Wg + kx] = 1.0
         self._vis_pending_dmas.append((self.VIS_POOL_P, Pm))
+
+        # Worker attention scratch aliases. Every region below is dead while
+        # attention runs and is completely produced again before consumption:
+        # post-attention/MLP intermediates, the QKV/MLP clip workspaces, the
+        # unused VIS_ATTN_P buffer plus explicit pad, and embed-pool outputs.
+        # Carve fixed-size, non-overlapping blocks and use only as many as the
+        # selected engine count needs (maximum seven workers).
+        alias_regions = [
+            (self.VIS_POST_ATTN_NORM,
+             self.VIS_POST_FFN_NORM + S * H * bpe,
+             "post_attn_mlp"),
+            (self.VIS_INPUT_CLIP_H_SCRATCH,
+             self.VIS_INPUT_CLIP_MLP_SCRATCH + S * MLP * bpe,
+             "clip_workspaces"),
+            (self.VIS_ATTN_P,
+             self._vis_attn_p_alias_pad + (attn_scratch_bytes - attn_p_bytes),
+             "unused_attn_p"),
+            (self.VIS_EMBED_POOL,
+             self.VIS_EMBED_OUT + S * text_h * bpe,
+             "embed_outputs"),
+        ]
+        alias_candidates = []
+        for region_start, region_end, region_name in alias_regions:
+            addr = self._align_up(region_start, 64)
+            while addr + attn_scratch_bytes <= region_end:
+                alias_candidates.append((addr, region_name))
+                addr = self._align_up(addr + attn_scratch_bytes, 64)
+        workers_needed = self.multi_core - 1
+        if len(alias_candidates) < workers_needed:
+            raise MemoryError(
+                f"Gemma4 needs {workers_needed} worker attention scratch buffers "
+                f"but only {len(alias_candidates)} safe alias region(s) fit")
+        chosen_aliases = alias_candidates[:workers_needed]
+        self.VIS_FLASH_SCRATCH_PER_ENGINE.extend(
+            addr for addr, _ in chosen_aliases)
+        self.VIS_FLASH_SCRATCH_WORKER = (
+            self.VIS_FLASH_SCRATCH_PER_ENGINE[1]
+            if self.multi_core > 1 else None)
+        scratch_ranges = sorted(
+            (addr, addr + attn_scratch_bytes)
+            for addr in self.VIS_FLASH_SCRATCH_PER_ENGINE)
+        for (_, prev_end), (next_start, _) in zip(scratch_ranges, scratch_ranges[1:]):
+            assert prev_end <= next_start, "per-engine attention scratch aliases overlap"
+        print(f"  Vision attention scratch: {self.multi_core} private buffer(s); "
+              f"{workers_needed} worker alias(es): "
+              f"{[name for _, name in chosen_aliases]}")
 
         # Scratch must stay below the vision WEIGHTS (placed at the top of the
         # tensor arena by vision_weight_init). The old guard used the ISA base and

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -513,21 +513,6 @@ class Gemma4VisionMixin:
         return self.gpr_seq_len
 
     # ------------------------------------------------------------------
-    # Vision encoder RoPE (S3): rotate-half as a batched matmul against a
-    # static swap permutation + tiled elementwise. HW-verified on alveo.
-    # ------------------------------------------------------------------
-    def rope_hf_matmul_core(self, src_dram: int, M: int, N: int) -> int:
-        """Vision-encoder RoPE (in place on ``src_dram``, head_dim N=64): thin adapter over the
-        library :meth:`UnifiedEngine.rope_hf_matmul_core`, wiring the model-owned swap matrix, rot
-        scratch, and host-tiled cos/sin. The library core does ``rot = X @ P_swap`` then
-        ``rot*=sin; out = X*cos; out += rot`` via three batched eltwise passes."""
-        return user_dma_core.UnifiedEngine.rope_hf_matmul_core(
-            self, M=M, N=N, input_dram_addr=src_dram, output_dram_addr=src_dram,
-            cos_dram_addr=self.VIS_ROPE_COS_TILED, sin_dram_addr=self.VIS_ROPE_SIN_TILED,
-            identity_swap_dram_addr=self.VIS_ROPE_P_SWAP, scratch_dram_addr=self.VIS_ROPE_ROT,
-            gpr_M_reg=self._prime_M(M))
-
-    # ------------------------------------------------------------------
     # Vision encoder layers (S3): one SigLIP layer = pre_norm + Q/K/V proj +
     # Q/K norm (part A) → V-norm + 2D RoPE + head-major transpose → per-head
     # attention → O proj + post-attn norm + residual + MLP (part C).
@@ -664,22 +649,34 @@ class Gemma4VisionMixin:
                 self._vis_flops += shard_flops[0]
             _checkpoint(f"L{li}_proj")
             self._vis_flops += self.rms_norm_core_dram(M=S * NH, N=HD, A_DRAM_ADDR=self.VIS_V_DRAM, OUTPUT_DRAM_ADDR=self.VIS_V_DRAM, GAMMA_DRAM_ADDR=self.VIS_V_NORM_ONES_GAMMA, gpr_M_reg=self._prime_M(S * NH))
+            # RoPE (rotate-half via a swap matmul + tiled cos/sin eltwise) uses
+            # the library UnifiedEngine.rope_hf_matmul_core directly, wiring the
+            # model-owned swap matrix / rot scratch / host-tiled cos/sin here.
             if gate_scheduler is None:
                 for dram in (self.VIS_Q_NORM, self.VIS_K_NORM):
                     self._vis_flops += self.rope_hf_matmul_core(
-                        src_dram=dram, M=S * NH, N=HD)
+                        M=S * NH, N=HD, input_dram_addr=dram, output_dram_addr=dram,
+                        cos_dram_addr=self.VIS_ROPE_COS_TILED,
+                        sin_dram_addr=self.VIS_ROPE_SIN_TILED,
+                        identity_swap_dram_addr=self.VIS_ROPE_P_SWAP,
+                        scratch_dram_addr=self.VIS_ROPE_ROT,
+                        gpr_M_reg=self._prime_M(S * NH))
             else:
                 # rope_hf_matmul_core is row-independent over its flattened
                 # M=S*NH dimension. Slice every [M, HD] tensor by the same rows;
                 # the HDxHD swap permutation is shared and read-only. The
                 # existing VIS_ROPE_ROT allocation is likewise row-sliced, so
                 # multicore RoPE needs no per-engine scratch allocation.
+                # The composite core is not in the shard proxy's row-independent
+                # allowlist (it wraps a matmul + 3 eltwise), so emit it through
+                # ctx.unsafe_ue — the deliberate escape hatch — with explicitly
+                # sliced addresses. Keeps multi_engine_shard.py unmodified.
                 rope_flops = [0]
                 def _emit_rope_shard(ctx, src_dram):
                     m_reg = gate_m_regs[ctx.engine_idx]
                     row_bytes = HD * bpe
                     shard_src = ctx.rows_addr(src_dram, row_bytes)
-                    rope_flops[0] += ctx.ue.rope_hf_matmul_core(
+                    rope_flops[0] += ctx.unsafe_ue.rope_hf_matmul_core(
                         M=ctx.rows,
                         N=HD,
                         input_dram_addr=shard_src,

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -474,7 +474,8 @@ class Gemma4VisionMixin:
             self._get_program_section(f"vision_worker{i}", profile)[0]
             for i in range(1, self.multi_core)
         ]
-        if (_vmeta is not None
+        if (getattr(self, "bin_reuse", False)
+                and _vmeta is not None
                 and _vmeta.get("vision_kernel") == self.vision_kernel
                 and _vmeta.get("multi_core", 1) == self.multi_core
                 and all(meta is not None for meta in _worker_metas)):
@@ -482,7 +483,9 @@ class Gemma4VisionMixin:
             bin_path, _ = self._program_image_paths(profile)
             print(f"  [Vision] reusing existing instruction image at {bin_path}", flush=True)
             print(f"    delete {bin_path} (or make clean) to force recompile.", flush=True)
+            self._vision_compile_reused = True
             return
+        self._vision_compile_reused = False
         print(f"  [Vision] compiling patch embed + {L} vision layers one-shot"
               f" ({self.multi_core} engine(s); projection phases row-sharded)"
               f"{' (+profile checkpoints)' if profile else ''} ...", flush=True)
@@ -867,9 +870,14 @@ class Gemma4VisionMixin:
         # Report like the LM's program_execute: HW latency + FLOP rate.
         latency_us = self.report_latency_in_us()
         print(f"    Total program execution latency = {latency_us} us")
+        # Stash for the run-summary writer (write_run_summary).
+        self._vis_last_latency_us = latency_us
+        self._vis_last_total_flops = meta.get("total_flops")
+        self._vis_last_gflops = None
         _flops = meta.get("total_flops")
         if _flops:
             gflops, _ = self.report_flop_rate_gflops(_flops)
+            self._vis_last_gflops = gflops
             print(f"Report FLOPS for program execution: {gflops:.2f} GFLOPS")
         print(f"Vision encoder execute done in {elapsed:.2f} seconds.", flush=True)
         return elapsed
@@ -919,6 +927,14 @@ class Gemma4VisionMixin:
         total_s = time.perf_counter() - host_t0
         print(f"[Vision] host encoder done: {image_features.shape[0]} soft tokens "
               f"in {total_s:.2f}s (model forward {forward_s:.2f}s).", flush=True)
+        # Stash for the run-summary writer (write_run_summary). Host vision runs
+        # no FPGA program, so there is no HW latency / GFLOPS to report.
+        self._vis_num_soft_tokens = int(image_features.shape[0])
+        self._vis_e2e_s = total_s
+        self._vis_device = "host"
+        self._vis_last_latency_us = None
+        self._vis_last_gflops = None
+        self._vis_last_total_flops = None
         return image_features, token_ids, mm_types
 
     def _run_vision_encoder_fpga(self, image_path: str, prompt: str, profile: bool = False):
@@ -1032,4 +1048,8 @@ class Gemma4VisionMixin:
             print(f"{'TOTAL':<38}{_tot:>9.2f}{100.0:>6.1f}%")
         print(f"[Vision] FPGA encoder done: {image_features.shape[0]} soft tokens "
               f"in {fpga_total_s:.2f}s total.", flush=True)
+        # Stash for the run-summary writer (write_run_summary).
+        self._vis_num_soft_tokens = int(image_features.shape[0])
+        self._vis_e2e_s = fpga_total_s
+        self._vis_device = "FPGA"
         return image_features, token_ids, mm_types

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -112,7 +112,7 @@ class Gemma4VisionMixin:
         # Arena top = first address the vision ISA claims: the master vision ISA
         # base (2-core), or the compact worker-ISA arena at 0xFC000000 (>2-core /
         # Alveo). vision_tensor_init uses the same split for its scratch limit.
-        _arena_top = 0xFC000000 if self.multi_core > 2 else self.VISION_ISA_BASE
+        _arena_top = self.VISION_ARENA_TOP
         _alloc_span = sum(self._align_up(s["size"], 64)
                           for k, s in sections.items() if k != "pos_embedding_table")
         _weight_base = ((_arena_top - _alloc_span) // 64) * 64
@@ -487,8 +487,7 @@ class Gemma4VisionMixin:
         # tensor arena by vision_weight_init). The old guard used the ISA base and
         # so silently allowed scratch to grow through the weights — the multi-core
         # "barcode" corruption. Guard the weight base instead.
-        tensor_limit = getattr(self, "_vis_weight_start",
-                               0xFC000000 if self.multi_core > 2 else self.VISION_ISA_BASE)
+        tensor_limit = getattr(self, "_vis_weight_start", self.VISION_ARENA_TOP)
         if self.get_tensor_dram_addr() > tensor_limit:
             raise MemoryError(
                 f"Gemma4 vision scratch overflows into the vision weights: "
@@ -665,8 +664,40 @@ class Gemma4VisionMixin:
                 self._vis_flops += shard_flops[0]
             _checkpoint(f"L{li}_proj")
             self._vis_flops += self.rms_norm_core_dram(M=S * NH, N=HD, A_DRAM_ADDR=self.VIS_V_DRAM, OUTPUT_DRAM_ADDR=self.VIS_V_DRAM, GAMMA_DRAM_ADDR=self.VIS_V_NORM_ONES_GAMMA, gpr_M_reg=self._prime_M(S * NH))
-            for dram in (self.VIS_Q_NORM, self.VIS_K_NORM):
-                self._vis_flops += self.rope_hf_matmul_core(src_dram=dram, M=S * NH, N=HD)
+            if gate_scheduler is None:
+                for dram in (self.VIS_Q_NORM, self.VIS_K_NORM):
+                    self._vis_flops += self.rope_hf_matmul_core(
+                        src_dram=dram, M=S * NH, N=HD)
+            else:
+                # rope_hf_matmul_core is row-independent over its flattened
+                # M=S*NH dimension. Slice every [M, HD] tensor by the same rows;
+                # the HDxHD swap permutation is shared and read-only. The
+                # existing VIS_ROPE_ROT allocation is likewise row-sliced, so
+                # multicore RoPE needs no per-engine scratch allocation.
+                rope_flops = [0]
+                def _emit_rope_shard(ctx, src_dram):
+                    m_reg = gate_m_regs[ctx.engine_idx]
+                    row_bytes = HD * bpe
+                    shard_src = ctx.rows_addr(src_dram, row_bytes)
+                    rope_flops[0] += ctx.ue.rope_hf_matmul_core(
+                        M=ctx.rows,
+                        N=HD,
+                        input_dram_addr=shard_src,
+                        output_dram_addr=shard_src,
+                        cos_dram_addr=ctx.rows_addr(
+                            self.VIS_ROPE_COS_TILED, row_bytes),
+                        sin_dram_addr=ctx.rows_addr(
+                            self.VIS_ROPE_SIN_TILED, row_bytes),
+                        identity_swap_dram_addr=self.VIS_ROPE_P_SWAP,
+                        scratch_dram_addr=ctx.rows_addr(
+                            self.VIS_ROPE_ROT, row_bytes),
+                        gpr_M_reg=m_reg)
+                for dram in (self.VIS_Q_NORM, self.VIS_K_NORM):
+                    gate_scheduler.sharded_region(
+                        S * NH,
+                        lambda ctx, src_dram=dram: _emit_rope_shard(
+                            ctx, src_dram))
+                self._vis_flops += rope_flops[0]
             _checkpoint(f"L{li}_rope")
             for src, dst in ((self.VIS_Q_NORM, self.VIS_FLASH_Q_HM),
                              (self.VIS_K_NORM, self.VIS_FLASH_K_HM),
@@ -858,7 +889,7 @@ class Gemma4VisionMixin:
                 worker_bytes = bytearray()
                 for inst in worker.capture_buffer:
                     worker_bytes.extend(inst.get_bytes())
-                worker_limit = (worker_addr + 0x00240000
+                worker_limit = (worker_addr + self.MULTICORE_WORKER_ISA_STRIDE
                                 if self.multi_core > 2 else self.LM_ISA_BASE)
                 if worker_addr + len(worker_bytes) > worker_limit:
                     raise RuntimeError(

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -97,8 +97,36 @@ class Gemma4VisionMixin:
                 }
             self._vis_clip_ranges.append(row)
 
+        # Place the vision weights at the TOP of the tensor arena (ending flush
+        # against the vision ISA base), DISJOINT from the vision scratch that
+        # vision_tensor_init lays down from _scratch_dram_base upward. Previously
+        # weights were allocated at the current cursor (the LM tensor high-water,
+        # ~0xF4900000), which sits IN the scratch growth path: once the matmul-
+        # RoPE buffers (bigger than the old SRAM RoPE) and the per-engine
+        # attention scratch grew vision scratch past that address, scratch DMAs
+        # clobbered the weights — mild single-core, severe multi-core (the extra
+        # worker scratch shifts scratch ~13 MB higher). Reserving the exact
+        # aligned weight span at the top makes scratch physically unable to reach
+        # it. `_dma_section` (below) allocates every key except pos_embedding_table
+        # (host-only), each 64-byte aligned, so the span is summed the same way.
+        # Arena top = first address the vision ISA claims: the master vision ISA
+        # base (2-core), or the compact worker-ISA arena at 0xFC000000 (>2-core /
+        # Alveo). vision_tensor_init uses the same split for its scratch limit.
+        _arena_top = 0xFC000000 if self.multi_core > 2 else self.VISION_ISA_BASE
+        _alloc_span = sum(self._align_up(s["size"], 64)
+                          for k, s in sections.items() if k != "pos_embedding_table")
+        _weight_base = ((_arena_top - _alloc_span) // 64) * 64
+        if _weight_base <= self._scratch_dram_base:
+            raise MemoryError(
+                f"Vision weights ({_alloc_span/1024/1024:.1f} MiB) do not fit below the "
+                f"vision ISA arena 0x{_arena_top:X}: base 0x{_weight_base:X} "
+                f"<= scratch base 0x{self._scratch_dram_base:X}")
+        self._tensor_dram_addr = _weight_base
+        self._vis_weight_start = _weight_base
+
         print(f"\n[Vision] Loading pre-quantized vision weights from combined bin "
-              f"({VISION_QUANT_PRECISION.upper()} block=64 + BF16 norms) ...")
+              f"({VISION_QUANT_PRECISION.upper()} block=64 + BF16 norms) "
+              f"at 0x{_weight_base:X} (top of tensor arena) ...")
         with open(weights_bin_path, "rb") as f:
             def _dma_section(key: str) -> int:
                 s = sections[key]
@@ -410,12 +438,18 @@ class Gemma4VisionMixin:
                         Pm[cell, base + ky * Wg + kx] = 1.0
         self._vis_pending_dmas.append((self.VIS_POOL_P, Pm))
 
-        tensor_limit = 0xFC000000 if self.multi_core > 2 else self.VISION_ISA_BASE
+        # Scratch must stay below the vision WEIGHTS (placed at the top of the
+        # tensor arena by vision_weight_init). The old guard used the ISA base and
+        # so silently allowed scratch to grow through the weights — the multi-core
+        # "barcode" corruption. Guard the weight base instead.
+        tensor_limit = getattr(self, "_vis_weight_start",
+                               0xFC000000 if self.multi_core > 2 else self.VISION_ISA_BASE)
         if self.get_tensor_dram_addr() > tensor_limit:
             raise MemoryError(
-                f"Gemma4 vision tensors overflow the 2-GB layout: "
-                f"end=0x{self.get_tensor_dram_addr():X}, "
-                f"worker_program_start=0x{tensor_limit:X}")
+                f"Gemma4 vision scratch overflows into the vision weights: "
+                f"scratch_end=0x{self.get_tensor_dram_addr():X}, "
+                f"weight_base=0x{tensor_limit:X}. Reduce vision scratch or raise the "
+                f"tensor arena.")
 
         self._vis_num_patches = S
         self._vis_aligned_S = aligned_S

--- a/multi_engine_shard.py
+++ b/multi_engine_shard.py
@@ -188,9 +188,6 @@ SHARDED_OP_ALLOWLIST = frozenset({
     "matmat_mul_core_dynamic",
     "matmat_mul_core_legacy",
     "quantized_matmat_mul_core",
-    # Composite small-head RoPE: matmul + row-wise eltwise operations. The
-    # caller must row-slice input/output, tiled cos/sin, and scratch together.
-    "rope_hf_matmul_core",
     # Standalone pointwise activation implemented through matmat_mul_core with
     # a shared read-only identity matrix. Each M row remains independent.
     "activation_core",
@@ -290,18 +287,12 @@ class _ShardedEngineProxy:
 
     def __getattr__(self, name):
         ue = object.__getattribute__(self, "_ue")
-        if name == "rope_hf_matmul_core":
-            # Model mixins may provide a convenience adapter with this same
-            # name but a narrower signature (Gemma4 wires its own buffers).
-            # A sharded call supplies explicitly sliced addresses, so dispatch
-            # to the library kernel rather than normal MRO lookup on ``ue``.
-            return UnifiedEngine.rope_hf_matmul_core.__get__(ue, type(ue))
         if name in SHARDED_OP_ALLOWLIST or name in _SCALAR_HELPER_ALLOWLIST:
             return getattr(ue, name)
         raise AssertionError(
             f"{name!r} is not allowed inside a sharded region. Only row-independent "
             f"ops are sharded in v1: {sorted(SHARDED_OP_ALLOWLIST)}. "
-            f"Attention, strided SRAM<->DRAM marshalling, permutes and non-row-wise RoPE must run "
+            f"Attention, strided SRAM<->DRAM marshalling, permutes and RoPE must run "
             f"single-engine: close the region (end_sharded()/leave sharded_region()), "
             f"emit them on the primary engine, then open a new region. "
             f"If you really mean it, use ctx.unsafe_ue."

--- a/multi_engine_shard.py
+++ b/multi_engine_shard.py
@@ -188,6 +188,9 @@ SHARDED_OP_ALLOWLIST = frozenset({
     "matmat_mul_core_dynamic",
     "matmat_mul_core_legacy",
     "quantized_matmat_mul_core",
+    # Composite small-head RoPE: matmul + row-wise eltwise operations. The
+    # caller must row-slice input/output, tiled cos/sin, and scratch together.
+    "rope_hf_matmul_core",
     # Standalone pointwise activation implemented through matmat_mul_core with
     # a shared read-only identity matrix. Each M row remains independent.
     "activation_core",
@@ -287,12 +290,18 @@ class _ShardedEngineProxy:
 
     def __getattr__(self, name):
         ue = object.__getattribute__(self, "_ue")
+        if name == "rope_hf_matmul_core":
+            # Model mixins may provide a convenience adapter with this same
+            # name but a narrower signature (Gemma4 wires its own buffers).
+            # A sharded call supplies explicitly sliced addresses, so dispatch
+            # to the library kernel rather than normal MRO lookup on ``ue``.
+            return UnifiedEngine.rope_hf_matmul_core.__get__(ue, type(ue))
         if name in SHARDED_OP_ALLOWLIST or name in _SCALAR_HELPER_ALLOWLIST:
             return getattr(ue, name)
         raise AssertionError(
             f"{name!r} is not allowed inside a sharded region. Only row-independent "
             f"ops are sharded in v1: {sorted(SHARDED_OP_ALLOWLIST)}. "
-            f"Attention, strided SRAM<->DRAM marshalling, permutes and RoPE must run "
+            f"Attention, strided SRAM<->DRAM marshalling, permutes and non-row-wise RoPE must run "
             f"single-engine: close the region (end_sharded()/leave sharded_region()), "
             f"emit them on the primary engine, then open a new region. "
             f"If you really mean it, use ctx.unsafe_ue."

--- a/multi_engine_shard.py
+++ b/multi_engine_shard.py
@@ -565,47 +565,69 @@ class HeadShardContext:
 
     @property
     def groups(self) -> int:
-        """KV groups THIS engine owns -- one flash kernel call each.
+        """KV groups THIS engine touches (the last may be partial under
+        ``mode="qheads"``). Prefer :meth:`call_runs`, which is exact."""
+        first_kv = self.head_off // self.gqa_ratio
+        last_kv = (self.head_off + self.heads - 1) // self.gqa_ratio
+        return last_kv - first_kv + 1
 
-        :meth:`MultiEngineScheduler.split_heads` splits on group boundaries, so
-        this is always exact.
+    def call_runs(self) -> list[tuple[int, int, int]]:
+        """Decompose this engine's head range into ``(q_head, kv_head, n_q)``
+        kernel calls -- THE contract between the split and the kernel.
+
+        Each run is a MAXIMAL span of consecutive Q heads sharing one KV head,
+        which is exactly what one flash call can process (it re-reads
+        ``K_DRAM_ADDR`` unshifted per head and builds ``V^T`` once). Whole-group
+        ownership yields one run per group; a straddling range yields a short
+        run at each ragged end and full runs in between. Both are correct, and
+        the caller never has to know which case it is in.
+
+        Head indices are ABSOLUTE (model-wide), so they feed the ``*_addr``
+        accessors directly.
         """
-        return self.heads // self.gqa_ratio
+        runs = []
+        h = self.head_off
+        end = self.head_off + self.heads
+        while h < end:
+            kv = h // self.gqa_ratio
+            # Stop at whichever comes first: the end of this KV group, or the
+            # end of what this engine owns.
+            run_end = min((kv + 1) * self.gqa_ratio, end)
+            runs.append((h, kv, run_end - h))
+            h = run_end
+        return runs
 
     # -- Q / K / V / output slicing -----------------------------------------
-    # ``group`` indexes THIS ENGINE's KV groups (0 .. self.groups-1), not the
-    # model's. Each one is a separate kernel call; see the body in
-    # MultiEngineScheduler.head_sharded_attention for why.
-    def q_addr(self, base_addr: int, group: int = 0) -> int:
-        """First Q head of ``group``, in a [H, seq_len, head_dim] blob.
-
-        The kernel walks the following ``gqa_ratio`` heads itself, which is
-        correct only because Q heads of one KV group are contiguous in H.
-        """
-        head = self.head_off + group * self.gqa_ratio
+    # ``head``/``kv_head`` are ABSOLUTE indices, as produced by call_runs().
+    def q_addr(self, base_addr: int, head: Optional[int] = None) -> int:
+        """Q head ``head`` in a [H, seq_len, head_dim] blob (default: this
+        engine's first). The kernel walks the run's remaining heads itself,
+        which is correct only because Q heads of one KV group are contiguous."""
+        head = self.head_off if head is None else head
         return _shifted(base_addr, head * self.head_bytes,
-                        f"Q head shard (engine {self.engine_idx}, group {group})")
+                        f"Q head {head} (engine {self.engine_idx})")
 
-    def kv_addr(self, base_addr: int, group: int = 0) -> int:
-        """KV head of ``group``, in a [H/gqa_ratio, seq_len, head_dim] blob.
+    def kv_addr(self, base_addr: int, kv_head: Optional[int] = None) -> int:
+        """KV head ``kv_head`` in a [H/gqa_ratio, seq_len, head_dim] blob.
 
-        Indexed by KV head, NOT Q head -- passing ``q_addr`` for K/V is the
-        single most likely GQA mistake and reads out of bounds on the last
-        engine rather than failing loudly.
+        Indexed by KV head, NOT Q head -- passing a Q index here is the single
+        most likely GQA mistake and reads out of bounds on the last engine
+        rather than failing loudly.
         """
-        kv_head = self.head_off // self.gqa_ratio + group
+        kv_head = (self.head_off // self.gqa_ratio) if kv_head is None else kv_head
         return _shifted(base_addr, kv_head * self.head_bytes,
-                        f"KV head shard (engine {self.engine_idx}, group {group})")
+                        f"KV head {kv_head} (engine {self.engine_idx})")
 
-    def out_addr(self, base_addr: int, group: int = 0) -> int:
-        """Output slice for ``group``. Disjoint per engine AND per group, so the
-        concatenated [H, seq_len, head_dim] is complete after one exit barrier."""
-        head = self.head_off + group * self.gqa_ratio
+    def out_addr(self, base_addr: int, head: Optional[int] = None) -> int:
+        """Output slice for Q head ``head``. Disjoint across engines AND runs,
+        so the concatenated [H, seq_len, head_dim] is complete after one exit
+        barrier."""
+        head = self.head_off if head is None else head
         return _shifted(base_addr, head * self.head_bytes,
-                        f"attn out shard (engine {self.engine_idx}, group {group})")
+                        f"attn out head {head} (engine {self.engine_idx})")
 
     def bias_addr(self, base_addr: int, per_head: bool = False,
-                  group: int = 0) -> int:
+                  head: Optional[int] = None) -> int:
         """Attention bias / mask base.
 
         ``prefill_flash_attention_core`` indexes its bias ``((i+r) * N_q + j)``
@@ -621,9 +643,9 @@ class HeadShardContext:
         if not per_head:
             return base_addr
         plane = self.seq_len * self.seq_len * self.elem_bytes
-        head = self.head_off + group * self.gqa_ratio
+        head = self.head_off if head is None else head
         return _shifted(base_addr, head * plane,
-                        f"attn bias shard (engine {self.engine_idx}, group {group})")
+                        f"attn bias head {head} (engine {self.engine_idx})")
 
     # -- scratch -------------------------------------------------------------
     def scratch(self, name: str = "attn_scratch") -> int:
@@ -888,30 +910,53 @@ class MultiEngineScheduler:
         return self.split_cols(K)
 
     # --------------------------------------------------------------- heads --
-    def split_heads(self, H: int, gqa_ratio: int = 1) -> list[tuple[int, int]]:
+    def split_heads(self, H: int, gqa_ratio: int = 1,
+                    mode: str = "groups") -> list[tuple[int, int]]:
         """Return [(head_offset, head_count)] per engine for H attention heads.
 
-        Split on KV-GROUP boundaries, not Q-head boundaries: with ``gqa_ratio``
-        Q heads per KV head, an engine that owned a partial group would need a
-        K/V slice starting mid-plane, which ``HeadShardContext.kv_addr`` cannot
-        express (and which would make ``V^T`` wrong, not merely redundant).
-        Engines that land on DIFFERENT groups each rebuild their own ``V^T``
-        from their own K/V -- there is no duplicated work to eliminate.
+        ``mode="groups"`` (default) splits on KV-GROUP boundaries, so every
+        engine owns whole groups and each KV plane is transposed to ``V^T``
+        exactly once across the machine. Parallelism caps at ``H // gqa_ratio``.
 
-        Uneven-but-aligned, like :meth:`split_cols`: trailing engines get one
-        group less rather than any engine getting a partial one.
+        ``mode="qheads"`` splits on Q-HEAD boundaries, letting a group straddle
+        engines. This is CORRECT, not a relaxation of a correctness rule: the
+        constraint the kernel imposes is per CALL (one call re-reads
+        ``K_DRAM_ADDR`` unshifted and builds ``V^T`` once, so its heads must
+        share a KV head), and an engine owning a partial group simply issues
+        more, smaller calls -- see :meth:`HeadShardContext.call_runs`. K/V are
+        read-only, so two engines reading one KV plane never conflict.
+
+        The cost is a duplicated ``V^T`` per straddled group: a
+        [head_dim, seq_len] transpose against a head whose real work is two
+        seq_len**2 * head_dim matmuls, i.e. sub-1% at typical shapes. Use
+        ``"qheads"`` when ``H // gqa_ratio < num_engines`` would otherwise
+        refuse to shard at all (heavily-GQA models: 16 Q heads over 2 KV heads
+        gives only 2 groups), and ``"groups"`` -- the tidier default -- when
+        there are enough groups to go around.
         """
         n = self.num_engines
         assert gqa_ratio >= 1, f"gqa_ratio must be >= 1, got {gqa_ratio}"
         assert H % gqa_ratio == 0, (
             f"split_heads: H={H} is not a multiple of gqa_ratio={gqa_ratio}")
+        assert mode in ("groups", "qheads"), f"unknown head split mode {mode!r}"
         if n == 1:
             return [(0, H)]
+
+        if mode == "qheads":
+            assert H >= n, (
+                f"split_heads(mode='qheads'): H={H} head(s) is fewer than "
+                f"num_engines={n}; there is nothing left to split.")
+            base, rem = divmod(H, n)
+            counts = [base + (1 if i < rem else 0) for i in range(n)]
+            offsets = [sum(counts[:i]) for i in range(n)]
+            return list(zip(offsets, counts))
+
         groups = H // gqa_ratio
         assert groups >= n, (
             f"split_heads: H={H} is only {groups} KV group(s) of {gqa_ratio} "
-            f"head(s), too few for num_engines={n}. Shard a different axis, or "
-            f"run attention on the primary alone.")
+            f"head(s), too few for num_engines={n}. Pass mode='qheads' to split "
+            f"within groups (costs a duplicated V^T per straddled group), shard "
+            f"a different axis, or run attention on the primary alone.")
         base, rem = divmod(groups, n)
         counts = [gqa_ratio * (base + (1 if i < rem else 0)) for i in range(n)]
         offsets = [sum(counts[:i]) for i in range(n)]
@@ -945,11 +990,12 @@ class MultiEngineScheduler:
 
     def begin_head_sharded(self, H: int, seq_len: int, head_dim: int,
                            gqa_ratio: int = 1,
-                           elem_bytes: int = 2) -> list[HeadShardContext]:
+                           elem_bytes: int = 2,
+                           mode: str = "groups") -> list[HeadShardContext]:
         """Rendezvous, then open a head-sharded region, one context per engine."""
         assert self._program_open, "begin_head_sharded() without begin_program()"
         assert not self._in_region, "nested sharded regions are not supported"
-        split = self.split_heads(H, gqa_ratio)
+        split = self.split_heads(H, gqa_ratio, mode=mode)
         self.barrier()
         self._in_region = True
         self._region_count += 1
@@ -960,7 +1006,7 @@ class MultiEngineScheduler:
     def head_sharded_region(self, H: int, seq_len: int, head_dim: int,
                             body: Callable[[HeadShardContext], None],
                             gqa_ratio: int = 1, elem_bytes: int = 2,
-                            join: bool = True) -> None:
+                            mode: str = "groups", join: bool = True) -> None:
         """Replay ``body(ctx)`` once per engine over a head split.
 
         ``join`` defaults to True and should almost always stay there: the next
@@ -969,7 +1015,7 @@ class MultiEngineScheduler:
         cross-shard read the exit barrier exists for.
         """
         contexts = self.begin_head_sharded(H, seq_len, head_dim, gqa_ratio,
-                                           elem_bytes)
+                                           elem_bytes, mode=mode)
         for ctx in contexts:
             body(ctx)
         self.end_sharded(join=join)
@@ -982,6 +1028,7 @@ class MultiEngineScheduler:
                                bias_addr: Optional[int] = None,
                                bias_per_head: bool = False,
                                scratch_name: str = "attn_scratch",
+                               mode: str = "groups",
                                kernel: Optional[Callable] = None,
                                elem_bytes: int = 2,
                                join: bool = True) -> None:
@@ -1024,22 +1071,25 @@ class MultiEngineScheduler:
             # gqa_ratio == 1 (MHA) this is one call per head, which is simply
             # what the kernel's batching means for MHA -- there is nothing to
             # batch when no two Q heads share a K/V.
-            for g in range(ctx.groups):
+            # call_runs() yields maximal spans of Q heads sharing one KV head --
+            # one group per run when the engine owns whole groups, ragged short
+            # runs at the ends when a group straddles engines (mode="qheads").
+            for q_head, kv_head, n_q in ctx.call_runs():
                 kernel(ctx.ue, head_dim, seq_len,
-                       Q_DRAM_ADDR=ctx.q_addr(Q_addr, group=g),
-                       K_DRAM_ADDR=ctx.kv_addr(K_addr, group=g),
-                       V_DRAM_ADDR=ctx.kv_addr(V_addr, group=g),
-                       OUTPUT_DRAM_ADDR=ctx.out_addr(OUT_addr, group=g),
+                       Q_DRAM_ADDR=ctx.q_addr(Q_addr, head=q_head),
+                       K_DRAM_ADDR=ctx.kv_addr(K_addr, kv_head=kv_head),
+                       V_DRAM_ADDR=ctx.kv_addr(V_addr, kv_head=kv_head),
+                       OUTPUT_DRAM_ADDR=ctx.out_addr(OUT_addr, head=q_head),
                        SCRATCH_DRAM_ADDR=ctx.scratch(scratch_name),
                        IDENTITY_DRAM_ADDR=IDENTITY_addr,   # shared, read-only
                        BIAS_DRAM_ADDR=ctx.bias_addr(bias_addr,
                                                     per_head=bias_per_head,
-                                                    group=g),
-                       num_q_heads=ctx.gqa_ratio)
+                                                    head=q_head),
+                       num_q_heads=n_q)
 
         self.head_sharded_region(H, seq_len, head_dim, body,
                                  gqa_ratio=gqa_ratio, elem_bytes=elem_bytes,
-                                 join=join)
+                                 mode=mode, join=join)
 
     def alloc_col_output(self, name: str, M: int, N: int, elem_bytes: int = 2) -> list[int]:
         """Allocate one contiguous ``[M, cols]`` output buffer PER ENGINE.

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -815,7 +815,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x3d04c689, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x3d04c689. Please update FPGA with commit update_3d04c689.bin using update_flash.py (public release v1.4)"
+        # assert hw_version == 0x3d04c689, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x3d04c689. Please update FPGA with commit update_3d04c689.bin using update_flash.py (public release v1.4)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -815,7 +815,16 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        assert hw_version == 0x3d04c689, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x3d04c689. Please update FPGA with commit update_3d04c689.bin using update_flash.py (public release v1.4)"
+        # 0x3d04c689 is the public v1.4 image used by Kintex.  The current
+        # eight-engine Alveo image reports 0x6bb5d25d and implements the same
+        # host-visible register/ISA contract. Keep this an explicit allowlist:
+        # accepting arbitrary versions would turn ABI mismatches into silent
+        # memory corruption.
+        supported_hw_versions = {0x3d04c689, 0x6bb5d25d}
+        assert hw_version in supported_hw_versions, (
+            f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, "
+            f"expected one of {[f'0x{v:08x}' for v in sorted(supported_hw_versions)]}. "
+            "Please program a supported FPGA image.")
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -815,16 +815,7 @@ class UnifiedEngine:
         print(f"{DMA_DEVICE_USER} register access...")
         hw_version = self.user_read_reg32(UE_FPGA_VERSION_ADDR)
         print(f"HW version via user device: 0x{hw_version & 0xFFFFFFFF:08x}")
-        # 0x3d04c689 is the public v1.4 image used by Kintex.  The current
-        # eight-engine Alveo image reports 0x6bb5d25d and implements the same
-        # host-visible register/ISA contract. Keep this an explicit allowlist:
-        # accepting arbitrary versions would turn ABI mismatches into silent
-        # memory corruption.
-        supported_hw_versions = {0x3d04c689, 0x6bb5d25d}
-        assert hw_version in supported_hw_versions, (
-            f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, "
-            f"expected one of {[f'0x{v:08x}' for v in sorted(supported_hw_versions)]}. "
-            "Please program a supported FPGA image.")
+        assert hw_version == 0x3d04c689, f"HW version mismatch: got 0x{hw_version & 0xFFFFFFFF:08x}, expected 0x3d04c689. Please update FPGA with commit update_3d04c689.bin using update_flash.py (public release v1.4)"
 
         addr = UE_START_ADDR # first reg address offset
         while addr <= UE_LAST_REG_ADDR: # last reg address


### PR DESCRIPTION
## Performance comparison

| Metric | Legacy | Kintex | Kintex 2-core | rk (outdated) | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Vision FPGA execution | 55.54 s | 53.78 s | 27.77s | 32.56 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.82 s** |
| Vision end-to-end path | not reported | 54.32 s | 28.58s | 33.03 s | **35.98 s** | **19.6 s** | **10.91 s** | **7.95 s** |
| Vision throughput | not reported | 21.37 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.98 GFLOPS** | **238.56 GFLOPS** |
| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
| LM prefill FPGA latency | 113.571 s | 51.52 s | 31.87s | 32.544 s | **28.23 s** | **17.3 s** | **11.60 s** | **8.81 s** |
| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **106.32 GFLOPS** | **139.90 GFLOPS** |
| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.76 tok/s | 6.00 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.50 tok/s** | **5.49 tok/s** |
| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.0 tok/s | 6.23 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.90 tok/s** | **5.87 tok/s** |
| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.03 GFLOPS** | **33.97 GFLOPS** |
| Vision program section | 3.58 MiB | 3.22 MiB | 2.39 MiB | / | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
| Prefill program section | 5.71 MiB | 3.08 MiB | 3.46 MiB | / | 3.08 MiB | 3.46 MiB | 3.39 MiB | 3.41 MiB |
| Decode program section | | 1.42 MiB | 1.46 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
| Combined program image | 10.37 MiB | 7.73 MiB | 10.81 MiB | / | 7.73 MiB | 10.81 MiB | 16.10 MiB | 26.92 MiB |
| Weight image (`params.bin`) | 6.91 GiB | same | same | / | same | same | same | same |
| Correctness |  | coherent, total 724 | coherent, total 709 | not recorded | coherent, total 724 | coherent, total 709 | coherent, total 709 | coherent, total 709 |

## Profile backup: vision encoder

Vision multi-core segments tile cleanly (they sum to the single-shot master total),
so the per-phase `--multi-core 2` numbers are exact.

| Phase | Single-core | --multi-core 2 |
|---|---:|---:|
| Patch embedding | 123.6 ms | 123.6 ms |
| Projection (Q/K/V) † | 6,682.4 ms | **3,361.0 ms** |
| RoPE | 1,072.8 ms | **740.0 ms** |
| Permute | 269.6 ms | 269.6 ms |
| Attention † | 16,642.2 ms | **8,664.7 ms** |
| Post-attention (O + MLP) † | 28,911.4 ms | **14,541.1 ms** |
| Pooler tail | 75.3 ms | 75.3 ms |
| Tail | 0.0 ms | 0.0 ms |
| **Total** | **53,777.3 ms** | **27,775 ms** |

† row-sharded across 2 engines