### PR TITLE
lm attention opt and multi-core support and 4k context length

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_config.json
+++ b/models/gemma4_e2b/gemma4_e2b_config.json
@@ -20,7 +20,7 @@
     "per_layer_input_dim": 256
   },
   "model": {
-    "max_context_size": 1024,
+    "max_context_size": 4096,
     "prefill_max_seq_len": 512,
     "max_prefill_seq_len": 512,
     "sliding_window": 512,
@@ -324,11 +324,11 @@
     },
     "ROPE_LOCAL": {
       "offset": "0x9026BD00",
-      "size": 1048576
+      "size": 4194304
     },
     "ROPE_GLOBAL": {
-      "offset": "0x9036BD00",
-      "size": 1048576
+      "offset": "0x9426BD00",
+      "size": 2097152
     }
   },
   "special": {
@@ -337,7 +337,7 @@
       "token_embd_size": "0x30000000"
     },
     "rope": {
-      "num_positions": 1024,
+      "num_positions": 4096,
       "theta": 1000000.0,
       "local_base": 10000.0,
       "partial_rotary_factor_global": 0.25

--- a/models/gemma4_e2b/gemma4_e2b_lm.py
+++ b/models/gemma4_e2b/gemma4_e2b_lm.py
@@ -705,6 +705,35 @@ class Gemma4LMMixin:
         prefill_scheduler = getattr(self, "_active_prefill_scheduler", None)
         shard_m_regs = getattr(self, "_prefill_shard_m_regs", None)
 
+        # Multi-core attention shards the group heads across engines; each engine
+        # needs PRIVATE flash scratch. Carve one slot per engine out of the big
+        # LAYER0_FLASH_SCRATCH_DRAM arena (sized for per_head_rows=max, head_dim
+        # max). register_per_engine_addrs is idempotent across recompiles.
+        if prefill_scheduler is not None:
+            _ph_rows = ((self.max_prefill_seq_len + 63) // 64) * 64
+            # unified_attention_core needs THREE scratch buffers (V^T + score +
+            # scaled_q), NOT the two the flash kernel's attn_scratch_bytes sizes.
+            # Match the core's own layout (user_dma_core: v_t=head_dim*aligned,
+            # score=aligned*aligned, scaled_q=batch*head_dim; aligned=batch=
+            # per_head_rows, head_dim=max). Undersizing overlaps adjacent engines'
+            # scaled_q onto the next engine's V^T and corrupts the worker heads.
+            _attn_scr_stride = (self.head_dim * _ph_rows + _ph_rows * _ph_rows
+                                + _ph_rows * self.head_dim) * self.bytes_per_element
+            _n_eng = prefill_scheduler.num_engines
+            _scr_end = self.LAYER0_FLASH_SCRATCH_DRAM + _n_eng * _attn_scr_stride
+            print(f"[prefill attn scratch] base=0x{self.LAYER0_FLASH_SCRATCH_DRAM:X} "
+                  f"stride=0x{_attn_scr_stride:X} engines={_n_eng} "
+                  f"end=0x{_scr_end:X} next_tensor=0x{self.LAYER0_ATTN_PROJ_OUTPUT_DRAM:X} "
+                  f"slack={ (self.LAYER0_ATTN_PROJ_OUTPUT_DRAM - _scr_end)/(1024*1024):.2f} MiB")
+            assert _scr_end <= self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, (
+                f"prefill per-engine attn scratch overruns FLASH_SCRATCH: "
+                f"{_n_eng} engines × 0x{_attn_scr_stride:X} ends at 0x{_scr_end:X} > "
+                f"next tensor 0x{self.LAYER0_ATTN_PROJ_OUTPUT_DRAM:X}")
+            prefill_scheduler.register_per_engine_addrs(
+                "prefill_attn_scratch",
+                [self.LAYER0_FLASH_SCRATCH_DRAM + e * _attn_scr_stride
+                 for e in range(_n_eng)])
+
         def _shard_projection_core(ctx, **kwargs) -> int:
             """Emit one fixed row shard through the two-pass matmatmul core."""
             m_reg = shard_m_regs[ctx.engine_idx]
@@ -873,38 +902,121 @@ class Gemma4LMMixin:
                 self._emit_strided_copy_pbi(tmp_out, self.LAYER0_FLASH_Q_DRAM, rope_n, rope_bytes, head_bytes, q_rows, self.gpr_q_seq_len)
                 self._emit_strided_copy_pbi(self.LAYER0_Q_NORM_DRAM + rope_bytes, self.LAYER0_FLASH_Q_DRAM + rope_bytes, non_rot, head_bytes, head_bytes, q_rows, self.gpr_q_seq_len)
             _checkpoint(f"L{layer_idx}_rope")
-            # GQA dup: read KV cache (k_size stride) → scatter group_size copies to FLASH (cur_head_dim stride).
-            self._emit_gqa_duplicate_pbi(k_cache_base, self.LAYER0_FLASH_K_DRAM, cur_head_dim, seq_len, self.gpr_seq_len, src_row_bytes=head_bytes)
-            self._emit_gqa_duplicate_pbi(v_cache_base, self.LAYER0_FLASH_V_DRAM, cur_head_dim, seq_len, self.gpr_seq_len, src_row_bytes=head_bytes)
             _checkpoint(f"L{layer_idx}_kv_gather")
 
-            # Gemma4 uses scaling=1.0 (no 1/sqrt(d) in attention scores), so pass
-            # q_scale=1.0 below; no Q pre-scale needed.
+            # ---- GQA = an outer loop over the group's query heads ----
+            # Standard GQA: the group_size query heads all attend the SAME K/V
+            # head (num_kv=1), so K/V are read straight from the compact per-layer
+            # cache — no duplication. unified_attention_core reads Q and writes OUT
+            # as contiguous [batch, head_dim], but the projection/RoPE produce Q
+            # token-major (row = token*group + head), so head g's rows are strided.
+            # Permute Q to head-major [group, per_head_rows, head_dim] (each head's
+            # rows contiguous), run one SDPA per head reusing the shared K/V, then
+            # permute the head-major output back to token-major [seq, group*head_dim]
+            # for the O projection. Both permutes are runtime-length (gpr_seq_len)
+            # strided copies (bf16_permute_dram_core bakes its row count, so it
+            # cannot be used on the dynamic-length prefill program).
+            #
+            # per_head_rows is the compile-time MAX aligned KV length; it (a) sizes
+            # the head-major per-head slot and (b) is the static aligned_seq_len the
+            # core uses to reserve its SCRATCH sub-buffers (the live length comes
+            # from gpr_aligned_seq_len = align64(seq_len) at runtime).
+            #
+            # FLASH_K (freed by dropping the GQA duplication) holds head-major Q;
+            # each head's attention output is written back into the SAME per-head
+            # slot — safe because the core copies Q into its scaled-Q scratch before
+            # writing OUT — then permuted into FLASH_OUTPUT. FLASH_V still holds the
+            # V-projection output, so it is not reused here.
+            per_head_rows = ((self.max_prefill_seq_len + 63) // 64) * 64
+            qhm_head_bytes = per_head_rows * cur_head_dim * self.bytes_per_element
+            # Compile-time runtime dims for multi-core workers (prefill compiles
+            # per prompt, so seq_len is a constant here): batch=seq_len,
+            # aligned=align64(seq_len). Master's single-core path uses the primed
+            # GPRs instead.
+            attn_aligned_ct = ((seq_len + 63) // 64) * 64
+            for g in range(self.group_size):
+                self._emit_strided_copy_pbi(
+                    self.LAYER0_FLASH_Q_DRAM + g * head_bytes,       # token-major head g
+                    self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,   # head-major head g
+                    cur_head_dim,
+                    self.group_size * head_bytes,                    # token-major row stride
+                    head_bytes,                                      # head-major contiguous
+                    seq_len, self.gpr_seq_len)
+            _checkpoint(f"L{layer_idx}_q_permute")
 
-            # Pick the per-layer bias: full attention layers see the
-            # entire causal window; sliding-attention layers are limited
-            # to `sliding_window` tokens (run_prefill builds both biases).
+            # Gemma4 uses scaling=1.0 (no 1/sqrt(d) in attention scores) → q_scale=1.0.
+            # Per-layer bias: full-attention layers see the whole causal window,
+            # sliding layers only `sliding_window` tokens (run_prefill builds both).
+            # Bias is ONE [aligned_kv, aligned_kv] plane shared by every head; the
+            # dynamic batch/aligned GPRs limit live rows/cols to seq_len /
+            # align64(seq_len).
             bias_addr_layer = (self.LAYER0_FLASH_BIAS_FULL_DRAM
                                if layer_idx in self._full_attention_layers
                                else self.LAYER0_FLASH_BIAS_SLIDING_DRAM)
-            # unified_attention_core uses bias_mode="full_matrix" internally.
-            # Prefill bias is [aligned_q, aligned_q], while the dynamic batch
-            # GPR limits the live rows to q_seq_len.
-            total_flops += self.unified_attention_core(
-                batch=aligned_seq_len,
-                aligned_seq_len=aligned_seq_len,
-                head_dim=cur_head_dim,
-                Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                BIAS_DRAM_ADDR=bias_addr_layer,
-                OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
-                SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                gpr_batch_reg=self.gpr_q_seq_len,
-                gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                q_scale=1.0,
-            )
+
+            def _emit_prefill_head(ue, h, scratch_addr, batch_reg, aligned_reg):
+                head_slot = self.LAYER0_FLASH_K_DRAM + h * qhm_head_bytes
+                # Static batch/aligned = the ACTUAL per-prompt dims (seq_len,
+                # align64(seq_len)), NOT per_head_rows. Prefill compiles per
+                # prompt so these are the true max the runtime GPRs take, which
+                # (a) makes the returned FLOP count accurate — per_head_rows=512
+                # over-counted the 272/320 attention ~3x, nudging reported
+                # prefill throughput above the MAC-array peak — and (b) reserves
+                # exactly the scratch the core uses. The head-major slot stride
+                # (qhm_head_bytes) stays at per_head_rows so buffer layout is
+                # seq-independent.
+                f = ue.unified_attention_core(
+                    batch=seq_len, aligned_seq_len=attn_aligned_ct,
+                    head_dim=cur_head_dim,
+                    Q_DRAM_ADDR=head_slot, K_DRAM_ADDR=k_cache_base,
+                    V_DRAM_ADDR=v_cache_base, BIAS_DRAM_ADDR=bias_addr_layer,
+                    OUTPUT_DRAM_ADDR=head_slot, SCRATCH_DRAM_ADDR=scratch_addr,
+                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                    gpr_batch_reg=batch_reg, gpr_aligned_seq_len_reg=aligned_reg,
+                    q_scale=1.0)
+                return f if isinstance(f, (int, float)) else 0
+
+            if prefill_scheduler is None:
+                # Single core: loop all group heads on the master, reusing the
+                # runtime seq/aligned GPRs and the shared scratch.
+                for g in range(self.group_size):
+                    total_flops += _emit_prefill_head(
+                        self, g, self.LAYER0_FLASH_SCRATCH_DRAM,
+                        self.gpr_seq_len, self.gpr_aligned_seq_len)
+            else:
+                # Multi core: shard the group heads across engines; each engine
+                # LOOPS its own heads (batch=seq per head — prefill can't stack
+                # heads into one batch, that would break batch<=aligned and the
+                # [aligned,aligned] score scratch). seq/aligned are compile-time
+                # constants (prefill compiles per prompt), so each engine
+                # add_sets its own batch/aligned regs — no worker dispatch
+                # priming needed. Private per-engine scratch via
+                # 'prefill_attn_scratch'. Master permutes Q in / OUT out around
+                # the region (workers park at the entry/exit barriers).
+                _attn_flops = [0]
+                def _emit_prefill_attn_shard(ctx):
+                    b_reg = ctx.ue.alloc_isa_reg()
+                    ctx.ue.generate_instruction_add_set(b_reg, seq_len)
+                    a_reg = ctx.ue.alloc_isa_reg()
+                    ctx.ue.generate_instruction_add_set(a_reg, attn_aligned_ct)
+                    scr = ctx.scratch("prefill_attn_scratch")
+                    for h in range(ctx.head_off, ctx.head_off + ctx.heads):
+                        _attn_flops[0] += _emit_prefill_head(ctx.ue, h, scr, b_reg, a_reg)
+                    ctx.ue.release_isa_reg()
+                    ctx.ue.release_isa_reg()
+                prefill_scheduler.head_sharded_region(
+                    self.group_size, per_head_rows, cur_head_dim,
+                    _emit_prefill_attn_shard, gqa_ratio=1)
+                total_flops += _attn_flops[0]
+            # Permute the head-major attention output back to token-major for O-proj.
+            for g in range(self.group_size):
+                self._emit_strided_copy_pbi(
+                    self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,   # head-major head g
+                    self.LAYER0_FLASH_OUTPUT_DRAM + g * head_bytes,  # token-major head g
+                    cur_head_dim,
+                    head_bytes,                                      # head-major contiguous
+                    self.group_size * head_bytes,                    # token-major row stride
+                    seq_len, self.gpr_seq_len)
             _checkpoint(f"L{layer_idx}_attention")
             if prefill_scheduler is None:
                 total_flops += _projection_core(M=seq_len, K=cur_q_size, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_ATTN_PROJ_OUTPUT_DRAM, is_B_quantized=True, data_type=TYPE.IF4, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_ATTN_PROJ_SCALE + layer_off, gpr_M_reg=self.gpr_seq_len)
@@ -1068,6 +1180,11 @@ class Gemma4LMMixin:
         self.seq_len = seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        # Per-head aligned KV length: with GQA run as an outer loop over query
+        # heads reusing one K/V, attention is per-token (not per q-position), so
+        # the live aligned length is align64(seq_len), primed into
+        # gpr_aligned_seq_len below (replaces the old align64(q_seq_len)).
+        attn_aligned = ((seq_len + 63) // 64) * 64
         prefill_scheduler = self._ensure_prefill_scheduler()
         worker_program_addrs = []
         if prefill_scheduler is not None:
@@ -1159,45 +1276,31 @@ class Gemma4LMMixin:
         # Build BOTH prefill bias matrices: full (causal) for full-attention
         # layers, and sliding (causal AND within `sliding_window` tokens) for
         # sliding-attention layers. compile_prefill picks per-layer.
-        # Both biases are in q_seq_len space (each token has group_size query
-        # heads, K is GQA-duplicated to match), so the window is converted
-        # from token space to q-position space by multiplying by group_size.
-        full_bias = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
-        # Q rows are laid out token*group_size + head, and K is GQA-duplicated
-        # to the same layout, so each attn head must attend ONLY its own head
-        # slot (its KV head), causal in tokens. A flat q-space causal tril
-        # (j<=i) additionally allows CROSS-HEAD attention (head h attending
-        # earlier heads 0..h within a token). For E2B (num_kv=1) this is one KV
-        # group so it doesn't corrupt the VALUE, but it still over-weights
-        # earlier tokens (each contributes group_size duplicate slots vs the
-        # current token's h+1), so the correct mask is same head AND
-        # token-causal. (For E4B num_kv=2 the flat tril was catastrophic — it
-        # let heads attend the WRONG KV group; see gemma4_e4b_test.py.)
-        _gs = self.group_size
-        _i = torch.arange(aligned_seq_len).unsqueeze(1)
-        _j = torch.arange(aligned_seq_len).unsqueeze(0)
-        _same_head = (_i % _gs) == (_j % _gs)
-        _tok_causal = ((_j // _gs) <= (_i // _gs)) if not self.causal_mask_upper else ((_j // _gs) >= (_i // _gs))
-        valid_mask = _same_head & _tok_causal
-        full_bias.masked_fill_(valid_mask, 0.0)
-        full_bias[:, q_seq_len:] = float("-inf")
+        #
+        # GQA now runs as an outer loop over query heads reusing one K/V, so a
+        # head attends the shared K/V over TOKEN positions: the bias is a single
+        # [attn_aligned, attn_aligned] causal plane in TOKEN space, reused by
+        # every head. No group_size expansion and no same-head term (the old
+        # q_seq×q_seq "same head AND token-causal" mask is gone). Columns past
+        # seq_len are the alignment padding and stay masked to -inf, which is
+        # what zeroes the stale K/V padding rows after softmax.
+        _i = torch.arange(attn_aligned).unsqueeze(1)
+        _j = torch.arange(attn_aligned).unsqueeze(0)
+        _tok_causal = (_j <= _i) if not self.causal_mask_upper else (_j >= _i)
+        full_bias = torch.full((attn_aligned, attn_aligned), float("-inf"), dtype=torch.bfloat16)
+        full_bias.masked_fill_(_tok_causal, 0.0)
+        full_bias[:, seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_FULL_DRAM, full_bias)
 
         # Sliding bias is identical to full when seq_len ≤ sliding_window;
-        # otherwise it additionally masks anything older than the window.
+        # otherwise it additionally masks tokens older than the window.
         if seq_len <= self.sliding_window:
             sliding_bias = full_bias
         else:
-            window_q = self.sliding_window * self.group_size
-            sliding_bias = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
-            i_idx = torch.arange(aligned_seq_len).unsqueeze(1)
-            j_idx = torch.arange(aligned_seq_len).unsqueeze(0)
-            i_token = i_idx // self.group_size
-            j_token = j_idx // self.group_size
-            in_window = (i_token - j_token) < self.sliding_window
-            sliding_mask = valid_mask & in_window
-            sliding_bias.masked_fill_(sliding_mask, 0.0)
-            sliding_bias[:, q_seq_len:] = float("-inf")
+            in_window = (_i - _j) < self.sliding_window
+            sliding_bias = torch.full((attn_aligned, attn_aligned), float("-inf"), dtype=torch.bfloat16)
+            sliding_bias.masked_fill_(_tok_causal & in_window, 0.0)
+            sliding_bias[:, seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_SLIDING_DRAM, sliding_bias)
 
         host_prepare_s = time.perf_counter() - _host_prepare_w0
@@ -1216,7 +1319,7 @@ class Gemma4LMMixin:
             return self._profile_execute(
                 [(self.gpr_seq_len,         seq_len),
                  (self.gpr_q_seq_len,       q_seq_len),
-                 (self.gpr_aligned_seq_len, aligned_seq_len)],
+                 (self.gpr_aligned_seq_len, attn_aligned)],
                 prefill_program_addr, profile_checkpoints, tail_name="tail_halt",
                 worker_scheduler=prefill_scheduler,
                 worker_addrs=worker_program_addrs)
@@ -1244,7 +1347,7 @@ class Gemma4LMMixin:
             latency, flop_rate_program = self._dispatch_program(
                 [(self.gpr_seq_len,         seq_len),
                  (self.gpr_q_seq_len,       q_seq_len),
-                 (self.gpr_aligned_seq_len, aligned_seq_len)],
+                 (self.gpr_aligned_seq_len, attn_aligned)],
                 prefill_program_addr, timeout=300.0, flops=flops)
             for worker in prefill_scheduler.workers if prefill_scheduler is not None else []:
                 worker.wait_queue(300.0)
@@ -1489,6 +1592,16 @@ class Gemma4LMMixin:
                 bias_addr_layer = (self.LAYER0_FLASH_BIAS_FULL_DRAM
                                    if layer_idx in self._full_attention_layers
                                    else self.LAYER0_FLASH_BIAS_SLIDING_DRAM)
+                # GQA for decode (num_kv=1): all group_size query heads attend
+                # the SAME K/V, so they stack as the batch rows of ONE call —
+                # Q is [group_size, cur_head_dim] (decode RoPE laid the heads out
+                # contiguously), and the [group_size, cur_head_dim] output is
+                # exactly the row the O projection consumes. batch=group_size
+                # shares one Vᵀ transpose across all heads (a per-head batch=1
+                # loop would recompute that identical transpose group_size times).
+                # Multi-core will shard these group rows across engines
+                # (batch=shard_size per engine); this is the single-core (shard=
+                # group_size) case.
                 total_flops += self.unified_attention_core(
                     batch=self.group_size,
                     aligned_seq_len=seq_len,

--- a/models/gemma4_e2b/gemma4_e2b_lm.py
+++ b/models/gemma4_e2b/gemma4_e2b_lm.py
@@ -409,9 +409,10 @@ class Gemma4LMMixin:
         persistent region below _scratch_dram_base is untouched either way).
         ==================================================================
         """
-        seq_len = self.MAX_CONTEXT_SIZE
-        q_seq_len = seq_len * self.group_size
-        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        # KV state follows the full decode context. Token-major workspaces only
+        # need the largest prefill request; decode reuses them for one token.
+        activation_seq_len = max(self.max_prefill_seq_len, 1)
+        activation_q_seq_len = activation_seq_len * self.group_size
         # Unified attention scratch/bias buffers are largest during prefill,
         # but decode can still require MAX_CONTEXT_SIZE KV rows. Size the
         # shared attention buffers for the larger aligned dimension.
@@ -458,7 +459,7 @@ class Gemma4LMMixin:
         # by the vision stage (which now resets only to self._scratch_dram_base).
         # These must stay intact across vision -> prefill -> decode: KV cache,
         # constants, attention bias, and per-layer injection inputs.
-        pli_elements = self.MAX_CONTEXT_SIZE * self.LAYER_SIZE * self.per_layer_input_dim
+        pli_elements = activation_seq_len * self.LAYER_SIZE * self.per_layer_input_dim
         # KV cache (reused throughout prefill + decode).
         self.LAYER0_V_DRAM = self.allocate_tensor_dram(self._kv_cache_bytes)
         self.LAYER0_K_ROPE_DRAM = self.allocate_tensor_dram(self._kv_cache_bytes)
@@ -466,8 +467,8 @@ class Gemma4LMMixin:
         self.dma_to_accelerator_memory(self.LAYER0_V_DRAM, zero_pad)
         self.dma_to_accelerator_memory(self.LAYER0_K_ROPE_DRAM, zero_pad)
         # Constant zero tensor + identity matrix (read by many ops).
-        zero_add = torch.zeros(seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
-        self.ZERO_DRAM_ADDR = self.allocate_tensor_dram(seq_len * self.head_dim * self.bytes_per_element)
+        zero_add = torch.zeros(activation_seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
+        self.ZERO_DRAM_ADDR = self.allocate_tensor_dram(activation_seq_len * self.head_dim * self.bytes_per_element)
         self.dma_to_accelerator_memory(self.ZERO_DRAM_ADDR, zero_add)
         self.IDENTITY_DRAM_ADDR = self.allocate_tensor_dram(UE_VECTOR_SIZE * UE_VECTOR_SIZE * self.bytes_per_element)
         self.dma_to_accelerator_memory(self.IDENTITY_DRAM_ADDR, torch.eye(UE_VECTOR_SIZE, dtype=torch.bfloat16))
@@ -497,18 +498,23 @@ class Gemma4LMMixin:
         # (seq_len*group_size rows) and decode (MAX_CONTEXT_SIZE KV rows).
         self.LAYER0_FLASH_Q_DRAM = self.allocate_tensor_dram(attention_aligned_seq_len * self.head_dim * self.bytes_per_element)
         self.LAYER0_FLASH_K_DRAM = self.allocate_tensor_dram(attention_aligned_seq_len * self.head_dim * self.bytes_per_element)
-        self.LAYER0_FLASH_V_DRAM = self.allocate_tensor_dram(attention_aligned_seq_len * self.head_dim * self.bytes_per_element)
-        zero_pad = torch.zeros(attention_aligned_seq_len * self.head_dim * self.bytes_per_element, dtype=torch.bfloat16)
-        self.dma_to_accelerator_memory(self.LAYER0_FLASH_Q_DRAM, zero_pad)
-        self.dma_to_accelerator_memory(self.LAYER0_FLASH_K_DRAM, zero_pad)
-        self.dma_to_accelerator_memory(self.LAYER0_FLASH_V_DRAM, zero_pad)
+        self.LAYER0_FLASH_V_DRAM = self.allocate_tensor_dram(activation_seq_len * self.head_dim * self.bytes_per_element)
+        attention_zero_pad = torch.zeros(
+            attention_aligned_seq_len * self.head_dim * self.bytes_per_element,
+            dtype=torch.bfloat16)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_Q_DRAM, attention_zero_pad)
+        self.dma_to_accelerator_memory(self.LAYER0_FLASH_K_DRAM, attention_zero_pad)
+        self.dma_to_accelerator_memory(
+            self.LAYER0_FLASH_V_DRAM,
+            torch.zeros(activation_seq_len * self.head_dim * self.bytes_per_element,
+                        dtype=torch.bfloat16))
         # Layer intermediate tensors:
-        self.LAYER0_INPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_PRE_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_Q_DRAM = self.allocate_tensor_dram(seq_len * self.q_size)
-        self.LAYER0_K_DRAM = self.allocate_tensor_dram(seq_len * self.k_size)
-        self.LAYER0_K_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.k_size)
-        self.LAYER0_Q_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.q_size)
+        self.LAYER0_INPUT_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_PRE_NORM_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_Q_DRAM = self.allocate_tensor_dram(activation_q_seq_len * self.head_dim * self.bytes_per_element)
+        self.LAYER0_K_DRAM = self.allocate_tensor_dram(activation_seq_len * self.k_size)
+        self.LAYER0_K_NORM_DRAM = self.allocate_tensor_dram(activation_seq_len * self.k_size)
+        self.LAYER0_Q_NORM_DRAM = self.allocate_tensor_dram(activation_q_seq_len * self.head_dim * self.bytes_per_element)
         self.LAYER0_FLASH_OUTPUT_DRAM = self.allocate_tensor_dram(attention_aligned_seq_len * self.head_dim * self.bytes_per_element)
         # unified_attention_core scratch layout:
         #   V.T [HD, S] + scores [S, S] + scaled_q [batch, HD].
@@ -516,23 +522,23 @@ class Gemma4LMMixin:
         self.LAYER0_FLASH_SCRATCH_DRAM = self.allocate_tensor_dram(
             (attention_aligned_seq_len * attention_aligned_seq_len
              + 2 * self.head_dim * attention_aligned_seq_len) * self.bytes_per_element)
-        self.LAYER0_ATTN_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_POST_ATTN_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_POST_ATTN_RESIDUAL_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_PRE_MLP_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_ATTN_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_POST_ATTN_NORM_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_POST_ATTN_RESIDUAL_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_PRE_MLP_NORM_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
         mlp_max = max(self.mlp_elements, self.mlp_elements_wide)
-        self.LAYER0_MLP_GATE_DRAM = self.allocate_tensor_dram(seq_len * mlp_max * 2)
-        self.LAYER0_MLP_UP_DRAM = self.allocate_tensor_dram(seq_len * mlp_max * 2)
-        self.LAYER0_MLP_MULT_DRAM = self.allocate_tensor_dram(seq_len * mlp_max * 2)
-        self.LAYER0_MLP_DOWN_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_POST_MLP_NORM_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
-        self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * 2)
+        self.LAYER0_MLP_GATE_DRAM = self.allocate_tensor_dram(activation_seq_len * mlp_max * 2)
+        self.LAYER0_MLP_UP_DRAM = self.allocate_tensor_dram(activation_seq_len * mlp_max * 2)
+        self.LAYER0_MLP_MULT_DRAM = self.allocate_tensor_dram(activation_seq_len * mlp_max * 2)
+        self.LAYER0_MLP_DOWN_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_POST_MLP_NORM_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
+        self.LAYER0_OUTPUT_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * 2)
         self.OUTPUT_NORM_DRAM = self.allocate_tensor_dram(1 * self.vector_length * self.bytes_per_element)
         self.LOGITS_DRAM = self.allocate_tensor_dram(1 * self.EMBEDDING_ELEMENTS * self.bytes_per_element)
         # Per-layer injection intermediates (scratch).
         self.PER_LAYER_MODEL_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(pli_elements * self.bytes_per_element)
-        self.LAYER0_PER_LAYER_GATE_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.per_layer_input_dim * self.bytes_per_element)
-        self.LAYER0_PER_LAYER_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(seq_len * self.vector_length * self.bytes_per_element)
+        self.LAYER0_PER_LAYER_GATE_OUTPUT_DRAM = self.allocate_tensor_dram(activation_seq_len * self.per_layer_input_dim * self.bytes_per_element)
+        self.LAYER0_PER_LAYER_PROJ_OUTPUT_DRAM = self.allocate_tensor_dram(activation_seq_len * self.vector_length * self.bytes_per_element)
 
         if self.get_tensor_dram_addr() > self.VISION_ISA_BASE:
             raise RuntimeError(
@@ -1225,7 +1231,10 @@ class Gemma4LMMixin:
         _flash_zero = torch.zeros(flash_qkv_elems, dtype=torch.bfloat16)
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_Q_DRAM, _flash_zero)
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_K_DRAM, _flash_zero)
-        self.dma_to_accelerator_memory(self.LAYER0_FLASH_V_DRAM, _flash_zero)
+        self.dma_to_accelerator_memory(
+            self.LAYER0_FLASH_V_DRAM,
+            torch.zeros(self.max_prefill_seq_len * self.head_dim,
+                        dtype=torch.bfloat16))
         self.dma_to_accelerator_memory(self.IDENTITY_DRAM_ADDR,
                                        torch.eye(_UE_VS, dtype=torch.bfloat16))
         print(f"[Prefill] LM-state restored ({num_slots} KV slots zeroed, IDENTITY re-uploaded)")

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -29,24 +29,25 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 
 ## Performance comparison
 
-| Metric | Legacy | Kintex | Kintex GQA | Kintex 2-core | rk (outdated) | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
+| Metric | Legacy | Kintex | Kintex GQA | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 53.78 s | 53.78 s | 27.78 s | 32.56 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.77 s** |
-| Vision end-to-end path | not reported | 54.32 s | 54.35 s | 28.57 s | 33.03 s | **35.98 s** | **19.6 s** | **10.93 s** | **7.92 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 21.37 GFLOPS | 41.37 GFLOPS | 35.00 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.99 GFLOPS** | **240.88 GFLOPS** |
+| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS | 25.39 GFLOPS | 50.77 GFLOPS | 42.67 GFLOPS | 46.93 GFLOPS | 93.87 GFLOPS | 187.73 GFLOPS | 375.47 GFLOPS |
+| Vision FPGA execution | 55.54 s | 53.78 s | 53.78 s | 27.78 s | 32.05 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.77 s** |
+| Vision end-to-end path | not reported | 54.32 s | 54.43 s | 28.54 s | 33.05 s | **35.98 s** | **19.6 s** | **10.93 s** | **7.92 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 21.37 GFLOPS | 41.41 GFLOPS | 35.85 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.99 GFLOPS** | **240.88 GFLOPS** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
 | LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 43.95 s | 23.46 s | 32.544 s | **28.23 s** | **17.3 s** | **6.88 s** | **3.96 s** |
-| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 24.08 GFLOPS | 45.12 GFLOPS | 37.89 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **153.92 GFLOPS** | **267.16 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.79 tok/s | 3.76 tok/s | 6.00 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.55 tok/s** | **5.56 tok/s** |
-| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.00 tok/s | 4.00 tok/s | 6.23 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.91 tok/s** | **5.87 tok/s** |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.97 GFLOPS | 18.88 GFLOPS | 30.45 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.41 GFLOPS** | **34.41 GFLOPS** |
-| Vision program section | 3.58 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | / | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
-| Prefill program section | 5.71 MiB | 3.08 MiB | 5.85 MiB | 4.77 MiB | / | 3.08 MiB | 3.46 MiB | 4.06 MiB | 3.72 MiB |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 43.95 s | 23.46 s | 28.02 s | **28.23 s** | **17.3 s** | **6.88 s** | **3.96 s** |
+| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 24.08 GFLOPS | 45.13 GFLOPS | 37.78 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **153.92 GFLOPS** | **267.16 GFLOPS** |
+| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.75 tok/s | 3.76 tok/s | 5.69 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.55 tok/s** | **5.56 tok/s** |
+| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.00 tok/s | 4.00 tok/s | 6.04 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.91 tok/s** | **5.87 tok/s** |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.97 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.41 GFLOPS** | **34.41 GFLOPS** |
+| Vision program section | 3.58 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | 3.4 MiB | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
+| Prefill program section | 5.71 MiB | 3.08 MiB | 5.85 MiB | 4.77 MiB | 5.9 MiB | 3.08 MiB | 3.46 MiB | 4.06 MiB | 3.72 MiB |
 | Decode program section | | 1.42 MiB | 1.42 MiB | 1.42 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
-| Combined program image | 10.37 MiB | 7.73 MiB | 10.49 MiB | 13.73 MiB | / | 7.73 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
+| Combined program image | 10.37 MiB | 7.73 MiB | 10.49 MiB | 13.73 MiB | 10.8 MiB | 7.73 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
 | Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
-| Correctness |  | coherent, total 724 | coherent, total 656 | coherent, total 709 | not recorded | coherent, total 724 | coherent, total 709 | coherent, total 699 | coherent, total 699 |
+| Correctness |  | coherent, total 724 | coherent, total 656 | coherent, total 699 | coherent, total 656 | coherent, total 656 | coherent, total 699 | coherent, total 699 | coherent, total 699 |
 
 ## Refactor optimizations
 

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -29,39 +29,24 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 
 ## Performance comparison
 
-| Metric | Legacy | Kintex | Kintex 2-core | rk (outdated) | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|
-| Vision FPGA execution | 55.54 s | 53.78 s | 27.77s | 32.56 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.82 s** |
-| Vision end-to-end path | not reported | 54.32 s | 28.58s | 33.03 s | **35.98 s** | **19.6 s** | **10.91 s** | **7.95 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 41.38 GFLOPS | 35.00 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.98 GFLOPS** | **238.56 GFLOPS** |
-| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
-| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 31.87s | 32.544 s | **28.23 s** | **17.3 s** | **11.60 s** | **8.81 s** |
-| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 38.76 GFLOPS | 37.89 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **106.32 GFLOPS** | **139.90 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.76 tok/s | 6.00 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.50 tok/s** | **5.49 tok/s** |
-| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.0 tok/s | 6.23 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.90 tok/s** | **5.87 tok/s** |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.85 GFLOPS | 30.45 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.03 GFLOPS** | **33.97 GFLOPS** |
-| Vision program section | 3.58 MiB | 3.22 MiB | 2.39 MiB | / | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
-| Prefill program section | 5.71 MiB | 3.08 MiB | 3.46 MiB | / | 3.08 MiB | 3.46 MiB | 3.39 MiB | 3.41 MiB |
-| Decode program section | | 1.42 MiB | 1.46 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
-| Combined program image | 10.37 MiB | 7.73 MiB | 10.81 MiB | / | 7.73 MiB | 10.81 MiB | 16.10 MiB | 26.92 MiB |
-| Weight image (`params.bin`) | 6.91 GiB | same | same | / | same | same | same | same |
-| Correctness |  | coherent, total 724 | coherent, total 709 | not recorded | coherent, total 724 | coherent, total 709 | coherent, total 709 | coherent, total 709 |
-
-The four Alveo columns were refreshed on 2026-08-17 against HW version
-`0x6bb5d25d`, with `make clean` before every run. All four produced coherent
-Yosemite descriptions and reached the stop token. Worker attention scratch now
-aliases output-only regions that are dead during attention and fully overwritten
-before later reads, allowing the complete eight-engine image path to fit in the
-32-bit DRAM window without overlapping vision weights or worker ISA.
-
-The Kintex 2-core column is from a 2026-08-17 `--multi-core` run with vision
-attention heads sharded across both engines, replacing the older projection-only
-multicore measurements. This nearly halves the vision encoder (53.78 → 28.09 s)
-and substantially reduces prefill (51.52 → 31.78 s) versus single-core. The
-current run produced a coherent Yosemite description and reached the stop token
-on the accepted `0x3d04c689` bitstream. The combined program image includes both
-engines; the vision and prefill section rows report the master sections.
+| Metric | Legacy | Kintex | Kintex GQA | Kintex 2-core | rk (outdated) | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Vision FPGA execution | 55.54 s | 53.78 s | 53.78 s | 27.78 s | 32.56 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.77 s** |
+| Vision end-to-end path | not reported | 54.32 s | 54.35 s | 28.57 s | 33.03 s | **35.98 s** | **19.6 s** | **10.93 s** | **7.92 s** |
+| Vision throughput | not reported | 21.37 GFLOPS | 21.37 GFLOPS | 41.37 GFLOPS | 35.00 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.99 GFLOPS** | **240.88 GFLOPS** |
+| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
+| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
+| LM prefill FPGA latency | 113.571 s | 51.52 s | 43.95 s | 23.46 s | 32.544 s | **28.23 s** | **17.3 s** | **6.88 s** | **3.96 s** |
+| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 24.08 GFLOPS | 45.12 GFLOPS | 37.89 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **153.92 GFLOPS** | **267.16 GFLOPS** |
+| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.79 tok/s | 3.76 tok/s | 6.00 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.55 tok/s** | **5.56 tok/s** |
+| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.00 tok/s | 4.00 tok/s | 6.23 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.91 tok/s** | **5.87 tok/s** |
+| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.97 GFLOPS | 18.88 GFLOPS | 30.45 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.41 GFLOPS** | **34.41 GFLOPS** |
+| Vision program section | 3.58 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | / | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
+| Prefill program section | 5.71 MiB | 3.08 MiB | 5.85 MiB | 4.77 MiB | / | 3.08 MiB | 3.46 MiB | 4.06 MiB | 3.72 MiB |
+| Decode program section | | 1.42 MiB | 1.42 MiB | 1.42 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
+| Combined program image | 10.37 MiB | 7.73 MiB | 10.49 MiB | 13.73 MiB | / | 7.73 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
+| Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
+| Correctness |  | coherent, total 724 | coherent, total 656 | coherent, total 709 | not recorded | coherent, total 724 | coherent, total 709 | coherent, total 699 | coherent, total 699 |
 
 ## Refactor optimizations
 
@@ -91,19 +76,7 @@ engines; the vision and prefill section rows report the master sections.
 - Add checkpointed profile images for vision, prefill, and decode without
   changing the normal execution image.
 
-Profile tables below are fresh `--profile` runs (`--dev xdma1`, 2026-08-17), rows
-in **compile order**. `--multi-core 2` uses per-phase multi-core profiling: the
-master's per-segment HW latency counter, with checkpoints at the sharded-region
-boundaries so each region's segment measures its fork-to-join wall-time.
-**Vision** now shards three regions — Projection, **Attention (head-sharded)**,
-and Post-attention — so all three ~halve (this is the change behind the faster
-28.09 s Kintex 2-core vision; the old table had vision attention engine-invariant).
-**Prefill** shards only its two matmul-heavy regions (QKV/V + MLP); its attention
-and per-layer prep stay master-only. The norm/RoPE/permute/gather phases are
-master-only and engine-invariant in both stages. Decode is single-engine (never
-sharded), so its multi-core breakdown equals single-core.
-
-## Profile backup: vision encoder
+## Profile backup: vision encoder (kintex7)
 
 Vision multi-core segments tile cleanly (they sum to the single-shot master total),
 so the per-phase `--multi-core 2` numbers are exact.
@@ -122,36 +95,26 @@ so the per-phase `--multi-core 2` numbers are exact.
 
 † row-sharded across 2 engines
 
-## Profile backup: LM prefill
+## Profile backup: LM prefill (kintex7)
 
-Prefill folds O projection into the MLP phase so single-core matches the multi-core
-O+MLP sharded region. Only **QKV/V projection** and **MLP (incl. O)** are sharded
-(†) — the rest are master-only and engine-invariant. Under two-engine the master's
-per-segment counter mis-times the two *long* master-only phases (per-layer prep,
-attention), so those rows show their single-core value (which is the true
-multi-core value — they run identically on the master). The reconstructed
-multi-core total (31,782 ms) matches the single-shot master counter (31,782.7 ms
-from the Kintex 2-core prefill run), confirming it.
-
-| Phase | Single-core | --multi-core 2 |
-|---|---:|---:|
-| Per-layer preparation ‡ | 596.0 ms | 596.0 ms |
-| QKV/V projection † | 3,302.5 ms | **1,682.3 ms** |
-| RoPE | 162.6 ms | 162.6 ms |
-| KV gather | 70.0 ms | 70.0 ms |
-| Attention ‡ | 9,268.7 ms | 9,268.7 ms |
-| MLP (incl. O projection) † | 37,426.6 ms | **19,309.4 ms** |
-| Injection | 694.2 ms | 694.2 ms |
-| Tail halt | 0.0 ms | 0.0 ms |
-| **Total** | **51,520.6 ms** | **31,782.4 ms** |
+| Phase | Single-core | --multi-core 2 | Single-core GQA | --multi-core 2 GQA |
+|---|---:|---:|---:|---:|
+| Per-layer preparation ‡ | 596.0 ms | 596.0 ms | 596.0 ms | 0.0 ms |
+| QKV/V projection † | 3,302.5 ms | **1,682.3 ms** | 3,302.5 ms | **1,693.6 ms** |
+| RoPE | 162.6 ms | 162.6 ms | 162.6 ms | 162.5 ms |
+| KV gather | 70.0 ms | 70.0 ms | 0.1 ms | 0.1 ms |
+| Q permute | — | — | 75.2 ms | 75.3 ms |
+| Attention † | 9,268.7 ms | 9,268.7 ms | 1,697.2 ms | **906.3 ms** |
+| MLP (incl. O projection) † | 37,426.6 ms | **19,309.4 ms** | 37,426.7 ms | **19,331.5 ms** |
+| Injection | 694.2 ms | 694.2 ms | 694.2 ms | 694.2 ms |
+| Tail halt | 0.0 ms | 0.0 ms | 0.0 ms | 0.0 ms |
+| **Total** | **51,520.6 ms** | **31,782.4 ms** | **43,954.5 ms** | **22,863.3 ms** |
 
 † row-sharded across 2 engines (these ~halve).
 
-## Profile backup: one decode token at position 272
+## Profile backup: one decode token at position 272 (kintex7) no multicore usecase in decoder
 
-Decode is single-engine; `--multi-core 2` is identical (245.3 ms total).
-
-| Phase | Single-core |
+| Phase | Single-core | 
 |---|---:|
 | Per-layer preparation | 5.6 ms |
 | QKV/V projection | 13.2 ms |
@@ -164,8 +127,3 @@ Decode is single-engine; `--multi-core 2` is identical (245.3 ms total).
 | LM head | 34.8 ms |
 | Tail increment | 0.0 ms |
 | **Total** | **245.3 ms** |
-
-The profiled single-token throughput is ~4.08 tok/s. Checkpoint HALTs add
-instrumentation control flow, so the refreshed normal-run average (3.74 tok/s
-single-core, 3.75 tok/s Kintex 2-core) remains the end-to-end decode result to use for
-user-visible throughput.

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -74,6 +74,17 @@ builtins.print = quiet_print
 DEFAULT_IMAGE = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "..", "test_samples", "yosemite.jpg"))
 DEFAULT_AUDIO = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "..", "test_samples", "apex.wav"))
 
+# Static context-capacity switch. Change this single constant to 1024, 2048,
+# 3072, or 4096 when building a program image; tensor allocation and decoder
+# bounds follow it consistently. The JSON value is checked against this choice.
+MAX_CONTEXT_SIZE = 4096
+
+# Context is a static capacity setting in gemma4_e2b_config.json. Keep the
+# supported range explicit because tensor sizing and address arithmetic assume
+# 64-token alignment and the fixed 32-bit DRAM layouts below.
+MIN_CONTEXT_SIZE = 1024
+MAX_CONTEXT_SIZE = 4096
+
 
 def _parse_offset(val) -> int:
     """Parse offset/size from JSON: int or hex string like '0x24000000'."""
@@ -828,7 +839,17 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         self.mlp_elements_wide = fi.get("mlp_elements_wide", fi["mlp_elements"])
         self.q_size = self.head_dim * self.group_size * self.bytes_per_element
         self.k_size = self.head_dim * self.bytes_per_element
-        self.MAX_CONTEXT_SIZE = model["max_context_size"]
+        self.MAX_CONTEXT_SIZE = MAX_CONTEXT_SIZE
+        # Keep fallback config lookups (for example sliding_window) consistent
+        # when the source macro is changed without editing the JSON file.
+        model["max_context_size"] = MAX_CONTEXT_SIZE
+        if (self.MAX_CONTEXT_SIZE < MIN_CONTEXT_SIZE
+                or self.MAX_CONTEXT_SIZE > MAX_CONTEXT_SIZE
+                or self.MAX_CONTEXT_SIZE % 64):
+            raise ValueError(
+                f"max_context_size must be a 64-aligned value in "
+                f"[{MIN_CONTEXT_SIZE}, {MAX_CONTEXT_SIZE}], got "
+                f"{self.MAX_CONTEXT_SIZE}")
         self.LAYER_SIZE = fi["num_layers"]
         self.EMBEDDING_ELEMENTS = fi["embedding_vocab"]
         self._isa_reg_counter = 1
@@ -866,6 +887,10 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         # of max_context_size. Decode may still need MAX_CONTEXT_SIZE KV rows, so
         # tensor_init sizes shared attention buffers for the larger aligned shape.
         self.max_prefill_seq_len = model.get("max_prefill_seq_len", model["max_context_size"])
+        if self.max_prefill_seq_len > self.MAX_CONTEXT_SIZE:
+            raise ValueError(
+                f"max_prefill_seq_len ({self.max_prefill_seq_len}) cannot exceed "
+                f"max_context_size ({self.MAX_CONTEXT_SIZE})")
         # KV sharing map: built from HF model during weight_init
         self._kv_shared_map = {}  # layer_idx -> reference_layer_idx (populated in weight_init)
         self._gamma_bin_offset = self._cfg["special"]["rms_norm"]["gamma_offset"]


### PR DESCRIPTION
## Test setup
Commands:

```bash
python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image
python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --profile
python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core
python models/gemma4_e2b/gemma4_e2b_test.py --dev xdma1 --image --multi-core --profile
python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image
python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core
python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 4
python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 8
```
## Performance comparison

| Metric | Legacy | Kintex | Kintex GQA | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS | 25.39 GFLOPS | 50.77 GFLOPS | 42.67 GFLOPS | 46.93 GFLOPS | 93.87 GFLOPS | 187.73 GFLOPS | 375.47 GFLOPS |
| Vision FPGA execution | 55.54 s | 53.78 s | 53.78 s | 27.78 s | 32.05 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.77 s** |
| Vision end-to-end path | not reported | 54.32 s | 54.43 s | 28.54 s | 33.05 s | **35.98 s** | **19.6 s** | **10.93 s** | **7.92 s** |
| Vision throughput | not reported | 21.37 GFLOPS | 21.37 GFLOPS | 41.41 GFLOPS | 35.85 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.99 GFLOPS** | **240.88 GFLOPS** |
| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
| LM prefill FPGA latency | 113.571 s | 51.52 s | 43.95 s | 23.46 s | 28.02 s | **28.23 s** | **17.3 s** | **6.88 s** | **3.96 s** |
| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 24.08 GFLOPS | 45.13 GFLOPS | 37.78 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **153.92 GFLOPS** | **267.16 GFLOPS** |
| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.75 tok/s | 3.76 tok/s | 5.69 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.55 tok/s** | **5.56 tok/s** |
| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.00 tok/s | 4.00 tok/s | 6.04 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.91 tok/s** | **5.87 tok/s** |
| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.97 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.41 GFLOPS** | **34.41 GFLOPS** |
| Vision program section | 3.58 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | 3.4 MiB | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
| Prefill program section | 5.71 MiB | 3.08 MiB | 5.85 MiB | 4.77 MiB | 5.9 MiB | 3.08 MiB | 3.46 MiB | 4.06 MiB | 3.72 MiB |
| Decode program section | | 1.42 MiB | 1.42 MiB | 1.42 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
| Combined program image | 10.37 MiB | 7.73 MiB | 10.49 MiB | 13.73 MiB | 10.8 MiB | 7.73 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
| Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
| Correctness |  | coherent, total 724 | coherent, total 656 | coherent, total 699 | coherent, total 656 | coherent, total 656 | coherent, total 699 | coherent, total 699 | coherent, total 699 |

## Profile backup: vision encoder (kintex7)

Vision multi-core segments tile cleanly (they sum to the single-shot master total),
so the per-phase `--multi-core 2` numbers are exact.

| Phase | Single-core | --multi-core 2 |
|---|---:|---:|
| Patch embedding | 123.6 ms | 123.6 ms |
| Projection (Q/K/V) † | 6,682.4 ms | **3,361.0 ms** |
| RoPE | 1,072.8 ms | **740.0 ms** |
| Permute | 269.6 ms | 269.6 ms |
| Attention † | 16,642.2 ms | **8,664.7 ms** |
| Post-attention (O + MLP) † | 28,911.4 ms | **14,541.1 ms** |
| Pooler tail | 75.3 ms | 75.3 ms |
| Tail | 0.0 ms | 0.0 ms |
| **Total** | **53,777.3 ms** | **27,775 ms** |

† row-sharded across 2 engines

## Profile backup: LM prefill (kintex7)

| Phase | Single-core | --multi-core 2 | Single-core GQA | --multi-core 2 GQA |
|---|---:|---:|---:|---:|
| Per-layer preparation ‡ | 596.0 ms | 596.0 ms | 596.0 ms | 0.0 ms |
| QKV/V projection † | 3,302.5 ms | **1,682.3 ms** | 3,302.5 ms | **1,693.6 ms** |
| RoPE | 162.6 ms | 162.6 ms | 162.6 ms | 162.5 ms |
| KV gather | 70.0 ms | 70.0 ms | 0.1 ms | 0.1 ms |
| Q permute | — | — | 75.2 ms | 75.3 ms |
| Attention † | 9,268.7 ms | 9,268.7 ms | 1,697.2 ms | **906.3 ms** |
| MLP (incl. O projection) † | 37,426.6 ms | **19,309.4 ms** | 37,426.7 ms | **19,331.5 ms** |
| Injection | 694.2 ms | 694.2 ms | 694.2 ms | 694.2 ms |
| Tail halt | 0.0 ms | 0.0 ms | 0.0 ms | 0.0 ms |
| **Total** | **51,520.6 ms** | **31,782.4 ms** | **43,954.5 ms** | **22,863.3 ms** |

† row-sharded across 2 engines (these ~halve).

## Profile backup: one decode token at position 272 (kintex7) no multicore usecase in decoder

| Phase | Single-core | 
|---|---:|
| Per-layer preparation | 5.6 ms |
| QKV/V projection | 13.2 ms |
| RoPE | 1.0 ms |
| KV gather | 0.1 ms |
| Attention | 30.5 ms |
| O projection | 11.8 ms |
| MLP | 135.8 ms |
| Injection | 12.6 ms |
| LM head | 34.8 ms |
| Tail increment | 0.0 ms |
| **Total** | **245.3 ms** |