### PR TITLE
Proper GQA for gemma3 and llama3.2_1b and corrections for alveo multicore benchmarking

### DIFF
--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -567,6 +567,54 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         self._zero_dram_bf16(self.LAYER0_FLASH_K_DRAM, elements)
         self._zero_dram_bf16(self.LAYER0_FLASH_V_DRAM, elements)
 
+    def _emit_strided_copy_pbi(self, src_base: int, dst_base: int, copy_elems: int,
+                               src_row_bytes: int, dst_row_bytes: int,
+                               n_template: int, gpr_loop: int,
+                               sram_addr: int = 0x10000) -> None:
+        """PBI hardware loop: for ``n_template`` rows (runtime trip count =
+        ``gpr_loop``) copy ``copy_elems`` bf16 from ``src_base`` to ``dst_base``,
+        advancing the source DRAM addr by ``src_row_bytes`` and the dest by
+        ``dst_row_bytes`` each iteration (both register-computed → arbitrary,
+        independent strides). Used to permute prefill Q between token-major and
+        head-major layouts for the proper-GQA per-head attention loop. Bases are
+        layer-invariant FLASH_* scratch, so they are baked compile-time constants."""
+        i_reg = self.alloc_isa_reg()
+        self.generate_instruction_add_set(i_reg, 0)
+        self.loop_start(loop_cnt=n_template, gpr_loop_cnt=gpr_loop)
+        self.generate_instruction_reg_mul_imm(
+            self.TMP_REG, i_reg, ue_35bit_addr_shifter(src_row_bytes))
+        self.generate_instruction_add_imm(
+            self.TMP_REG, ue_35bit_addr_shifter(src_base), self.TMP_REG)
+        self.accelerator_memory_to_sram(
+            accelerator_dram_address=0, sram_address=sram_addr,
+            element_size=copy_elems, general_reg_src=self.TMP_REG)
+        self.generate_instruction_reg_mul_imm(
+            self.TMP_REG, i_reg, ue_35bit_addr_shifter(dst_row_bytes))
+        self.generate_instruction_add_imm(
+            self.TMP_REG, ue_35bit_addr_shifter(dst_base), self.TMP_REG)
+        self.sram_to_accelerator_memory(
+            sram_address=sram_addr, accelerator_dram_address=0,
+            element_size=copy_elems, general_reg_src=self.TMP_REG)
+        self.generate_instruction_add_inc(i_reg)
+        self.loop_end()
+        self.release_isa_reg()       # i_reg
+
+    def _emit_strided_copy_static(self, src_base: int, dst_base: int, copy_elems: int,
+                                  src_row_bytes: int, dst_row_bytes: int,
+                                  n_rows: int, sram_addr: int = 0x10000) -> None:
+        """Compile-time (Python-unrolled) equivalent of :meth:`_emit_strided_copy_pbi`
+        for the legacy static-unrolled prefill path, which is deliberately ISA-loop
+        free (no backward-branch jumps → no 512-instruction i-cache window concern).
+        Copies ``n_rows`` rows of ``copy_elems`` bf16 via a shared SRAM staging cell,
+        advancing src/dst by their own byte strides each row."""
+        for i in range(n_rows):
+            self.accelerator_memory_to_sram(
+                src_base + i * src_row_bytes, sram_addr, copy_elems)
+            self.sram_to_accelerator_memory(
+                sram_address=sram_addr,
+                accelerator_dram_address=dst_base + i * dst_row_bytes,
+                element_size=copy_elems)
+
     def _compile_prefill_program(self, prefill_seq_len: int, layer_size: int = 26, use_pbi: bool = False, profile: bool = False) -> dict:
         """
         Compile a single prefill program and return its metadata (start_addr, size_bytes, flops).
@@ -608,6 +656,10 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         seq_len = prefill_seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
+        # Proper-GQA per-head attention runs over the compact (seq_len-long) KV, so
+        # its static batch/aligned are seq_len / align64(seq_len), not the q_seq_len
+        # values (which only size the token-major Q/OUTPUT scratch buffers).
+        aligned_seq_len = ((seq_len + 63) // 64) * 64
         checkpoints: list[list] = []
 
         def _checkpoint(name: str) -> None:
@@ -1019,55 +1071,77 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                 if profile:
                     _checkpoint("qk_norm_rope")
 
-                # Pre-flash-attn layout:
-                # Q: [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                # K/V cache: [seq_len, head_dim]; duplicate each token row group_size times for GQA. [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                duplicate_gqa_rows_pbi(
-                    self.LAYER0_K_ROPE_DRAM,
-                    self.LAYER0_FLASH_K_DRAM,
-                    0x10000,
-                    self.gpr_seq_len,
-                    gpr_src_addr=kv_addr(self.LAYER0_K_ROPE_DRAM, gpr_scratch_a),
-                    gpr_dst_addr=const_addr(self.LAYER0_FLASH_K_DRAM, gpr_scratch_b),
-                )
-                duplicate_gqa_rows_pbi(
-                    self.LAYER0_V_DRAM,
-                    self.LAYER0_FLASH_V_DRAM,
-                    0x20000,
-                    self.gpr_seq_len,
-                    gpr_src_addr=kv_addr(self.LAYER0_V_DRAM, gpr_scratch_a),
-                    gpr_dst_addr=const_addr(self.LAYER0_FLASH_V_DRAM, gpr_scratch_b),
-                )
+                # ---- Proper GQA: an outer loop over the group's query heads ----
+                # Standard GQA: the group_size query heads all attend the SAME K/V
+                # head (num_kv=1). Instead of replicating the compact per-layer K/V
+                # cache group_size times and running ONE attention over a
+                # q_seq_len=(seq_len*group_size)-long KV dimension — which spends
+                # group_size x the score-matrix FLOPs and DMA — the K/V are read
+                # straight from the compact per-layer cache (seq_len rows) and one
+                # SDPA is run per query head, reusing that shared K/V. This turns the
+                # attention cost from O((seq_len*group_size)^2) into
+                # group_size * O(seq_len^2) — a group_size-fold reduction.
+                head_bytes = self.head_dim * self.bytes_per_element
+                per_head_rows = ((self.PREFILL_MAX_SEQ_LEN + 63) // 64) * 64
+                qhm_head_bytes = per_head_rows * head_bytes
+                # Q token-major -> head-major (into freed FLASH_K per-head slots).
+                for g in range(self.group_size):
+                    self._emit_strided_copy_pbi(
+                        self.LAYER0_FLASH_Q_DRAM + g * head_bytes,        # token-major head g
+                        self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,    # head-major head g
+                        self.head_dim,
+                        self.group_size * head_bytes,                     # token-major row stride
+                        head_bytes,                                       # head-major contiguous
+                        seq_len, self.gpr_seq_len)
 
-                # Attention reads/writes the LAYER-INVARIANT flash-scratch buffers (LAYER0_FLASH_*),
-                # which are the same physical DRAM every layer. head_dim is a model constant, so it is
-                # kept BAKED (no gpr_head_dim_reg) — the V transpose and Q pre-scale then take their
-                # validated dynamic-M / N-baked paths. Only batch (q_seq_len) and aligned_seq_len are
-                # runtime. The Q/K/V/bias/out bases are sourced from GPRs (const_addr — same invariant
-                # address, the identical gpr-address path the decoder fold uses for per-layer KV) and
-                # the 1/sqrt(head_dim) scale from gpr_attn_scale (arithmetic PBI field 11; baked scalar is the
-                # fallback, so it's correct on both bitstreams).
-                flash_attention_result = self.unified_attention_core(
-                    batch=q_seq_len,
-                    aligned_seq_len=self.FLASH_ATTN_ROWS,
-                    head_dim=self.head_dim,
-                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
-                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                    gpr_batch_reg=self.gpr_q_seq_len,
-                    gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                    gpr_q_addr=const_addr(self.LAYER0_FLASH_Q_DRAM, gpr_scratch_a),
-                    gpr_k_addr=const_addr(self.LAYER0_FLASH_K_DRAM, gpr_scratch_b),
-                    gpr_v_addr=const_addr(self.LAYER0_FLASH_V_DRAM, gpr_scratch_c),
-                    gpr_bias_addr=const_addr(self.LAYER0_FLASH_BIAS_DRAM, gpr_scratch_d),
-                    gpr_out_addr=const_addr(self.LAYER0_FLASH_OUTPUT_DRAM, gpr_scratch_e),
-                    gpr_scale_reg=gpr_attn_scale,
-                )
-                total_flops += flash_attention_result or 0
+                # head_dim is a model constant, so it is kept BAKED (no gpr_head_dim_reg)
+                # — the V transpose and Q pre-scale then take their validated
+                # dynamic-M / N-baked paths. Only batch (seq_len) and aligned_seq_len
+                # (align64(seq_len)) are runtime. K/V bases are sourced from the
+                # per-layer KV GPR (kv_addr — the identical gpr-address path the
+                # decoder fold uses); Q/OUT/bias bases are layer-invariant scratch
+                # (const_addr); the 1/sqrt(head_dim) scale from gpr_attn_scale.
+                for g in range(self.group_size):
+                    head_slot = self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes
+                    flash_attention_result = self.unified_attention_core(
+                        batch=seq_len,
+                        # aligned_seq_len is the compile-time MAX per-head aligned KV
+                        # length (per_head_rows = align64(PREFILL_MAX_SEQ_LEN)); it sizes
+                        # the core's scratch sub-buffers (Vᵀ / score / scaled_q) so they
+                        # never overlap at any runtime length. The real KV length is
+                        # primed into gpr_aligned_seq_len at run time (dynamic path), and
+                        # the caller owns the SCRATCH buffer (LAYER0_FLASH_SCRATCH_DRAM,
+                        # sized for the max). Keeping this at the per-head max (not the
+                        # duplicated q_seq_len) is what makes the reserved scratch and the
+                        # reported attention FLOPs match the compact per-head shapes.
+                        aligned_seq_len=per_head_rows,
+                        head_dim=self.head_dim,
+                        Q_DRAM_ADDR=head_slot,
+                        K_DRAM_ADDR=self.LAYER0_K_ROPE_DRAM,
+                        V_DRAM_ADDR=self.LAYER0_V_DRAM,
+                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                        OUTPUT_DRAM_ADDR=head_slot,
+                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                        gpr_batch_reg=self.gpr_seq_len,
+                        gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
+                        gpr_q_addr=const_addr(head_slot, gpr_scratch_a),
+                        gpr_k_addr=kv_addr(self.LAYER0_K_ROPE_DRAM, gpr_scratch_b),
+                        gpr_v_addr=kv_addr(self.LAYER0_V_DRAM, gpr_scratch_c),
+                        gpr_bias_addr=const_addr(self.LAYER0_FLASH_BIAS_DRAM, gpr_scratch_d),
+                        gpr_out_addr=const_addr(head_slot, gpr_scratch_e),
+                        gpr_scale_reg=gpr_attn_scale,
+                    )
+                    total_flops += flash_attention_result or 0
+                # head-major OUT -> token-major FLASH_OUTPUT for the O projection.
+                for g in range(self.group_size):
+                    self._emit_strided_copy_pbi(
+                        self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,    # head-major head g
+                        self.LAYER0_FLASH_OUTPUT_DRAM + g * head_bytes,   # token-major head g
+                        self.head_dim,
+                        head_bytes,                                       # head-major contiguous
+                        self.group_size * head_bytes,                     # token-major row stride
+                        seq_len, self.gpr_seq_len)
                 if profile:
                     _checkpoint("attention")
             total_flops += prefill_projection_core(
@@ -1345,38 +1419,53 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                         gpr_M_reg=None,
                     )
                 
-                    # Pre-flash-attn layout:
-                    # Q: [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                    # K/V cache: [seq_len, head_dim]; duplicate each token row group_size times for GQA. [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                    # TODO: generate register for dram addr over layer_idx loop.
-                    duplicate_gqa_rows_pbi(
-                        self.LAYER0_K_ROPE_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size,
-                        self.LAYER0_FLASH_K_DRAM,
-                        0x10000,
-                        None,
-                    )
-                    duplicate_gqa_rows_pbi(
-                        self.LAYER0_V_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size,
-                        self.LAYER0_FLASH_V_DRAM,
-                        0x20000,
-                        None,
-                    )
-
-                    flash_attention_result = self.unified_attention_core(
-                        batch=q_seq_len,
-                        aligned_seq_len=aligned_seq_len_q,
-                        head_dim=self.head_dim,
-                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                        K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                        V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
-                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                        gpr_batch_reg=None,
-                        gpr_aligned_seq_len_reg=None,
-                    )
-                    total_flops += flash_attention_result or 0
+                    # ---- Proper GQA (legacy static-unrolled path) ----
+                    # Same correctness fix as the folded path: no K/V duplication.
+                    # seq_len is a compile-time constant here (legacy bakes it), so
+                    # the per-head permutes + attention use static addresses and the
+                    # static (Python-unrolled) copy helper — no ISA loops, matching
+                    # the legacy path's loop-free style. Q token-major -> head-major
+                    # into freed FLASH_K per-head slots; one attention per head over
+                    # the compact per-layer K/V; head-major OUT permuted back to
+                    # token-major FLASH_OUTPUT for the O projection.
+                    head_bytes = self.head_dim * self.bytes_per_element
+                    per_head_rows = ((self.PREFILL_MAX_SEQ_LEN + 63) // 64) * 64
+                    qhm_head_bytes = per_head_rows * head_bytes
+                    k_cache_base = self.LAYER0_K_ROPE_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                    v_cache_base = self.LAYER0_V_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                    for g in range(self.group_size):
+                        self._emit_strided_copy_static(
+                            self.LAYER0_FLASH_Q_DRAM + g * head_bytes,
+                            self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,
+                            self.head_dim,
+                            self.group_size * head_bytes,
+                            head_bytes,
+                            seq_len)
+                    for g in range(self.group_size):
+                        head_slot = self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes
+                        flash_attention_result = self.unified_attention_core(
+                            batch=seq_len,
+                            aligned_seq_len=aligned_seq_len,
+                            head_dim=self.head_dim,
+                            Q_DRAM_ADDR=head_slot,
+                            K_DRAM_ADDR=k_cache_base,
+                            V_DRAM_ADDR=v_cache_base,
+                            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                            OUTPUT_DRAM_ADDR=head_slot,
+                            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                            gpr_batch_reg=None,
+                            gpr_aligned_seq_len_reg=None,
+                        )
+                        total_flops += flash_attention_result or 0
+                    for g in range(self.group_size):
+                        self._emit_strided_copy_static(
+                            self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,
+                            self.LAYER0_FLASH_OUTPUT_DRAM + g * head_bytes,
+                            self.head_dim,
+                            head_bytes,
+                            self.group_size * head_bytes,
+                            seq_len)
                 total_flops += prefill_projection_core(
                     M=seq_len,
                     K=self.head_dim * self.group_size,
@@ -2136,7 +2225,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "checkpoints": checkpoints,
         }
 
-    def compile_gemma3(self, layer_size: int = 26, use_pbi: bool = False, slave_engine = None, profile: bool = False) -> None:
+    def compile_gemma3(self, layer_size: int = 26, use_pbi: bool = False, slave_engine = None, profile: bool = False, bin_reuse: bool = False) -> None:
         """Compile a single prefill program (seq_len-agnostic) and one decoder program into a
         combined instruction image.
 
@@ -2154,7 +2243,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         (64-aligned seq_len). Each decode step rebuilds a tiny dispatch stub that sets
         ``gpr_aligned_seq_len`` then jumps into the cached decoder program.
 
-        If both the bin and meta sidecar already exist, this is a no-op (reuse the cached image).
+        By default the image is always recompiled from scratch. Pass ``bin_reuse=True``
+        (CLI ``--bin-reuse``) to reuse an existing bin + meta sidecar when both are present.
 
         Writes:
           - paths.instruction_bin : raw 32 B/instruction stream (HALT appends a trailing NOP when
@@ -2187,10 +2277,12 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             instruction_meta_path = os.path.join(self.script_dir, "gemma3_bin/gemma3_program.json")
         print(f"Decode kernel: {'matmat_mul_core (two-pass)' if self.matmatmul else 'quantized_matmat_core (streaming)'}")
         print(f"Prefill kernel: {'two-pass (matmat_mul_core)' if self.two_pass_prefill else 'streaming (quantized_matmat_core)'}")
-        if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
-            print(f"Reusing existing instruction image at {instruction_bin_path}")
-            print(f"  delete {instruction_bin_path} to force recompile.")
+        if bin_reuse and os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
+            print(f"--bin-reuse: reusing existing instruction image at {instruction_bin_path}")
+            print(f"  delete {instruction_bin_path} (or drop --bin-reuse) to force recompile.")
             return
+        print("Compiling instruction image from scratch"
+              f"{' (--bin-reuse set but no cached bin found)' if bin_reuse else ''}.")
 
         self.clear_inst_id()
         self.start_capture()
@@ -2373,9 +2465,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         # --- Prefill preamble + inputs ---
         self.clear_inst_id()
         self.start_capture()
+        # Proper GQA: prime gpr_aligned_seq_len with align64(seq_len) (compact KV
+        # length), NOT align64(q_seq_len) — the per-head attention loop reads the
+        # un-duplicated K/V cache.
+        aligned_seq_len = ((prefill_seq_len + 63) // 64) * 64
         self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
         self.generate_instruction_add_set(self.gpr_q_seq_len, q_seq_len)
-        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len_q)
+        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
         self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
         self.stop_capture()
         self.write_captured_instructions_to_dram(preamble_addr)
@@ -2384,10 +2480,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
-        bias_one_group = torch.full((aligned_seq_len_q, aligned_seq_len_q), float("-inf"), dtype=torch.bfloat16)
-        valid_mask = torch.tril(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool))
+        # Proper-GQA per-head causal bias (both folded and legacy paths): one
+        # [aligned_seq, aligned_seq] plane shared by every query head (num_kv=1),
+        # over the compact seq_len-long KV.
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        valid_mask = torch.tril(torch.ones(aligned_seq_len, aligned_seq_len, dtype=torch.bool))
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, prefill_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         print(f"\n--- Profiling: prefill (seq_len={prefill_seq_len}) ---")
@@ -2498,13 +2597,15 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         seq_len = prefill_seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
+        # Proper GQA: gpr_aligned_seq_len holds the compact KV length align64(seq_len).
+        aligned_seq_len = ((seq_len + 63) // 64) * 64
 
         # ----- Runtime preamble: prime three GPRs, then jump into the cached prefill -----
         self.clear_inst_id()
         self.start_capture()
         self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
         self.generate_instruction_add_set(self.gpr_q_seq_len, q_seq_len)
-        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len_q)
+        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
         # Unconditional absolute jump into the cached prefill program.
         self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
         self.stop_capture()
@@ -2521,10 +2622,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
-        bias_one_group = torch.full((aligned_seq_len_q, aligned_seq_len_q), float("-inf"), dtype=torch.bfloat16)
-        valid_mask = torch.tril(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool), diagonal=0) if not self.causal_mask_upper else torch.triu(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool), diagonal=0)
+        # Proper-GQA per-head causal bias (both folded and legacy paths): one
+        # [aligned_seq, aligned_seq] plane over the compact seq_len-long KV, shared
+        # by every query head (num_kv=1).
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        valid_mask = torch.tril(torch.ones(aligned_seq_len, aligned_seq_len, dtype=torch.bool), diagonal=0) if not self.causal_mask_upper else torch.triu(torch.ones(aligned_seq_len, aligned_seq_len, dtype=torch.bool), diagonal=0)
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
         # Execute from the preamble; preamble jumps into cached prefill, which HALTs on completion.
         timer = time.perf_counter()
@@ -2558,6 +2662,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "prefill_seq_len": prefill_seq_len,
             "latency_prefill": latency_prefill,
             "latency_hw_prefill": latency_hw_prefill,
+            "flop_rate_hw_prefill": flop_rate_hw_prefill,
             "numeric": numeric,
             "_ref_kv": _ref_kv,
             "_dec_new_kv": _dec_new_kv,
@@ -2576,6 +2681,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         prefill_seq_len = ctx["prefill_seq_len"]
         latency_prefill = ctx["latency_prefill"]
         latency_hw_prefill = ctx["latency_hw_prefill"]
+        flop_rate_hw_prefill = ctx.get("flop_rate_hw_prefill")
         numeric = ctx["numeric"]
         _ref_kv = ctx["_ref_kv"]
         _dec_new_kv = ctx["_dec_new_kv"]
@@ -2747,9 +2853,11 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         avg_tokens_per_s = tokens_decoded / latency_decoder if latency_decoder > 0 else 0.0
         return {
             "prefill_tokens": prefill_seq_len,
+            "total_tokens": self.seq_len,
             "decoded_text": decoded_text,
             "decoded_tokens": tokens_decoded,
             "tokens_decoded": tokens_decoded,
+            "prefill_gflops": round(flop_rate_hw_prefill, 2) if flop_rate_hw_prefill else None,
             "avg_tokens_per_s": avg_tokens_per_s,
             "peak_tokens_per_s": peak_tokens_per_s,
             "prefill_speed_tok_s": prefill_seq_len / latency_prefill if latency_prefill > 0 else 0.0,
@@ -2777,6 +2885,139 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         ctx = self.run_gemma3_prefill(slave_engine=slave_engine, numeric=numeric)
         return self.run_gemma3_decode(ctx)
 
+    def write_run_summary(self, out_path: str, args, run_result: dict, cores: int = 1,
+                          title: str = "gemma3_test") -> str:
+        """Write a per-run Markdown performance summary (device info, weight/program
+        sizes, prefill + decode HW latency/throughput, and the prompt/decoded text),
+        built from ``run_result`` (the run_gemma3_decode dict) plus cheap host-side
+        bookkeeping. No FPGA program is launched here, so calling it after a run is
+        free. Mirrors gemma4_e2b_test.write_run_summary. Returns the written path."""
+        clock_ns = self._clock_period_ns
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        peak_gflops = freq_mhz * 0.128 * cores   # freq(MHz) * 128 MAC/cyc/1000 * cores
+        try:
+            hw_version = self.user_read_reg32(user_dma_core.UE_FPGA_VERSION_ADDR) & 0xFFFFFFFF
+            hw_version_str = f"0x{hw_version:08x}"
+        except Exception as e:
+            hw_version_str = f"(read failed: {e})"
+
+        # Weights.
+        weight_bin_path = os.path.join(self.script_dir, self._weights_bin_rel)
+        weight_bin_size = os.path.getsize(weight_bin_path) if os.path.exists(weight_bin_path) else 0
+        total_weight_dram_mb = self.get_params_dram_usage() / (1024 * 1024)
+
+        # Program sections (KB, from the compiled meta threaded into run_result).
+        prefill_kb = run_result.get("prefill_size_kb")
+        decoder_kb = run_result.get("decoder_size_kb")
+        combined_kb = (prefill_kb or 0) + (decoder_kb or 0)
+
+        def _mb(n):
+            return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
+        def _kb(v):
+            return f"{v:.1f} KB" if v is not None else "n/a"
+
+        pf_tokens = run_result.get("prefill_tokens")
+        pf_hw_ms = run_result.get("prefill_hw_ms")
+        pf_gflops = run_result.get("prefill_gflops")
+        pf_cpu_ms = run_result.get("prefill_cpu_ms")
+        dec_n = run_result.get("decoded_tokens")
+        total_tok = run_result.get("total_tokens")
+        peak_toks = run_result.get("peak_tokens_per_s")
+        avg_toks = run_result.get("avg_tokens_per_s")
+        dec_gflops = run_result.get("decoder_gflops")
+        dec_first_ms = run_result.get("decode_first_hw_ms")
+        dec_avg_ms = run_result.get("decode_avg_hw_ms")
+
+        try:
+            prompt_text = self.tokenizer.decode(list(self.prefill_seq), skip_special_tokens=False)
+        except Exception:
+            prompt_text = "(decode failed)"
+        decoded_text = run_result.get("decoded_text") or "(none)"
+
+        L = []
+        L.append(f"# {title} run summary")
+        L.append("")
+        L.append(f"- **HW version:** {hw_version_str}")
+        L.append(f"- **--dev:** {args.dev}")
+        L.append(f"- **--device:** {args.device}")
+        L.append(f"- **Clock / frequency:** {clock_ns:.4f} ns ({freq_mhz:.1f} MHz)")
+        L.append(f"- **Cores:** {cores}")
+        L.append(f"- **Peak throughput:** {peak_gflops:.2f} GFLOPS "
+                 f"({freq_mhz:.1f} MHz × 128 × {cores} core(s))")
+        L.append("")
+        L.append(f"## Weights")
+        L.append("")
+        L.append(f"- **Weight bin:** `{os.path.basename(weight_bin_path)}` — {_mb(weight_bin_size)}")
+        L.append(f"- **Total weight DRAM (quantized, on FPGA):** {total_weight_dram_mb:.1f} MB")
+        L.append("")
+        L.append(f"## Program image")
+        L.append("")
+        L.append(f"- **Prefill program:** {_kb(prefill_kb)}")
+        L.append(f"- **Decoder program:** {_kb(decoder_kb)}")
+        L.append(f"- **Combined program image:** {_kb(combined_kb)}")
+        L.append("")
+        L.append(f"## Prefill")
+        L.append("")
+        L.append(f"- **Prefill tokens (seq_len):** {pf_tokens if pf_tokens is not None else 'n/a'}")
+        if pf_hw_ms is not None:
+            L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
+        if pf_gflops is not None:
+            L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+        if pf_cpu_ms is not None:
+            L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
+        L.append("")
+        L.append(f"## Decode")
+        L.append("")
+        L.append(f"- **Decoded tokens:** {dec_n if dec_n is not None else 'n/a'} generated "
+                 f"(sequence total {total_tok if total_tok is not None else 'n/a'})")
+        if peak_toks is not None:
+            L.append(f"- **First-token speed (peak):** {peak_toks:.2f} tok/s")
+        if avg_toks is not None:
+            L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
+        if dec_gflops is not None:
+            L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+        if dec_first_ms is not None:
+            L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
+        if dec_avg_ms is not None:
+            L.append(f"- **Decode average HW latency:** {dec_avg_ms:.1f} ms/tok")
+        L.append("")
+        L.append(f"## Prompt & output")
+        L.append("")
+        L.append(f"### Full prefill prompt")
+        L.append("")
+        L.append("```")
+        L.append(prompt_text)
+        L.append("```")
+        L.append("")
+        L.append(f"### Decoded text")
+        L.append("")
+        L.append("```")
+        L.append(decoded_text)
+        L.append("```")
+        L.append("")
+
+        with open(out_path, "w") as f:
+            f.write("\n".join(L))
+        return out_path
+
+
+def gemma3_run_summary_filename(args, prefix: str = "gemma3_test") -> str:
+    """Per-run summary .md filename encoding the CLI config, e.g.
+    ``gemma3_test_xdma1_kintex7.md`` or ``gemma3_test_xdma0_alveo_legacy.md``.
+    dev/device are always present; other knobs are appended only when non-default."""
+    tokens = [args.dev, args.device]
+    if getattr(args, "dual_engine", False):
+        tokens.append("dual-engine")
+    if getattr(args, "legacy", False):
+        tokens.append("legacy")
+    if getattr(args, "two_pass_prefill", False):
+        tokens.append("two-pass-prefill")
+    if getattr(args, "matmatmul", False):
+        tokens.append("two-pass-decoder")
+    if getattr(args, "cycle", None) is not None:
+        tokens.append(f"cycle_{args.cycle}")
+    return prefix + "_" + "_".join(str(t) for t in tokens) + ".md"
+
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
@@ -2789,213 +3030,6 @@ def _clock_ns_default_for_device(device: str) -> float:
     if device == "alveo_u55c":                     return 3.3333333
     if device == "efinix":                         return 4.0
     return 10.0
-
-
-def gemma3_decoder_quantized_matmat_compare_test(
-    data_type: TYPE = TYPE.IF4,
-    int_variant: bool = True,
-    legacy: bool = False,
-    snr_threshold_db: float = 38.0,
-    compare_threshold_db: float = 45.0,
-    scale_pairs: tuple[tuple[float, float], ...] = (
-        (1.0, 1.0),
-        (4.0, 1.0),
-        (1.0, 4.0),
-        (4.0, 4.0),
-        (16.0, 0.25),
-        (0.25, 16.0),
-    ),
-):
-    """
-    Compare the original quantized_matmat_core against the Gemma3 decoder
-    matmat_mul_core path with quantized B weights for every Gemma3 decoder
-    projection shape. By default this mirrors the normal Gemma3 decoder
-    dynamic-M path; legacy=True mirrors the Gemma3 --legacy path.
-
-    Host reference uses quantize_weight_simulate(), so it compares against the
-    same effective BF16 weights produced by the hardware dequantize path rather
-    than the pre-quantization random weights.
-    """
-    M = 1
-    hidden_size = 1152
-    head_dim = 256
-    group_size = 4
-    mlp_elements = 6912
-    embedding_vocab = 262144
-    callsites = [
-        ("q_proj", hidden_size, head_dim * group_size, {}),
-        ("k_proj", hidden_size, head_dim, {}),
-        ("v_proj", hidden_size, head_dim, {}),
-        ("o_proj", head_dim * group_size, hidden_size, {}),
-        ("mlp_gate", hidden_size, mlp_elements, {"gelu_enable": True}),
-        ("mlp_up", hidden_size, mlp_elements, {}),
-        ("mlp_down", mlp_elements, hidden_size, {}),
-        # ("lm_head", hidden_size, embedding_vocab, {}),
-    ]
-
-    def _apply_activation(x: torch.Tensor, flags: dict) -> torch.Tensor:
-        if flags.get("gelu_enable", False):
-            return x * torch.sigmoid(1.702 * x)
-        if flags.get("silu_enable", False):
-            return x * torch.sigmoid(x)
-        if flags.get("sigmoid_enable", False):
-            return torch.sigmoid(x)
-        if flags.get("clamp_enable", False):
-            return torch.clamp(x, min=0.0)
-        if flags.get("log_enable", False):
-            return torch.log(torch.clamp(x, min=1e-3))
-        return x
-
-    def _compile_program(ue: UnifiedEngine, emit_core) -> tuple[int, int, int]:
-        ue.clear_capture_buffer()
-        ue.start_capture()
-        flops = emit_core()
-        ue.stop_capture()
-        ue.generate_instruction_halt()
-        program_addr = ue.get_program_dram_addr()
-        inst_bytes = ue.get_capture_instruction_size_bytes()
-        ue.write_captured_instructions_to_dram(program_addr)
-        ue.allocate_program_dram(inst_bytes)
-        return program_addr, inst_bytes, flops
-
-    worst_ref_snr = float("inf")
-    worst_compare_snr = float("inf")
-    total_inst_bytes = 0
-
-    width_str = "IF4" if data_type == TYPE.IF4 else "IF8"
-    variant_str = "INT" if int_variant else "FP"
-    path_str = "legacy" if legacy else "dynamic-M"
-    print(f"\nGemma3 decoder quantized matmat compare ({width_str}-{variant_str}, M=1, {path_str})")
-
-    for name, K, N, flags in callsites:
-        base_a = (torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)).contiguous()
-        base_weight = (torch.randn(N, K, dtype=torch.bfloat16) / math.sqrt(K)).contiguous()
-        for a_scale, w_scale in scale_pairs:
-            ue = UnifiedEngine()
-            A_DRAM_ADDR = ue.allocate_tensor_dram(M * K * 2)
-            QMM_OUTPUT_DRAM_ADDR = ue.allocate_tensor_dram(M * N * 2)
-            MMM_OUTPUT_DRAM_ADDR = ue.allocate_tensor_dram(M * N * 2)
-
-            a = (base_a.to(torch.float32) * float(a_scale)).to(torch.bfloat16).contiguous()
-            weight = (base_weight.to(torch.float32) * float(w_scale)).to(torch.bfloat16).contiguous()
-            QUANTIZED_MATRIX_DRAM_ADDR, SCALE_DRAM_ADDR = ue.quantize_weight(
-                weight=weight,
-                N=N,
-                K=K,
-                data_type=data_type,
-                int_variant=int_variant,
-            )
-
-            qmm_program_addr, qmm_inst_bytes, qmm_flops = _compile_program(
-                ue,
-                lambda: ue.quantized_matmat_core(
-                    M=M,
-                    K=K,
-                    N=N,
-                    A_DRAM_ADDR=A_DRAM_ADDR,
-                    B_DRAM_ADDR=QUANTIZED_MATRIX_DRAM_ADDR,
-                    OUTPUT_DRAM_ADDR=QMM_OUTPUT_DRAM_ADDR,
-                    SCALE_DRAM_ADDR=SCALE_DRAM_ADDR,
-                    data_type=data_type,
-                    **flags,
-                ),
-            )
-            def _emit_decoder_matmat_mul_core() -> int:
-                if legacy:
-                    return ue.matmat_mul_core(
-                        M=M,
-                        K=K,
-                        N=N,
-                        A_DRAM_ADDR=A_DRAM_ADDR,
-                        B_DRAM_ADDR=QUANTIZED_MATRIX_DRAM_ADDR,
-                        OUTPUT_DRAM_ADDR=MMM_OUTPUT_DRAM_ADDR,
-                        is_B_quantized=True,
-                        data_type=data_type,
-                        SCALE_DRAM_ADDR=SCALE_DRAM_ADDR,
-                        **flags,
-                    )
-
-                m_reg = ue.alloc_isa_reg()
-                ue.generate_instruction_add_set(m_reg, M)
-                try:
-                    return ue.matmat_mul_core(
-                        M=M,
-                        K=K,
-                        N=N,
-                        A_DRAM_ADDR=A_DRAM_ADDR,
-                        B_DRAM_ADDR=QUANTIZED_MATRIX_DRAM_ADDR,
-                        OUTPUT_DRAM_ADDR=MMM_OUTPUT_DRAM_ADDR,
-                        is_B_quantized=True,
-                        data_type=data_type,
-                        SCALE_DRAM_ADDR=SCALE_DRAM_ADDR,
-                        gpr_M_reg=m_reg,
-                        **flags,
-                    )
-                finally:
-                    ue.release_isa_reg()
-
-            mmm_program_addr, mmm_inst_bytes, mmm_flops = _compile_program(
-                ue,
-                _emit_decoder_matmat_mul_core,
-            )
-
-            ue.dma_to_accelerator_memory(A_DRAM_ADDR, a)
-
-            ue.start_execute_from_dram(qmm_program_addr)
-            ue.wait_queue(10.0)
-            qmm_latency_us = ue.report_latency_in_us()
-            qmm_output = ue.dma_from_accelerator_memory(QMM_OUTPUT_DRAM_ADDR, (M, N))
-
-            ue.start_execute_from_dram(mmm_program_addr)
-            ue.wait_queue(10.0)
-            mmm_latency_us = ue.report_latency_in_us()
-            mmm_output = ue.dma_from_accelerator_memory(MMM_OUTPUT_DRAM_ADDR, (M, N))
-
-            effective_weight = ue.quantize_weight_simulate(
-                weight,
-                data_type,
-                int_variant=int_variant,
-            )
-            ref = _apply_activation(a @ effective_weight.T, flags)
-
-            qmm_snr = calculate_snr(ref, qmm_output)
-            mmm_snr = calculate_snr(ref, mmm_output)
-            compare_snr = calculate_snr(qmm_output, mmm_output)
-            worst_ref_snr = min(worst_ref_snr, qmm_snr, mmm_snr)
-            worst_compare_snr = min(worst_compare_snr, compare_snr)
-            total_inst_bytes += qmm_inst_bytes + mmm_inst_bytes
-
-            qmm_gflops = (qmm_flops or 0) / (qmm_latency_us * 1e3) if qmm_latency_us > 0 else 0.0
-            mmm_gflops = (mmm_flops or 0) / (mmm_latency_us * 1e3) if mmm_latency_us > 0 else 0.0
-            print(
-                f"  {name:8s} K={K:5d} N={N:6d} "
-                f"A_scale={a_scale:g} W_scale={w_scale:g}: "
-                f"quantized_core SNR={qmm_snr:6.2f} dB ({qmm_gflops:6.2f} GFLOPS), "
-                f"matmat_core SNR={mmm_snr:6.2f} dB ({mmm_gflops:6.2f} GFLOPS), "
-                f"core-vs-core={compare_snr:6.2f} dB"
-            )
-            assert qmm_snr >= snr_threshold_db or qmm_snr == float("inf"), (
-                f"Gemma3 {name} A_scale={a_scale:g} W_scale={w_scale:g} "
-                f"quantized_matmat_core SNR {qmm_snr:.2f} dB below {snr_threshold_db:g} dB"
-            )
-            assert mmm_snr >= snr_threshold_db or mmm_snr == float("inf"), (
-                f"Gemma3 {name} A_scale={a_scale:g} W_scale={w_scale:g} "
-                f"matmat_mul_core quantized-B SNR {mmm_snr:.2f} dB below {snr_threshold_db:g} dB"
-            )
-            assert compare_snr >= compare_threshold_db or compare_snr == float("inf"), (
-                f"Gemma3 {name} A_scale={a_scale:g} W_scale={w_scale:g} "
-                f"core-vs-core SNR {compare_snr:.2f} dB below {compare_threshold_db:g} dB"
-            )
-
-            ue.clear_capture_buffer()
-            ue.reset_tensor_dram_addr()
-            ue.reset_program_dram_addr()
-
-    print(
-        f"Gemma3 decoder quantized matmat compare worst host-ref SNR={worst_ref_snr:.2f} dB, "
-        f"worst core-vs-core SNR={worst_compare_snr:.2f} dB"
-    )
-
 
 def main():
     import argparse
@@ -3036,6 +3070,9 @@ def main():
                         help='Use matmat_mul_core for decoder projections. Default: streaming quantized_matmat_core.')
     parser.add_argument('--numeric', action='store_true',
                         help='After prefill and after the first decoded token, compare HW KV cache against host reference and print SNR for K and V.')
+    parser.add_argument('--bin-reuse', dest='bin_reuse', action='store_true',
+                        help='Reuse a cached program image (gemma3_bin/*_program.bin + .json) if it exists. '
+                             'Default: always recompile the program image from scratch.')
     args = parser.parse_args()
 
     set_dma_device("efinix" if args.device == "efinix" else args.dev)
@@ -3076,13 +3113,13 @@ def main():
 
     print(f"\n--- Compiling ---")
     timer = time.perf_counter()
-    ue.compile_gemma3(slave_engine=ue2 if dual_engine else None)
+    ue.compile_gemma3(slave_engine=ue2 if dual_engine else None, bin_reuse=args.bin_reuse)
     print(f"Compile done in {time.perf_counter() - timer:.2f} seconds")
 
     if args.profile:
         print("\n--- Compiling profile binary ---")
         timer = time.perf_counter()
-        ue.compile_gemma3(profile=True)
+        ue.compile_gemma3(profile=True, bin_reuse=args.bin_reuse)
         print(f"Profile compile done in {time.perf_counter() - timer:.2f} seconds")
         ue.run_gemma3_profile()
         ue.clear_dram()
@@ -3092,6 +3129,16 @@ def main():
     run_result = ue.run_gemma3(slave_engine=ue2 if dual_engine else None, numeric=args.numeric)
     print("Gemma3 test ends.")
     _original_print(f"TEST_RESULT: {json.dumps(run_result)}")
+
+    # Per-run Markdown performance summary, named for the CLI config, written
+    # next to this script (see gemma3_run_summary_filename / write_run_summary).
+    _summary_path = os.path.join(SCRIPT_DIR, gemma3_run_summary_filename(args))
+    try:
+        ue.write_run_summary(_summary_path, args, run_result,
+                             cores=2 if dual_engine else 1)
+        print(f"Wrote run summary: {_summary_path}")
+    except Exception as _e:
+        print(f"[warn] failed to write run summary: {_e}")
 
 if __name__ == "__main__":
     main()

--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -2915,6 +2915,9 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
         def _kb(v):
             return f"{v:.1f} KB" if v is not None else "n/a"
+        def _util(gflops):
+            """Reported throughput as a percent of this run's peak GFLOPS."""
+            return f"{100.0 * gflops / peak_gflops:.1f}%" if peak_gflops else "n/a"
 
         pf_tokens = run_result.get("prefill_tokens")
         pf_hw_ms = run_result.get("prefill_hw_ms")
@@ -2963,6 +2966,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
         if pf_gflops is not None:
             L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+            L.append(f"- **Prefill utilization (% peak):** {_util(pf_gflops)}")
         if pf_cpu_ms is not None:
             L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
         L.append("")
@@ -2976,6 +2980,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
         if dec_gflops is not None:
             L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+            L.append(f"- **Decode utilization (% peak):** {_util(dec_gflops)}")
         if dec_first_ms is not None:
             L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
         if dec_avg_ms is not None:

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -642,6 +642,54 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         self._zero_dram_bf16(self.LAYER0_FLASH_K_DRAM, elements)
         self._zero_dram_bf16(self.LAYER0_FLASH_V_DRAM, elements)
 
+    def _emit_strided_copy_pbi(self, src_base: int, dst_base: int, copy_elems: int,
+                               src_row_bytes: int, dst_row_bytes: int,
+                               n_template: int, gpr_loop: int,
+                               sram_addr: int = 0x10000) -> None:
+        """PBI hardware loop: for ``n_template`` rows (runtime trip count =
+        ``gpr_loop``) copy ``copy_elems`` bf16 from ``src_base`` to ``dst_base``,
+        advancing the source DRAM addr by ``src_row_bytes`` and the dest by
+        ``dst_row_bytes`` each iteration (both register-computed → arbitrary,
+        independent strides). Used to permute prefill Q between token-major and
+        head-major layouts for the proper-GQA per-head attention loop. Bases are
+        layer-invariant FLASH_* scratch, so they are baked compile-time constants."""
+        i_reg = self.alloc_isa_reg()
+        self.generate_instruction_add_set(i_reg, 0)
+        self.loop_start(loop_cnt=n_template, gpr_loop_cnt=gpr_loop)
+        self.generate_instruction_reg_mul_imm(
+            self.TMP_REG, i_reg, ue_35bit_addr_shifter(src_row_bytes))
+        self.generate_instruction_add_imm(
+            self.TMP_REG, ue_35bit_addr_shifter(src_base), self.TMP_REG)
+        self.accelerator_memory_to_sram(
+            accelerator_dram_address=0, sram_address=sram_addr,
+            element_size=copy_elems, general_reg_src=self.TMP_REG)
+        self.generate_instruction_reg_mul_imm(
+            self.TMP_REG, i_reg, ue_35bit_addr_shifter(dst_row_bytes))
+        self.generate_instruction_add_imm(
+            self.TMP_REG, ue_35bit_addr_shifter(dst_base), self.TMP_REG)
+        self.sram_to_accelerator_memory(
+            sram_address=sram_addr, accelerator_dram_address=0,
+            element_size=copy_elems, general_reg_src=self.TMP_REG)
+        self.generate_instruction_add_inc(i_reg)
+        self.loop_end()
+        self.release_isa_reg()       # i_reg
+
+    def _emit_strided_copy_static(self, src_base: int, dst_base: int, copy_elems: int,
+                                  src_row_bytes: int, dst_row_bytes: int,
+                                  n_rows: int, sram_addr: int = 0x10000) -> None:
+        """Compile-time (Python-unrolled) equivalent of :meth:`_emit_strided_copy_pbi`
+        for the legacy static-unrolled prefill path, which is deliberately ISA-loop
+        free (no backward-branch jumps → no 512-instruction i-cache window concern).
+        Copies ``n_rows`` rows of ``copy_elems`` bf16 via a shared SRAM staging cell,
+        advancing src/dst by their own byte strides each row."""
+        for i in range(n_rows):
+            self.accelerator_memory_to_sram(
+                src_base + i * src_row_bytes, sram_addr, copy_elems)
+            self.sram_to_accelerator_memory(
+                sram_address=sram_addr,
+                accelerator_dram_address=dst_base + i * dst_row_bytes,
+                element_size=copy_elems)
+
     def _compile_prefill_program(self, prefill_seq_len: int, layer_size: int = 26, use_pbi: bool = False) -> dict:
         """
         Compile a single prefill program and return its metadata (start_addr, size_bytes, flops).
@@ -683,6 +731,10 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         seq_len = prefill_seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
+        # Proper-GQA per-head attention runs over the compact (seq_len-long) KV, so
+        # its static batch/aligned are seq_len / align64(seq_len), not the q_seq_len
+        # values (which only size the token-major Q/OUTPUT scratch buffers).
+        aligned_seq_len = ((seq_len + 63) // 64) * 64
         engine_master = not self.engine_slave
         row_offset = 0 if engine_master else seq_len // 2
         # Dual-engine: halve per-engine ``seq_len`` and offset DRAM views. Not validated with PBI
@@ -1078,55 +1130,95 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                     gpr_cos_addr=gpr_rope_base,
                 )
 
-                # Pre-flash-attn layout:
-                # Q: [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                # K/V cache: [seq_len, head_dim]; duplicate each token row group_size times for GQA. [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                duplicate_gqa_rows_pbi(
-                    self.LAYER0_K_ROPE_DRAM,
-                    self.LAYER0_FLASH_K_DRAM,
-                    0x10000,
-                    self.gpr_seq_len,
-                    gpr_src_addr=kv_addr(self.LAYER0_K_ROPE_DRAM, gpr_scratch_a),
-                    gpr_dst_addr=const_addr(self.LAYER0_FLASH_K_DRAM, gpr_scratch_b),
-                )
-                duplicate_gqa_rows_pbi(
-                    self.LAYER0_V_DRAM,
-                    self.LAYER0_FLASH_V_DRAM,
-                    0x20000,
-                    self.gpr_seq_len,
-                    gpr_src_addr=kv_addr(self.LAYER0_V_DRAM, gpr_scratch_a),
-                    gpr_dst_addr=const_addr(self.LAYER0_FLASH_V_DRAM, gpr_scratch_b),
-                )
+                # ---- Proper GQA: an outer loop over the group's query heads ----
+                # Standard GQA: the group_size query heads all attend the SAME K/V
+                # head (num_kv=1). Instead of replicating the compact per-layer K/V
+                # cache group_size times and running ONE attention over a
+                # q_seq_len=(seq_len*group_size)-long KV dimension — which spends
+                # group_size x the score-matrix FLOPs and DMA — the K/V are read
+                # straight from the compact per-layer cache (seq_len rows) and one
+                # SDPA is run per query head, reusing that shared K/V. This turns the
+                # attention cost from O((seq_len*group_size)^2) into
+                # group_size * O(seq_len^2) — a group_size-fold reduction.
+                #
+                # Layout bridge: the projection + RoPE produce Q token-major
+                # (row = token*group_size + head) in FLASH_Q, but the core reads Q /
+                # writes OUT as contiguous [batch, head_dim]. So permute Q to
+                # head-major [group, per_head_rows, head_dim] (each head's seq_len
+                # rows contiguous) into the FLASH_K scratch (freed by dropping the
+                # GQA duplication), run one core per head reusing the compact K/V,
+                # write each head's OUT back into the SAME head slot (safe — the core
+                # copies Q into its scaled-Q scratch before writing OUT), then permute
+                # the head-major output back to token-major [seq, group*head_dim] in
+                # FLASH_OUTPUT for the O projection. Both permutes are runtime-length
+                # (gpr_seq_len) strided copies.
+                #
+                # per_head_rows is the compile-time MAX aligned KV length; it sizes
+                # the head-major per-head slot stride. The live length comes from
+                # gpr_aligned_seq_len = align64(seq_len) at run time. batch/aligned
+                # for the core are seq_len / align64(seq_len) (NOT q_seq_len), primed
+                # into the runtime GPRs by the preamble.
+                head_bytes = self.head_dim * self.bytes_per_element
+                per_head_rows = ((self.PREFILL_MAX_SEQ_LEN + 63) // 64) * 64
+                qhm_head_bytes = per_head_rows * head_bytes
+                # Q token-major -> head-major (into freed FLASH_K per-head slots).
+                for g in range(self.group_size):
+                    self._emit_strided_copy_pbi(
+                        self.LAYER0_FLASH_Q_DRAM + g * head_bytes,        # token-major head g
+                        self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,    # head-major head g
+                        self.head_dim,
+                        self.group_size * head_bytes,                     # token-major row stride
+                        head_bytes,                                       # head-major contiguous
+                        seq_len, self.gpr_seq_len)
 
-                # Attention reads/writes the LAYER-INVARIANT flash-scratch buffers (LAYER0_FLASH_*),
-                # which are the same physical DRAM every layer. head_dim is a model constant, so it is
-                # kept BAKED (no gpr_head_dim_reg) — the V transpose and Q pre-scale then take their
-                # validated dynamic-M / N-baked paths. Only batch (q_seq_len) and aligned_seq_len are
-                # runtime. The Q/K/V/bias/out bases are sourced from GPRs (const_addr — same invariant
-                # address, the identical gpr-address path the decoder fold uses for per-layer KV) and
-                # the 1/sqrt(head_dim) scale from gpr_attn_scale (arithmetic PBI field 11; baked scalar is the
-                # fallback, so it's correct on both bitstreams).
-                flash_attention_result = self.unified_attention_core(
-                    batch=q_seq_len,
-                    aligned_seq_len=self.FLASH_ATTN_ROWS,
-                    head_dim=self.head_dim,
-                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
-                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                    gpr_batch_reg=self.gpr_q_seq_len,
-                    gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                    gpr_q_addr=const_addr(self.LAYER0_FLASH_Q_DRAM, gpr_scratch_a),
-                    gpr_k_addr=const_addr(self.LAYER0_FLASH_K_DRAM, gpr_scratch_b),
-                    gpr_v_addr=const_addr(self.LAYER0_FLASH_V_DRAM, gpr_scratch_c),
-                    gpr_bias_addr=const_addr(self.LAYER0_FLASH_BIAS_DRAM, gpr_scratch_d),
-                    gpr_out_addr=const_addr(self.LAYER0_FLASH_OUTPUT_DRAM, gpr_scratch_e),
-                    gpr_scale_reg=gpr_attn_scale,
-                )
-                total_flops += flash_attention_result or 0
+                # head_dim is a model constant, so it is kept BAKED (no gpr_head_dim_reg)
+                # — the V transpose and Q pre-scale then take their validated
+                # dynamic-M / N-baked paths. Only batch (seq_len) and aligned_seq_len
+                # (align64(seq_len)) are runtime. K/V bases are sourced from the
+                # per-layer KV GPR (kv_addr — the identical gpr-address path the
+                # decoder fold uses); Q/OUT/bias bases are layer-invariant scratch
+                # (const_addr); the 1/sqrt(head_dim) scale from gpr_attn_scale.
+                for g in range(self.group_size):
+                    head_slot = self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes
+                    flash_attention_result = self.unified_attention_core(
+                        batch=seq_len,
+                        # aligned_seq_len is the compile-time MAX per-head aligned KV
+                        # length (per_head_rows = align64(PREFILL_MAX_SEQ_LEN)); it sizes
+                        # the core's scratch sub-buffers (Vᵀ / score / scaled_q) so they
+                        # never overlap at any runtime length. The real KV length is
+                        # primed into gpr_aligned_seq_len at run time (dynamic path), and
+                        # the caller owns the SCRATCH buffer (LAYER0_FLASH_SCRATCH_DRAM,
+                        # sized for the max). Keeping this at the per-head max (not the
+                        # duplicated q_seq_len) is what makes the reserved scratch and the
+                        # reported attention FLOPs match the compact per-head shapes.
+                        aligned_seq_len=per_head_rows,
+                        head_dim=self.head_dim,
+                        Q_DRAM_ADDR=head_slot,
+                        K_DRAM_ADDR=self.LAYER0_K_ROPE_DRAM,
+                        V_DRAM_ADDR=self.LAYER0_V_DRAM,
+                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                        OUTPUT_DRAM_ADDR=head_slot,
+                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                        gpr_batch_reg=self.gpr_seq_len,
+                        gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
+                        gpr_q_addr=const_addr(head_slot, gpr_scratch_a),
+                        gpr_k_addr=kv_addr(self.LAYER0_K_ROPE_DRAM, gpr_scratch_b),
+                        gpr_v_addr=kv_addr(self.LAYER0_V_DRAM, gpr_scratch_c),
+                        gpr_bias_addr=const_addr(self.LAYER0_FLASH_BIAS_DRAM, gpr_scratch_d),
+                        gpr_out_addr=const_addr(head_slot, gpr_scratch_e),
+                        gpr_scale_reg=gpr_attn_scale,
+                    )
+                    total_flops += flash_attention_result or 0
+                # head-major OUT -> token-major FLASH_OUTPUT for the O projection.
+                for g in range(self.group_size):
+                    self._emit_strided_copy_pbi(
+                        self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,    # head-major head g
+                        self.LAYER0_FLASH_OUTPUT_DRAM + g * head_bytes,   # token-major head g
+                        self.head_dim,
+                        head_bytes,                                       # head-major contiguous
+                        self.group_size * head_bytes,                     # token-major row stride
+                        seq_len, self.gpr_seq_len)
             total_flops += prefill_projection_core(
                 M=seq_len,
                 K=self.head_dim * self.group_size,
@@ -1394,38 +1486,53 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
                         gpr_M_reg=None,
                     )
 
-                    # Pre-flash-attn layout:
-                    # Q: [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                    # K/V cache: [seq_len, head_dim]; duplicate each token row group_size times for GQA. [seq_len, group_size, head_dim], [seq_len:max_seq_len, :] has been padded 0
-                    # TODO: generate register for dram addr over layer_idx loop.
-                    duplicate_gqa_rows_pbi(
-                        self.LAYER0_K_ROPE_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size,
-                        self.LAYER0_FLASH_K_DRAM,
-                        0x10000,
-                        None,
-                    )
-                    duplicate_gqa_rows_pbi(
-                        self.LAYER0_V_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size,
-                        self.LAYER0_FLASH_V_DRAM,
-                        0x20000,
-                        None,
-                    )
-
-                    flash_attention_result = self.unified_attention_core(
-                        batch=q_seq_len,
-                        aligned_seq_len=aligned_seq_len_q,
-                        head_dim=self.head_dim,
-                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                        K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                        V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUTPUT_DRAM,
-                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                        gpr_batch_reg=None,
-                        gpr_aligned_seq_len_reg=None,
-                    )
-                    total_flops += flash_attention_result or 0
+                    # ---- Proper GQA (legacy static-unrolled path) ----
+                    # Same correctness fix as the folded path: no K/V duplication.
+                    # seq_len is a compile-time constant here (legacy bakes it), so
+                    # the per-head permutes + attention use static addresses and the
+                    # static (Python-unrolled) copy helper — no ISA loops, matching
+                    # the legacy path's loop-free style. Q token-major -> head-major
+                    # into freed FLASH_K per-head slots; one attention per head over
+                    # the compact per-layer K/V; head-major OUT permuted back to
+                    # token-major FLASH_OUTPUT for the O projection.
+                    head_bytes = self.head_dim * self.bytes_per_element
+                    per_head_rows = ((self.PREFILL_MAX_SEQ_LEN + 63) // 64) * 64
+                    qhm_head_bytes = per_head_rows * head_bytes
+                    k_cache_base = self.LAYER0_K_ROPE_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                    v_cache_base = self.LAYER0_V_DRAM + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
+                    for g in range(self.group_size):
+                        self._emit_strided_copy_static(
+                            self.LAYER0_FLASH_Q_DRAM + g * head_bytes,
+                            self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,
+                            self.head_dim,
+                            self.group_size * head_bytes,
+                            head_bytes,
+                            seq_len)
+                    for g in range(self.group_size):
+                        head_slot = self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes
+                        flash_attention_result = self.unified_attention_core(
+                            batch=seq_len,
+                            aligned_seq_len=aligned_seq_len,
+                            head_dim=self.head_dim,
+                            Q_DRAM_ADDR=head_slot,
+                            K_DRAM_ADDR=k_cache_base,
+                            V_DRAM_ADDR=v_cache_base,
+                            BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                            OUTPUT_DRAM_ADDR=head_slot,
+                            SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                            IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                            gpr_batch_reg=None,
+                            gpr_aligned_seq_len_reg=None,
+                        )
+                        total_flops += flash_attention_result or 0
+                    for g in range(self.group_size):
+                        self._emit_strided_copy_static(
+                            self.LAYER0_FLASH_K_DRAM + g * qhm_head_bytes,
+                            self.LAYER0_FLASH_OUTPUT_DRAM + g * head_bytes,
+                            self.head_dim,
+                            head_bytes,
+                            self.group_size * head_bytes,
+                            seq_len)
                 total_flops += prefill_projection_core(
                     M=seq_len,
                     K=self.head_dim * self.group_size,
@@ -2167,7 +2274,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "checkpoints": checkpoints,
         }
 
-    def compile_gemma3(self, layer_size: int = 26, use_pbi: bool = False, slave_engine = None, profile: bool = False) -> None:
+    def compile_gemma3(self, layer_size: int = 26, use_pbi: bool = False, slave_engine = None, profile: bool = False, bin_reuse: bool = False) -> None:
         """Compile a single prefill program (seq_len-agnostic) and one decoder program into a
         combined instruction image.
 
@@ -2185,7 +2292,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         (64-aligned seq_len). Each decode step rebuilds a tiny dispatch stub that sets
         ``gpr_aligned_seq_len`` then jumps into the cached decoder program.
 
-        If both the bin and meta sidecar already exist, this is a no-op (reuse the cached image).
+        By default the image is always recompiled from scratch. Pass ``bin_reuse=True``
+        (CLI ``--bin-reuse``) to reuse an existing bin + meta sidecar when both are present.
 
         Writes:
           - paths.instruction_bin : raw 32 B/instruction stream (HALT appends a trailing NOP when
@@ -2218,10 +2326,12 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             instruction_meta_path = os.path.join(self.script_dir, "gemma3_if8_bin/gemma3_program.json")
         print(f"Decode kernel: {'matmat_mul_core (two-pass)' if self.matmatmul else 'quantized_matmat_core (streaming)'}")
         print(f"Prefill kernel: {'two-pass (matmat_mul_core)' if self.two_pass_prefill else 'streaming (quantized_matmat_core)'}")
-        if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
-            print(f"Reusing existing instruction image at {instruction_bin_path}")
-            print(f"  delete {instruction_bin_path} to force recompile.")
+        if bin_reuse and os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
+            print(f"--bin-reuse: reusing existing instruction image at {instruction_bin_path}")
+            print(f"  delete {instruction_bin_path} (or drop --bin-reuse) to force recompile.")
             return
+        print("Compiling instruction image from scratch"
+              f"{' (--bin-reuse set but no cached bin found)' if bin_reuse else ''}.")
 
         self.clear_inst_id()
         self.start_capture()
@@ -2364,9 +2474,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         self.clear_inst_id()
         self.start_capture()
+        # Proper GQA: prime gpr_aligned_seq_len with align64(seq_len) (compact KV
+        # length), NOT align64(q_seq_len) — the per-head attention loop reads the
+        # un-duplicated K/V cache.
+        aligned_seq_len = ((prefill_seq_len + 63) // 64) * 64
         self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
         self.generate_instruction_add_set(self.gpr_q_seq_len, q_seq_len)
-        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len_q)
+        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
         self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
         self.stop_capture()
         self.write_captured_instructions_to_dram(preamble_addr)
@@ -2375,10 +2489,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
-        bias_one_group = torch.full((aligned_seq_len_q, aligned_seq_len_q), float("-inf"), dtype=torch.bfloat16)
-        valid_mask = torch.tril(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool))
+        # Proper-GQA per-head causal bias (both folded and legacy paths): one
+        # [aligned_seq, aligned_seq] plane shared by every query head (num_kv=1),
+        # over the compact seq_len-long KV.
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        valid_mask = torch.tril(torch.ones(aligned_seq_len, aligned_seq_len, dtype=torch.bool))
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, prefill_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         print(f"\n--- Profiling: prefill (seq_len={prefill_seq_len}) ---")
@@ -2501,13 +2618,15 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         seq_len = prefill_seq_len
         q_seq_len = seq_len * self.group_size
         aligned_seq_len_q = ((q_seq_len + 63) // 64) * 64
+        # Proper GQA: gpr_aligned_seq_len holds the compact KV length align64(seq_len).
+        aligned_seq_len = ((seq_len + 63) // 64) * 64
 
         # ----- Runtime preamble: prime three GPRs, then jump into the cached prefill -----
         self.clear_inst_id()
         self.start_capture()
         self.generate_instruction_add_set(self.gpr_seq_len, prefill_seq_len)
         self.generate_instruction_add_set(self.gpr_q_seq_len, q_seq_len)
-        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len_q)
+        self.generate_instruction_add_set(self.gpr_aligned_seq_len, aligned_seq_len)
         # Unconditional absolute jump into the cached prefill program.
         self.generate_instruction_jump_abs(ue_35bit_addr_shifter(prefill_program_addr))
         self.stop_capture()
@@ -2524,10 +2643,13 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
-        bias_one_group = torch.full((aligned_seq_len_q, aligned_seq_len_q), float("-inf"), dtype=torch.bfloat16)
-        valid_mask = torch.tril(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool), diagonal=0) if not self.causal_mask_upper else torch.triu(torch.ones(aligned_seq_len_q, aligned_seq_len_q, dtype=torch.bool), diagonal=0)
+        # Proper-GQA per-head causal bias (both folded and legacy paths): one
+        # [aligned_seq, aligned_seq] plane over the compact seq_len-long KV, shared
+        # by every query head (num_kv=1).
+        bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
+        valid_mask = torch.tril(torch.ones(aligned_seq_len, aligned_seq_len, dtype=torch.bool), diagonal=0) if not self.causal_mask_upper else torch.triu(torch.ones(aligned_seq_len, aligned_seq_len, dtype=torch.bool), diagonal=0)
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
         # Execute from the preamble; preamble jumps into cached prefill, which HALTs on completion.
         latency_hw_prefill, flop_rate_hw_prefill = self.program_execute(preamble_addr, flops=flops_prefill)
@@ -2560,6 +2682,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             "prefill_seq_len": prefill_seq_len,
             "latency_prefill": latency_prefill,
             "latency_hw_prefill": latency_hw_prefill,
+            "flop_rate_hw_prefill": flop_rate_hw_prefill,
             "numeric": numeric,
             "_ref_kv": _ref_kv,
             "_dec_new_kv": _dec_new_kv,
@@ -2578,6 +2701,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         prefill_seq_len = ctx["prefill_seq_len"]
         latency_prefill = ctx["latency_prefill"]
         latency_hw_prefill = ctx["latency_hw_prefill"]
+        flop_rate_hw_prefill = ctx.get("flop_rate_hw_prefill")
         numeric = ctx["numeric"]
         _ref_kv = ctx["_ref_kv"]
         _dec_new_kv = ctx["_dec_new_kv"]
@@ -2726,6 +2850,12 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         hw_decode_avg_ms  = sum(hw_decode_lats_us) / len(hw_decode_lats_us) / 1e3 if hw_decode_lats_us else 0.0
         hw_decode_first_ms = hw_decode_lats_us[0] / 1e3 if hw_decode_lats_us else 0.0
+        hw_decode_total_us = sum(hw_decode_lats_us)
+        decoder_gflops = (
+            decoder_flops_per_token * len(hw_decode_lats_us) / (hw_decode_total_us * 1e3)
+            if (hw_decode_total_us > 0 and isinstance(decoder_flops_per_token, (int, float)))
+            else 0.0
+        )
         cpu_decode_avg_ms = latency_decoder * 1e3 / tokens_decoded if tokens_decoded else 0.0
         _original_print("\n=== Performance Summary ===")
         _original_print(f"Instruction size  : prefill={meta['prefill_program_size']/1024:.1f} kB  decoder={meta['decoder_program_size']/1024:.1f} kB  total={(meta['prefill_program_size']+meta['decoder_program_size'])/1024:.1f} kB")
@@ -2737,10 +2867,19 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         return {
             "decoded_text": decoded_text,
             "tokens_decoded": tokens_decoded,
+            "decoded_tokens": tokens_decoded,
             "prefill_tokens": prefill_seq_len,
+            "total_tokens": self.seq_len,
             "avg_tokens_per_s": avg_tokens_per_s,
             "peak_tokens_per_s": peak_tokens_per_s,
             "prefill_hw_ms": latency_hw_prefill / 1e3,
+            "prefill_cpu_ms": latency_prefill * 1e3,
+            "prefill_gflops": round(flop_rate_hw_prefill, 2) if flop_rate_hw_prefill else None,
+            "decode_first_hw_ms": hw_decode_first_ms,
+            "decode_avg_hw_ms": hw_decode_avg_ms,
+            "decoder_gflops": round(decoder_gflops, 2),
+            "prefill_size_kb": round(meta["prefill_program_size"] / 1024, 1),
+            "decoder_size_kb": round(meta["decoder_program_size"] / 1024, 1),
             "snr_k_pre": snr_k_pre,
             "snr_v_pre": snr_v_pre,
             "snr_k_new": snr_k_new,
@@ -2755,6 +2894,137 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         """
         ctx = self.run_gemma3_prefill(slave_engine=slave_engine, numeric=numeric)
         return self.run_gemma3_decode(ctx)
+
+    def write_run_summary(self, out_path: str, args, run_result: dict, cores: int = 1,
+                          title: str = "gemma3_test_IF8") -> str:
+        """Write a per-run Markdown performance summary (device info, weight/program
+        sizes, prefill + decode HW latency/throughput, and the prompt/decoded text),
+        built from ``run_result`` (the run_gemma3_decode dict) plus cheap host-side
+        bookkeeping. No FPGA program is launched here. Mirrors
+        gemma4_e2b_test.write_run_summary. Returns the written path."""
+        clock_ns = self._clock_period_ns
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        peak_gflops = freq_mhz * 0.128 * cores   # freq(MHz) * 128 MAC/cyc/1000 * cores
+        try:
+            hw_version = self.user_read_reg32(user_dma_core.UE_FPGA_VERSION_ADDR) & 0xFFFFFFFF
+            hw_version_str = f"0x{hw_version:08x}"
+        except Exception as e:
+            hw_version_str = f"(read failed: {e})"
+
+        weight_bin_path = os.path.join(self.script_dir, self._weights_bin_rel)
+        weight_bin_size = os.path.getsize(weight_bin_path) if os.path.exists(weight_bin_path) else 0
+        total_weight_dram_mb = self.get_params_dram_usage() / (1024 * 1024)
+
+        prefill_kb = run_result.get("prefill_size_kb")
+        decoder_kb = run_result.get("decoder_size_kb")
+        combined_kb = (prefill_kb or 0) + (decoder_kb or 0)
+
+        def _mb(n):
+            return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
+        def _kb(v):
+            return f"{v:.1f} KB" if v is not None else "n/a"
+
+        pf_tokens = run_result.get("prefill_tokens")
+        pf_hw_ms = run_result.get("prefill_hw_ms")
+        pf_gflops = run_result.get("prefill_gflops")
+        pf_cpu_ms = run_result.get("prefill_cpu_ms")
+        dec_n = run_result.get("decoded_tokens")
+        total_tok = run_result.get("total_tokens")
+        peak_toks = run_result.get("peak_tokens_per_s")
+        avg_toks = run_result.get("avg_tokens_per_s")
+        dec_gflops = run_result.get("decoder_gflops")
+        dec_first_ms = run_result.get("decode_first_hw_ms")
+        dec_avg_ms = run_result.get("decode_avg_hw_ms")
+
+        try:
+            prompt_text = self.tokenizer.decode(list(self.prefill_seq), skip_special_tokens=False)
+        except Exception:
+            prompt_text = "(decode failed)"
+        decoded_text = run_result.get("decoded_text") or "(none)"
+
+        L = []
+        L.append(f"# {title} run summary")
+        L.append("")
+        L.append(f"- **HW version:** {hw_version_str}")
+        L.append(f"- **--dev:** {args.dev}")
+        L.append(f"- **--device:** {args.device}")
+        L.append(f"- **Clock / frequency:** {clock_ns:.4f} ns ({freq_mhz:.1f} MHz)")
+        L.append(f"- **Cores:** {cores}")
+        L.append(f"- **Peak throughput:** {peak_gflops:.2f} GFLOPS "
+                 f"({freq_mhz:.1f} MHz × 128 × {cores} core(s))")
+        L.append("")
+        L.append(f"## Weights")
+        L.append("")
+        L.append(f"- **Weight bin:** `{os.path.basename(weight_bin_path)}` — {_mb(weight_bin_size)}")
+        L.append(f"- **Total weight DRAM (quantized, on FPGA):** {total_weight_dram_mb:.1f} MB")
+        L.append("")
+        L.append(f"## Program image")
+        L.append("")
+        L.append(f"- **Prefill program:** {_kb(prefill_kb)}")
+        L.append(f"- **Decoder program:** {_kb(decoder_kb)}")
+        L.append(f"- **Combined program image:** {_kb(combined_kb)}")
+        L.append("")
+        L.append(f"## Prefill")
+        L.append("")
+        L.append(f"- **Prefill tokens (seq_len):** {pf_tokens if pf_tokens is not None else 'n/a'}")
+        if pf_hw_ms is not None:
+            L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
+        if pf_gflops is not None:
+            L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+        if pf_cpu_ms is not None:
+            L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
+        L.append("")
+        L.append(f"## Decode")
+        L.append("")
+        L.append(f"- **Decoded tokens:** {dec_n if dec_n is not None else 'n/a'} generated "
+                 f"(sequence total {total_tok if total_tok is not None else 'n/a'})")
+        if peak_toks is not None:
+            L.append(f"- **First-token speed (peak):** {peak_toks:.2f} tok/s")
+        if avg_toks is not None:
+            L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
+        if dec_gflops is not None:
+            L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+        if dec_first_ms is not None:
+            L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
+        if dec_avg_ms is not None:
+            L.append(f"- **Decode average HW latency:** {dec_avg_ms:.1f} ms/tok")
+        L.append("")
+        L.append(f"## Prompt & output")
+        L.append("")
+        L.append(f"### Full prefill prompt")
+        L.append("")
+        L.append("```")
+        L.append(prompt_text)
+        L.append("```")
+        L.append("")
+        L.append(f"### Decoded text")
+        L.append("")
+        L.append("```")
+        L.append(decoded_text)
+        L.append("```")
+        L.append("")
+
+        with open(out_path, "w") as f:
+            f.write("\n".join(L))
+        return out_path
+
+
+def gemma3_run_summary_filename(args, prefix: str = "gemma3_test_IF8") -> str:
+    """Per-run summary .md filename encoding the CLI config, e.g.
+    ``gemma3_test_IF8_xdma1_kintex7.md``. dev/device always present; other knobs
+    appended only when non-default."""
+    tokens = [args.dev, args.device]
+    if getattr(args, "dual_engine", False):
+        tokens.append("dual-engine")
+    if getattr(args, "legacy", False):
+        tokens.append("legacy")
+    if getattr(args, "two_pass_prefill", False):
+        tokens.append("two-pass-prefill")
+    if getattr(args, "matmatmul", False):
+        tokens.append("two-pass-decoder")
+    if getattr(args, "cycle", None) is not None:
+        tokens.append(f"cycle_{args.cycle}")
+    return prefix + "_" + "_".join(str(t) for t in tokens) + ".md"
 
 # -----------------------------------------------------------------------------
 # Main
@@ -3014,6 +3284,9 @@ def main():
                         help='Use matmat_mul_core for decoder projections. Default: streaming quantized_matmat_core.')
     parser.add_argument('--numeric', action='store_true',
                         help='After prefill and after the first decoded token, compare HW KV cache against host reference and print SNR for K and V.')
+    parser.add_argument('--bin-reuse', dest='bin_reuse', action='store_true',
+                        help='Reuse a cached program image (gemma3_if8_bin/*_program.bin + .json) if it exists. '
+                             'Default: always recompile the program image from scratch.')
     args = parser.parse_args()
 
     set_dma_device("efinix" if args.device == "efinix" else args.dev)
@@ -3054,13 +3327,13 @@ def main():
 
     print(f"\n--- Compiling ---")
     timer = time.perf_counter()
-    ue.compile_gemma3(slave_engine=ue2 if dual_engine else None)
+    ue.compile_gemma3(slave_engine=ue2 if dual_engine else None, bin_reuse=args.bin_reuse)
     print(f"Compile done in {time.perf_counter() - timer:.2f} seconds")
 
     if args.profile:
         print("\n--- Compiling profile binary ---")
         timer = time.perf_counter()
-        ue.compile_gemma3(profile=True)
+        ue.compile_gemma3(profile=True, bin_reuse=args.bin_reuse)
         print(f"Profile compile done in {time.perf_counter() - timer:.2f} seconds")
         ue.run_gemma3_profile()
         print("Decoder profile done.")
@@ -3068,6 +3341,16 @@ def main():
 
     run_result = ue.run_gemma3(slave_engine=ue2 if dual_engine else None, numeric=args.numeric)
     print("Gemma3 test ends.")
+
+    # Per-run Markdown performance summary, named for the CLI config, written
+    # next to this script (see gemma3_run_summary_filename / write_run_summary).
+    _summary_path = os.path.join(SCRIPT_DIR, gemma3_run_summary_filename(args))
+    try:
+        ue.write_run_summary(_summary_path, args, run_result,
+                             cores=2 if dual_engine else 1)
+        print(f"Wrote run summary: {_summary_path}")
+    except Exception as _e:
+        print(f"[warn] failed to write run summary: {_e}")
 
 if __name__ == "__main__":
     main()

--- a/models/gemma3/gemma3_test_IF8.py
+++ b/models/gemma3/gemma3_test_IF8.py
@@ -2923,6 +2923,9 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
         def _kb(v):
             return f"{v:.1f} KB" if v is not None else "n/a"
+        def _util(gflops):
+            """Reported throughput as a percent of this run's peak GFLOPS."""
+            return f"{100.0 * gflops / peak_gflops:.1f}%" if peak_gflops else "n/a"
 
         pf_tokens = run_result.get("prefill_tokens")
         pf_hw_ms = run_result.get("prefill_hw_ms")
@@ -2971,6 +2974,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
         if pf_gflops is not None:
             L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+            L.append(f"- **Prefill utilization (% peak):** {_util(pf_gflops)}")
         if pf_cpu_ms is not None:
             L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
         L.append("")
@@ -2984,6 +2988,7 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
         if dec_gflops is not None:
             L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+            L.append(f"- **Decode utilization (% peak):** {_util(dec_gflops)}")
         if dec_first_ms is not None:
             L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
         if dec_avg_ms is not None:

--- a/models/gemma3/performance.md
+++ b/models/gemma3/performance.md
@@ -27,11 +27,13 @@ compiled the program image **from scratch** (default; `--bin-reuse` off).
 | Prefill tokens (seq_len) | 19 | 19 |
 | Prefill FPGA time (HW latency) | 1118.80 ms | 1128.10 ms |
 | Prefill throughput | ~ GFLOPS | 23.65 GFLOPS |
+| — utilization (% peak) | ~ | 93.1% |
 | Prefill end-to-end (CPU) | 1.12 s | 1.13 s |
 | Decoded tokens | 80 generated (total 99) | 76 generated (total 95) |
 | Decode 1st-token speed (peak) | 10.60 tok/s | 10.60 tok/s |
 | Decode average speed | 10.29 tok/s | 10.32 tok/s |
 | Decode average throughput | 21.50 GFLOPS | 21.52 GFLOPS |
+| — utilization (% peak) | 84.7% | 84.8% |
 | Decode 1st-token HW latency | 94.4 ms/tok | 94.4 ms/tok |
 | Decode average HW latency | 95.6 ms/tok | 95.5 ms/tok |
 | Correctness | coherent (solves x = 2) | coherent (solves x = 2) |
@@ -49,11 +51,13 @@ compiled the program image **from scratch** (default; `--bin-reuse` off).
 | Prefill tokens (seq_len) | 19 | 19 |
 | Prefill FPGA time (HW latency) | 2163.20 ms | 2172.52 ms |
 | Prefill throughput | ~ GFLOPS | 12.28 GFLOPS |
+| — utilization (% peak) | ~ | 48.4% |
 | Prefill end-to-end (CPU) | 2.17 s | 2.18 s |
 | Decoded tokens | 74 generated (total 93) | 74 generated (total 93) |
 | Decode 1st-token speed (peak) | 5.78 tok/s | 5.78 tok/s |
 | Decode average speed | 5.69 tok/s | 5.69 tok/s |
 | Decode average throughput | 11.80 GFLOPS | 11.80 GFLOPS |
+| — utilization (% peak) | 46.5% | 46.5% |
 | Decode 1st-token HW latency | 173.1 ms/tok | 173.1 ms/tok |
 | Decode average HW latency | 174.3 ms/tok | 174.3 ms/tok |
 | Correctness | coherent (solves x = 2) | coherent (solves x = 2) |

--- a/models/gemma3/performance.md
+++ b/models/gemma3/performance.md
@@ -1,70 +1,59 @@
 # Gemma3 Performance
 
-Hardware: Andromeda FPGA (HW version 0x25e4082c), clock cycle 5.15 ns (194 MHz), device kintex7.
+Baseline numbers captured from the per-run summaries written by
+`gemma3_test.py` / `gemma3_test_IF8.py` (see `write_run_summary`). Both runs
+compiled the program image **from scratch** (default; `--bin-reuse` off).
 
-Architecture: 26 layers, hidden 2048, GQA (4 KV heads × 4 Q/KV = 16 Q heads), head_dim 256, MLP 16384, IF4 quantization.
+- **HW version:** `0x3d04c689`
+- **--dev / --device:** `xdma1` / `kintex7`
+- **Clock / frequency:** 5.0422 ns (198.3 MHz)
+- **Cores:** 1
+- **Prompt:** `x+3=5, what is x?`
+- **Architecture:** 26 layers, hidden 1152, head_dim 256, group_size 4, MLP 6912,
+  global-RoPE layers [5, 11, 17, 23].
+- **Source summaries:** [gemma3_test_xdma1_kintex7.md](gemma3_test_xdma1_kintex7.md) (IF4),
+  [gemma3_test_IF8_xdma1_kintex7.md](gemma3_test_IF8_xdma1_kintex7.md) (IF8).
 
-## Instruction Size
+## Gemma3 IF4
 
-| Stage   | Baseline (kB) | Quantized LM head (kB) | + flash attn reuse (kB) |
-|---------|--------------|----------------------|------------------------|
-| Prefill | 1,655.8      | 1,655.8              | **382.5**              |
-| Decoder | 1,150.4      | 1,077.3              | **326.9**              |
-| Total   | 2,806.2      | 2,733.1              | **709.4**              |
+| Metric | Baseline | proper-gqa |
+|---|---:|---:|
+| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS |
+| Weight bin (`weights_gemma3_hf.bin`) | 1083.77 MB | 1083.77 MB |
+| Weight DRAM (quantized, on FPGA) | 507.8 MB | 507.8 MB |
+| Prefill program | 53.6 KB | 88.9 KB |
+| Decoder program | 66.6 KB | 66.6 KB |
+| Combined program image | 120.2 KB | 155.6 KB |
+| Prefill tokens (seq_len) | 19 | 19 |
+| Prefill FPGA time (HW latency) | 1118.80 ms | 1128.10 ms |
+| Prefill throughput | ~ GFLOPS | 23.65 GFLOPS |
+| Prefill end-to-end (CPU) | 1.12 s | 1.13 s |
+| Decoded tokens | 80 generated (total 99) | 76 generated (total 95) |
+| Decode 1st-token speed (peak) | 10.60 tok/s | 10.60 tok/s |
+| Decode average speed | 10.29 tok/s | 10.32 tok/s |
+| Decode average throughput | 21.50 GFLOPS | 21.52 GFLOPS |
+| Decode 1st-token HW latency | 94.4 ms/tok | 94.4 ms/tok |
+| Decode average HW latency | 95.6 ms/tok | 95.5 ms/tok |
+| Correctness | coherent (solves x = 2) | coherent (solves x = 2) |
 
-Prefill: 4.3× smaller (26 flash_attention_core copies → 1 shared subroutine + 26 call stubs).
-Decoder: 3.2× smaller (26 decoder_group_attention_core copies → 1 shared subroutine + 26 KV-staging + call stubs).
-Total: 3.8× smaller vs quantized LM head baseline.
+## Gemma3 IF8
 
-## Run Performance
-
-| Metric | Baseline | Quantized LM head | + flash attn reuse |
-|--------|----------|-------------------|-------------------|
-| Prompt tokens (prefill) | 19 | 19 | 19 |
-| Decode tokens generated | 77 | 113 | 77 |
-| **Prefill HW time (ms)** | 1,224.0 | 1,224.0 | 1,224.1 |
-| **Prefill CPU time (ms)** | 1,241.1 | 1,232.6 | 1,236.0 |
-| **Decode 1st token HW (ms/tok)** | 120.2 | 95.3 | 95.8 |
-| **Decode 1st token (tok/s)** | 8.32 | 10.50 | 10.44 |
-| **Decode avg HW time (ms/tok)** | 121.4 | 97.2 | 97.3 |
-| **Decode avg CPU time (ms/tok)** | 128.7 | 105.2 | 104.7 |
-| Decode throughput (inc. host detokenizer) (tok/s) | 7.77 | 9.51 | 9.55 |
-
-## Decoder Step Breakdown (1st token, all 26 layers)
-
-| Step | Baseline (ms) | Quantized LM head (ms) | + flash attn reuse (ms) |
-|------|--------------|----------------------|------------------------|
-| pre_norm | 0.19 | 0.19 | 0.19 |
-| qkv_proj_vcache | 4.27 | 4.27 | 4.27 |
-| qk_norm_rope | 0.53 | 0.53 | 0.52 |
-| attention | 5.55 | 5.55 | 5.55 |
-| o_proj_post_attn_norm_residual | 2.96 | 2.96 | 2.96 |
-| pre_ffn_norm | 0.15 | 0.15 | 0.15 |
-| mlp_gateup_gelu_mul | 36.97 | 36.97 | 36.97 |
-| mlp_down_post_ffn_norm_residual | 18.59 | 18.59 | 18.59 |
-| norm_lm_head | 51.62 | 26.68 | 26.54 |
-| **Total** | **120.84** | **95.90** | **95.75** |
-
----
-
-## Gemma3-IF8 Performance (+ flash attn reuse)
-
-Same subroutine reuse applied to both prefill and decoder.
-
-### Instruction Size
-
-| Stage   | + flash attn reuse (kB) |
-|---------|------------------------|
-| Prefill | 382.5                  |
-| Decoder | 418.3                  |
-| Total   | 800.8                  |
-
-### Run Performance
-
-| Metric | + flash attn reuse |
-|--------|--------------------|
-| Prompt tokens (prefill) | 19 |
-| Decode tokens generated | 76 |
-| **Prefill HW time (ms)** | 1,280.4 |
-| **Decode avg HW time (ms/tok)** | 220.0 |
-| Decode throughput (tok/s) | 4.77 |
+| Metric | Baseline | proper-gqa |
+|---|---:|---:|
+| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS |
+| Weight bin (`weights_gemma3_hf.bin`) | 1560.49 MB | 1560.49 MB |
+| Weight DRAM (quantized, on FPGA) | 984.5 MB | 984.5 MB |
+| Prefill program | 53.6 KB | 88.9 KB |
+| Decoder program | 66.6 KB | 66.6 KB |
+| Combined program image | 120.2 KB | 155.6 KB |
+| Prefill tokens (seq_len) | 19 | 19 |
+| Prefill FPGA time (HW latency) | 2163.20 ms | 2172.52 ms |
+| Prefill throughput | ~ GFLOPS | 12.28 GFLOPS |
+| Prefill end-to-end (CPU) | 2.17 s | 2.18 s |
+| Decoded tokens | 74 generated (total 93) | 74 generated (total 93) |
+| Decode 1st-token speed (peak) | 5.78 tok/s | 5.78 tok/s |
+| Decode average speed | 5.69 tok/s | 5.69 tok/s |
+| Decode average throughput | 11.80 GFLOPS | 11.80 GFLOPS |
+| Decode 1st-token HW latency | 173.1 ms/tok | 173.1 ms/tok |
+| Decode average HW latency | 174.3 ms/tok | 174.3 ms/tok |
+| Correctness | coherent (solves x = 2) | coherent (solves x = 2) |

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -8,11 +8,17 @@ Both implementations used `test_samples/yosemite.jpg`, the prompt
 `Describe this image in detail.`, the same `params.bin`, IF4 projection
 weights, 35 LM layers, 16 vision layers, and 256 image soft tokens.
 
-> **2026-08-17 refresh.** The Kintex, Kintex 2-core, and Alveo columns were
-> re-measured from clean builds. Kintex used `--dev xdma1` with accepted HW
-> version `0x3d04c689`; Alveo used `--device alveo` with accepted HW version
-> `0x6bb5d25d`. Each run was preceded by `make clean`
+> **2026-08-20 refresh.** Every column except `rk` was re-measured from clean
+> builds (Kintex, Kintex 2-core, Alveo, and Alveo 2/4/8-core). Kintex used
+> `--dev xdma1` with accepted HW version `0x3d04c689`; Alveo used
+> `--device alveo`. Each run was preceded by `make clean`
 > (`clean_program_bins.sh`) so every program image was recompiled from scratch.
+> This refresh also carries the corrected **Vision end-to-end path** metric:
+> it now covers only the vision *run time* (FPGA execute + the LM-facing
+> soft-token readback), excluding one-time weight init / host compile and the
+> numeric-harness debug readbacks — hence it sits just above Vision FPGA
+> execution. The `rk` column predates this fix and is left as previously
+> measured.
 
 Commands:
 
@@ -32,23 +38,23 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 | Metric | Kintex | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Peak throughput | 25.39 GFLOPS | 50.77 GFLOPS | 42.67 GFLOPS | 46.93 GFLOPS | 93.87 GFLOPS | 187.73 GFLOPS | 375.47 GFLOPS |
-| Vision FPGA execution | 53.78 s | 27.78 s | 32.05 s | **29.12 s** | **15.43 s** | **8.08 s** | **4.95 s** |
-| Vision end-to-end path | 54.43 s | 28.54 s | 32.62 s | **29.66 s** | **16.16 s** | **9.22 s** | **7.03 s** |
-| Vision throughput | 21.37 GFLOPS | 41.41 GFLOPS | 35.85 GFLOPS | **39.46 GFLOPS** | **74.47 GFLOPS** | **142.21 GFLOPS** | **232.17 GFLOPS** |
-| — utilization (% peak) | 84.2% | 81.6% | 84.0% | **84.1%** | **79.3%** | **75.8%** | **61.8%** |
+| Vision FPGA execution | 53.78 s | 27.74 s | 32.05 s | **29.21 s** | **15.54 s** | **8.08 s** | **4.94 s** |
+| Vision end-to-end path | 53.81 s | 27.81 s | 32.62 s | **29.26 s** | **15.60 s** | **8.15 s** | **5.05 s** |
+| Vision throughput | 21.37 GFLOPS | 41.42 GFLOPS | 35.85 GFLOPS | **39.35 GFLOPS** | **73.96 GFLOPS** | **142.20 GFLOPS** | **232.38 GFLOPS** |
+| — utilization (% peak) | 84.2% | 81.6% | 84.0% | **83.8%** | **78.8%** | **75.7%** | **61.9%** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
 | LM prefill sequence executed | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 43.95 s | 23.46 s | 28.02 s | **24.92 s** | **12.84 s** | **6.94 s** | **4.02 s** |
-| LM prefill throughput | 24.08 GFLOPS | 45.13 GFLOPS | 37.78 GFLOPS | **42.48 GFLOPS** | **82.47 GFLOPS** | **152.64 GFLOPS** | **263.39 GFLOPS** |
-| — utilization (% peak) | 94.8% | 88.9% | 88.5% | **90.5%** | **87.9%** | **81.3%** | **70.1%** |
-| Decode average throughput | 3.75 tok/s | 3.76 tok/s | 5.85 tok/s | **6.59 tok/s** | **6.52 tok/s** | **6.56 tok/s** | **6.56 tok/s** |
-| Decode peak first-token throughput | 4.00 tok/s | 4.00 tok/s | 6.21 tok/s | **6.95 tok/s** | **6.98 tok/s** | **6.94 tok/s** | **6.93 tok/s** |
-| Decode average hardware throughput | 18.97 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **40.77 GFLOPS** | **40.56 GFLOPS** | **40.56 GFLOPS** | **40.57 GFLOPS** |
-| — utilization (% peak) | 74.7% | 45.2% | 85.5% | **86.9%** | **43.2%** | **21.6%** | **10.8%** |
+| LM prefill FPGA latency | 43.95 s | 23.46 s | 28.02 s | **26.29 s** | **12.93 s** | **6.94 s** | **4.02 s** |
+| LM prefill throughput | 24.08 GFLOPS | 45.12 GFLOPS | 37.78 GFLOPS | **40.26 GFLOPS** | **81.89 GFLOPS** | **152.56 GFLOPS** | **263.61 GFLOPS** |
+| — utilization (% peak) | 94.9% | 88.9% | 88.5% | **85.8%** | **87.2%** | **81.3%** | **70.2%** |
+| Decode average throughput | 3.78 tok/s | 3.76 tok/s | 5.85 tok/s | **6.32 tok/s** | **5.78 tok/s** | **6.53 tok/s** | **6.53 tok/s** |
+| Decode peak first-token throughput | 3.99 tok/s | 4.00 tok/s | 6.21 tok/s | **6.65 tok/s** | **6.53 tok/s** | **7.08 tok/s** | **6.90 tok/s** |
+| Decode average hardware throughput | 23.06 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **39.01 GFLOPS** | **35.71 GFLOPS** | **40.56 GFLOPS** | **40.56 GFLOPS** |
+| — utilization (% peak) | 90.8% | 45.2% | 85.5% | **83.1%** | **38.0%** | **21.6%** | **10.8%** |
 | Vision program section | 3.22 MiB | 2.39 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
 | Prefill program section | 5.85 MiB | 4.77 MiB | 5.85 MiB | 5.85 MiB | 4.77 MiB | 4.06 MiB | 3.72 MiB |
 | Decode program section | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB |
-| Combined program image | 10.49 MiB | 13.73 MiB | 10.49 MiB | 10.49 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
+| Combined program image | 10.49 MiB | 13.73 MiB | 10.49 MiB | 10.49 MiB | 13.73 MiB | 19.20 MiB | 30.40 MiB |
 | Weight image (`params.bin`) | 6.91 GiB | same | same | same | same | same | same |
 | Correctness | coherent, total 656 | coherent, total 699 | coherent, total 656 | coherent, total 656 | coherent, total 699 | coherent, total 699 | coherent, total 699 |
 

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -29,25 +29,28 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device alveo --image --multi-core 
 
 ## Performance comparison
 
-| Metric | Legacy | Kintex | Kintex GQA | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS | 25.39 GFLOPS | 50.77 GFLOPS | 42.67 GFLOPS | 46.93 GFLOPS | 93.87 GFLOPS | 187.73 GFLOPS | 375.47 GFLOPS |
-| Vision FPGA execution | 55.54 s | 53.78 s | 53.78 s | 27.78 s | 32.05 s | **28.99 s** | **15.4 s** | **7.98 s** | **4.77 s** |
-| Vision end-to-end path | not reported | 54.32 s | 54.43 s | 28.54 s | 33.05 s | **35.98 s** | **19.6 s** | **10.93 s** | **7.92 s** |
-| Vision throughput | not reported | 21.37 GFLOPS | 21.37 GFLOPS | 41.41 GFLOPS | 35.85 GFLOPS | **39.64 GFLOPS** | **74.4 GFLOPS** | **143.99 GFLOPS** | **240.88 GFLOPS** |
-| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
-| LM prefill sequence executed | 512-token template | 272 actual tokens | 272 actual tokens | 272 actual tokens | 273 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
-| LM prefill FPGA latency | 113.571 s | 51.52 s | 43.95 s | 23.46 s | 28.02 s | **28.23 s** | **17.3 s** | **6.88 s** | **3.96 s** |
-| LM prefill throughput | 23.20 GFLOPS | 23.94 GFLOPS | 24.08 GFLOPS | 45.13 GFLOPS | 37.78 GFLOPS | **43.68 GFLOPS** | **71.22 GFLOPS** | **153.92 GFLOPS** | **267.16 GFLOPS** |
-| Decode average throughput | 2.68 tok/s | 3.74 tok/s | 3.75 tok/s | 3.76 tok/s | 5.69 tok/s | **5.54 tok/s** | **5.49 tok/s** | **5.55 tok/s** | **5.56 tok/s** |
-| Decode peak first-token throughput | 2.86 tok/s | 3.99 tok/s | 4.00 tok/s | 4.00 tok/s | 6.04 tok/s | **5.92 tok/s** | **5.88 tok/s** | **5.91 tok/s** | **5.87 tok/s** |
-| Decode average hardware throughput | 13.42 GFLOPS | 18.78 GFLOPS | 18.97 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **34.22 GFLOPS** | **33.97 GFLOPS** | **34.41 GFLOPS** | **34.41 GFLOPS** |
-| Vision program section | 3.58 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | 3.4 MiB | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
-| Prefill program section | 5.71 MiB | 3.08 MiB | 5.85 MiB | 4.77 MiB | 5.9 MiB | 3.08 MiB | 3.46 MiB | 4.06 MiB | 3.72 MiB |
-| Decode program section | | 1.42 MiB | 1.42 MiB | 1.42 MiB | | 1.42 MiB | 1.46 MiB | 1.42 MiB | 1.42 MiB |
-| Combined program image | 10.37 MiB | 7.73 MiB | 10.49 MiB | 13.73 MiB | 10.8 MiB | 7.73 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
-| Weight image (`params.bin`) | 6.91 GiB | same | same | same | / | same | same | same | same |
-| Correctness |  | coherent, total 724 | coherent, total 656 | coherent, total 699 | coherent, total 656 | coherent, total 656 | coherent, total 699 | coherent, total 699 | coherent, total 699 |
+| Metric | Kintex | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Peak throughput | 25.39 GFLOPS | 50.77 GFLOPS | 42.67 GFLOPS | 46.93 GFLOPS | 93.87 GFLOPS | 187.73 GFLOPS | 375.47 GFLOPS |
+| Vision FPGA execution | 53.78 s | 27.78 s | 32.05 s | **29.12 s** | **15.43 s** | **8.08 s** | **4.95 s** |
+| Vision end-to-end path | 54.43 s | 28.54 s | 32.62 s | **29.66 s** | **16.16 s** | **9.22 s** | **7.03 s** |
+| Vision throughput | 21.37 GFLOPS | 41.41 GFLOPS | 35.85 GFLOPS | **39.46 GFLOPS** | **74.47 GFLOPS** | **142.21 GFLOPS** | **232.17 GFLOPS** |
+| — utilization (% peak) | 84.2% | 81.6% | 84.0% | **84.1%** | **79.3%** | **75.8%** | **61.8%** |
+| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
+| LM prefill sequence executed | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
+| LM prefill FPGA latency | 43.95 s | 23.46 s | 28.02 s | **24.92 s** | **12.84 s** | **6.94 s** | **4.02 s** |
+| LM prefill throughput | 24.08 GFLOPS | 45.13 GFLOPS | 37.78 GFLOPS | **42.48 GFLOPS** | **82.47 GFLOPS** | **152.64 GFLOPS** | **263.39 GFLOPS** |
+| — utilization (% peak) | 94.8% | 88.9% | 88.5% | **90.5%** | **87.9%** | **81.3%** | **70.1%** |
+| Decode average throughput | 3.75 tok/s | 3.76 tok/s | 5.85 tok/s | **6.59 tok/s** | **6.52 tok/s** | **6.56 tok/s** | **6.56 tok/s** |
+| Decode peak first-token throughput | 4.00 tok/s | 4.00 tok/s | 6.21 tok/s | **6.95 tok/s** | **6.98 tok/s** | **6.94 tok/s** | **6.93 tok/s** |
+| Decode average hardware throughput | 18.97 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **40.77 GFLOPS** | **40.56 GFLOPS** | **40.56 GFLOPS** | **40.57 GFLOPS** |
+| — utilization (% peak) | 74.7% | 45.2% | 85.5% | **86.9%** | **43.2%** | **21.6%** | **10.8%** |
+| Vision program section | 3.22 MiB | 2.39 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
+| Prefill program section | 5.85 MiB | 4.77 MiB | 5.85 MiB | 5.85 MiB | 4.77 MiB | 4.06 MiB | 3.72 MiB |
+| Decode program section | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB |
+| Combined program image | 10.49 MiB | 13.73 MiB | 10.49 MiB | 10.49 MiB | 10.81 MiB | 19.20 MiB | 30.40 MiB |
+| Weight image (`params.bin`) | 6.91 GiB | same | same | same | same | same | same |
+| Correctness | coherent, total 656 | coherent, total 699 | coherent, total 656 | coherent, total 656 | coherent, total 699 | coherent, total 699 | coherent, total 699 |
 
 ## Refactor optimizations
 

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -1327,6 +1327,9 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             return f"{n / (1024 * 1024):.2f} MB" if n is not None else "n/a"
         def _kb(n):
             return f"{n / 1024:.1f} KB" if n is not None else "n/a"
+        def _util(gflops):
+            """Reported throughput as a percent of this run's peak GFLOPS."""
+            return f"{100.0 * gflops / peak_gflops:.1f}%" if peak_gflops else "n/a"
 
         is_image = bool(getattr(args, "image", None))
         is_audio = bool(getattr(args, "audio", None))
@@ -1382,6 +1385,7 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
                 lines.append(f"- **Vision FPGA run time (HW latency):** n/a (host vision)")
             if vis_gflops is not None:
                 lines.append(f"- **Vision reported FLOPS:** {vis_gflops:.2f} GFLOPS")
+                lines.append(f"- **Vision utilization (% peak):** {_util(vis_gflops)}")
             else:
                 lines.append(f"- **Vision reported FLOPS:** n/a (host vision)")
             _vis_e2e = getattr(self, "_vis_e2e_s", None)
@@ -1403,6 +1407,7 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
                          f"({pf_lat_us:.0f} us)")
         if pf_gflops is not None:
             lines.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+            lines.append(f"- **Prefill utilization (% peak):** {_util(pf_gflops)}")
         if pf_e2e is not None:
             lines.append(f"- **Prefill end-to-end (CPU timer):** {pf_e2e:.2f} s")
         lines.append("")
@@ -1424,6 +1429,7 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             lines.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
         if avg_gflops is not None:
             lines.append(f"- **Average FLOPS:** {avg_gflops:.2f} GFLOPS")
+            lines.append(f"- **Decode utilization (% peak):** {_util(avg_gflops)}")
         lines.append("")
 
         # --- Text ------------------------------------------------------------

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -1108,7 +1108,13 @@ class Gemma4VisionMixin:
 
         self.compile_vision_encoder_bin(num_patches, profile=profile)
         _mark("patch+encoder compile (host emit)")
+        # Vision run time = FPGA execute + the runtime data handoff the LM needs
+        # (the pooled image soft-tokens read back for run_prefill's merge). One-time
+        # setup (weight init / scratch alloc / host compile) is assumed done and
+        # excluded; the numeric-harness readbacks below (encoder_out + checkpoints)
+        # are debug-only and also excluded.
         self._vis_fpga_t0 = time.perf_counter()
+        _run_t0 = self._vis_fpga_t0
         enc_result = self.execute_vision_encoder_bin(num_patches, profile=profile)
         _mark("patch+encoder execute (FPGA)")
 
@@ -1119,6 +1125,8 @@ class Gemma4VisionMixin:
         N_SOFT = self.VIS_POOL_N_SOFT
         image_features = self.dma_from_accelerator_memory(
             self.VIS_EMBED_OUT, (N_SOFT, self.VIS_TEXT_H)).float().cpu()
+        # Run time ends here: FPGA execute + the LM-facing soft-token readback.
+        self._vis_e2e_s = time.perf_counter() - _run_t0
         encoder_out = self.dma_from_accelerator_memory(
             final_buf, (num_patches, self.VIS_H)).cpu()
         _mark("pooler tail readback (DMA)")
@@ -1154,9 +1162,12 @@ class Gemma4VisionMixin:
             print("-" * 54)
             print(f"{'TOTAL':<38}{_tot:>9.2f}{100.0:>6.1f}%")
         print(f"[Vision] FPGA encoder done: {image_features.shape[0]} soft tokens "
-              f"in {fpga_total_s:.2f}s total.", flush=True)
-        # Stash for the run-summary writer (write_run_summary).
+              f"in {self._vis_e2e_s:.2f}s run time "
+              f"(host total incl. setup/compile/debug readback {fpga_total_s:.2f}s).",
+              flush=True)
+        # Stash for the run-summary writer (write_run_summary). _vis_e2e_s is the
+        # vision run time (FPGA execute + LM-facing soft-token readback), set above
+        # right after the image_features readback — NOT the full host wall-clock.
         self._vis_num_soft_tokens = int(image_features.shape[0])
-        self._vis_e2e_s = fpga_total_s
         self._vis_device = "FPGA"
         return image_features, token_ids, mm_types

--- a/models/llama3.2_1b/llama3.2_1b_IF8.py
+++ b/models/llama3.2_1b/llama3.2_1b_IF8.py
@@ -1776,6 +1776,9 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
         def _kb(v):
             return f"{v:.1f} KB" if v is not None else "n/a"
+        def _util(gflops):
+            """Reported throughput as a percent of this run's peak GFLOPS."""
+            return f"{100.0 * gflops / peak_gflops:.1f}%" if peak_gflops else "n/a"
 
         pf_tokens = run_result.get("prefill_tokens")
         pf_hw_ms = run_result.get("prefill_hw_ms")
@@ -1826,6 +1829,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
         if pf_gflops is not None:
             L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+            L.append(f"- **Prefill utilization (% peak):** {_util(pf_gflops)}")
         if pf_cpu_ms is not None:
             L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
         L.append("")
@@ -1839,6 +1843,7 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
         if dec_gflops is not None:
             L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+            L.append(f"- **Decode utilization (% peak):** {_util(dec_gflops)}")
         if dec_first_ms is not None:
             L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
         if dec_avg_ms is not None:

--- a/models/llama3.2_1b/llama3.2_1b_IF8.py
+++ b/models/llama3.2_1b/llama3.2_1b_IF8.py
@@ -726,6 +726,25 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
         half_ahd    = ahd // 2              # 32
         rope_row    = hd * 2 * bpe          # bytes per rope table row
 
+        # ---- Proper-GQA prefill attention: seq_len-agnostic static dims ----
+        # `seq_len` here is the REAL prompt length, used ONLY for FLOP accounting
+        # (the caller passes len(prefill_seq)-1). The emitted attention instructions
+        # and the core's baked scratch offsets must instead reserve the MAX runtime
+        # length so one cached bin serves any prompt <= PREFILL_CONTEXT_SIZE. So the
+        # unified_attention_core static batch/aligned are pinned to PREFILL_CONTEXT
+        # (never the prompt), while the real per-token counts come from the GPRs.
+        pc_seq_len     = self.PREFILL_CONTEXT_SIZE
+        attn_aligned_static = ((pc_seq_len + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE) * UE_VECTOR_SIZE
+        real_aligned   = ((seq_len + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE) * UE_VECTOR_SIZE
+
+        def _attn_flops(batch: int, aligned: int, head_dim: int) -> int:
+            """Attention FLOPs (matching unified_attention_core's accounting) for one
+            per-head SDPA at the REAL prompt dims: QKᵀ + softmax + PV. Computed
+            model-side because the core is called with the PREFILL_CONTEXT-max static
+            dims (for scratch), so its own returned count would reflect the max, not
+            the real prompt."""
+            return 2 * batch * head_dim * aligned + 5 * batch * aligned + 2 * batch * aligned * head_dim
+
         # The host uploads prompt embeddings to OUTPUT_DRAM. Each layer consumes
         # that recurrent buffer and writes its final residual back to the same
         # buffer, eliminating the old OUTPUT->INPUT inter-layer copy.
@@ -815,7 +834,12 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                 gpr_M_reg=self.gpr_seq_len,
             )
 
-            # Phase 3: Per-KV-head scatter → KV cache + flash buffers → flash_attention
+            # Phase 3: Proper GQA — outer loop over the 8 KV heads, inner loop over
+            # the 4 query heads in each group. Each query head runs ONE compact SDPA
+            # over the un-duplicated per-KV-head K/V (read straight from the KV cache),
+            # so there is no group_size replication of K/V and the score matrix is
+            # [S, align64(S)] per head instead of [4S, 4S] per KV head — group_size×
+            # less attention MAC + KV DMA than the old duplicate-and-batch scheme.
             for kv_h in range(nkvh):
                 k_cache_base = (self.LAYER0_K_ROPE_DRAM
                                 + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
@@ -824,20 +848,12 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                                 + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
                                 + kv_h * self.MAX_CONTEXT_SIZE * ahd * bpe)
 
-                # Scatter K_h_roped (64-dim) from [lo|hi] K_DRAM → KV cache + FLASH_K
-                # lo half and hi half are non-contiguous in K_DRAM → two PBI loops.
-                k_flash_lo_specs = (
-                    [(k_cache_base,               ahd * bpe)]
-                    + [(self.LAYER0_FLASH_K_DRAM + g * ahd * bpe,               qpkv * ahd * bpe) for g in range(qpkv)]
-                )
-                k_flash_hi_specs = (
-                    [(k_cache_base + half_ahd * bpe, ahd * bpe)]
-                    + [(self.LAYER0_FLASH_K_DRAM + g * ahd * bpe + half_ahd * bpe, qpkv * ahd * bpe) for g in range(qpkv)]
-                )
+                # Scatter K_h_roped (64-dim) from [lo|hi] K_DRAM → KV cache ONLY (the
+                # compact cache row is [lo|hi] = 64 contiguous). No FLASH_K duplication.
                 self._emit_pbi_scatter_per_token(
                     read_base=self.LAYER0_K_DRAM + kv_h * half_ahd * bpe,
                     read_stride_bytes=hd * bpe,
-                    write_specs=k_flash_lo_specs,
+                    write_specs=[(k_cache_base, ahd * bpe)],
                     sram_byte_addr=0x10000,
                     element_count=half_ahd,
                     gpr_seq_len=self.gpr_seq_len,
@@ -846,33 +862,30 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                 self._emit_pbi_scatter_per_token(
                     read_base=self.LAYER0_K_DRAM + (hd // 2 + kv_h * half_ahd) * bpe,
                     read_stride_bytes=hd * bpe,
-                    write_specs=k_flash_hi_specs,
+                    write_specs=[(k_cache_base + half_ahd * bpe, ahd * bpe)],
                     sram_byte_addr=0x10080,
                     element_count=half_ahd,
                     gpr_seq_len=self.gpr_seq_len,
                     template_seq_len=seq_len,
                 )
 
-                # Scatter V_h (64-dim, standard layout) from V_PROJ_TEMP → KV cache + FLASH_V
-                # V_PROJ_TEMP layout: [seq_len, nkvh, ahd] → stride = nkvh*ahd*bpe per token.
+                # Scatter V_h (64-dim, standard layout) from V_PROJ_TEMP → KV cache ONLY.
                 self._emit_pbi_scatter_per_token(
                     read_base=self.LAYER0_V_PROJ_TEMP + kv_h * ahd * bpe,
                     read_stride_bytes=nkvh * ahd * bpe,
-                    write_specs=(
-                        [(v_cache_base, ahd * bpe)]
-                        + [(self.LAYER0_FLASH_V_DRAM + g * ahd * bpe, qpkv * ahd * bpe) for g in range(qpkv)]
-                    ),
+                    write_specs=[(v_cache_base, ahd * bpe)],
                     sram_byte_addr=0x20000,
                     element_count=ahd,
                     gpr_seq_len=self.gpr_seq_len,
                     template_seq_len=seq_len,
                 )
 
-                # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q
-                # Q group g_for_kv = kv_h//2; sub-heads 0..qpkv-1 within that group.
                 g_for_kv = kv_h // 2
                 local_kv = kv_h % 2
                 for q in range(qpkv):
+                    # Scatter this ONE query head (64-dim) from [lo|hi] Q_DRAM into a
+                    # contiguous FLASH_Q [S, 64] (lo at 0, hi at half_ahd) — the layout
+                    # unified_attention_core expects for Q=[batch, head_dim].
                     sub_idx = local_kv * qpkv + q
                     q_lo_base = (self.LAYER0_Q_DRAM
                                  + g_for_kv * hd * bpe
@@ -880,12 +893,10 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                     q_hi_base = (self.LAYER0_Q_DRAM
                                  + g_for_kv * hd * bpe
                                  + (hd // 2 + sub_idx * half_ahd) * bpe)
-                    flash_q_lo = self.LAYER0_FLASH_Q_DRAM + q * ahd * bpe
-                    flash_q_hi = flash_q_lo + half_ahd * bpe
                     self._emit_pbi_scatter_per_token(
                         read_base=q_lo_base,
                         read_stride_bytes=total_q_dim * bpe,
-                        write_specs=[(flash_q_lo, qpkv * ahd * bpe)],
+                        write_specs=[(self.LAYER0_FLASH_Q_DRAM, ahd * bpe)],
                         sram_byte_addr=0x30000,
                         element_count=half_ahd,
                         gpr_seq_len=self.gpr_seq_len,
@@ -894,53 +905,47 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                     self._emit_pbi_scatter_per_token(
                         read_base=q_hi_base,
                         read_stride_bytes=total_q_dim * bpe,
-                        write_specs=[(flash_q_hi, qpkv * ahd * bpe)],
+                        write_specs=[(self.LAYER0_FLASH_Q_DRAM + half_ahd * bpe, ahd * bpe)],
                         sram_byte_addr=0x30080,
                         element_count=half_ahd,
                         gpr_seq_len=self.gpr_seq_len,
                         template_seq_len=seq_len,
                     )
 
-                # Scaled dot-product attention for this KV head's qpkv query heads,
-                # called inline per KV head (unified_attention_core replaces the old
-                # shared flash_attention_core subroutine + JUMP_ABS call-site pattern).
-                attn_result = self.unified_attention_core(
-                    batch=q_seq_len,
-                    aligned_seq_len=aligned_seq_len,
-                    head_dim=ahd,
-                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
-                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                    gpr_batch_reg=self.gpr_q_seq_len,
-                    gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                    q_pre_scaled=True,
-                )
-                total_flops += attn_result or 0
+                    # Compact per-head SDPA: Q=[S,64] (FLASH_Q), K/V=[S,64] straight
+                    # from the cache, plain causal bias [S, align64(S)]. Static
+                    # batch/aligned pinned to PREFILL_CONTEXT (scratch/instructions
+                    # seq_len-agnostic); real per-token counts come from the GPRs.
+                    self.unified_attention_core(
+                        batch=pc_seq_len,
+                        aligned_seq_len=attn_aligned_static,
+                        head_dim=ahd,
+                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+                        K_DRAM_ADDR=k_cache_base,
+                        V_DRAM_ADDR=v_cache_base,
+                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                        gpr_batch_reg=self.gpr_seq_len,
+                        gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
+                        q_pre_scaled=True,
+                    )
+                    # FLOP counted at the REAL prompt dims (model-side, see _attn_flops).
+                    total_flops += _attn_flops(seq_len, real_aligned, ahd)
 
-                # Assemble output into LAYER0_FLASH_OUTPUT_DRAM
-                # Standard GQA layout per token: [kv0_q0(64), kv0_q1..q3, kv1_q0..q3, ...]
-                out_h_base = kv_h * qpkv * ahd * bpe
-                t_reg = self.alloc_isa_reg()
-                src_off_reg = self.alloc_isa_reg()
-                dst_off_reg = self.alloc_isa_reg()
-                self.generate_instruction_add_set(t_reg, 0)
-                self.loop_start(loop_cnt=seq_len, gpr_loop_cnt=self.gpr_seq_len)
-                self.generate_instruction_reg_mul_imm(src_off_reg, t_reg, ue_35bit_addr_shifter(qpkv * ahd * bpe))
-                self.generate_instruction_reg_mul_imm(dst_off_reg, t_reg, ue_35bit_addr_shifter(total_q_dim * bpe))
-                for g in range(qpkv):
-                    self.generate_instruction_add_imm(src_off_reg, ue_35bit_addr_shifter(self.LAYER0_FLASH_OUT_HEAD_DRAM + g * ahd * bpe), self.TMP_REG)
-                    self.accelerator_memory_to_sram(0, 0x40000, ahd, general_reg_src=self.TMP_REG)
-                    self.generate_instruction_add_imm(dst_off_reg, ue_35bit_addr_shifter(self.LAYER0_FLASH_OUTPUT_DRAM + out_h_base + g * ahd * bpe), self.TMP_REG)
-                    self.sram_to_accelerator_memory(0x40000, 0, ahd, general_reg_src=self.TMP_REG)
-                self.generate_instruction_add_inc(t_reg)
-                self.loop_end()
-                self.release_isa_reg()  # dst_off_reg
-                self.release_isa_reg()  # src_off_reg
-                self.release_isa_reg()  # t_reg
+                    # Assemble this head's [S, 64] output into FLASH_OUTPUT at its
+                    # standard-GQA slot: token row = [kv0_q0..q3, kv1_q0..q3, ...].
+                    head_pos = (kv_h * qpkv + q) * ahd * bpe
+                    self._emit_pbi_scatter_per_token(
+                        read_base=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                        read_stride_bytes=ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_OUTPUT_DRAM + head_pos, total_q_dim * bpe)],
+                        sram_byte_addr=0x40000,
+                        element_count=ahd,
+                        gpr_seq_len=self.gpr_seq_len,
+                        template_seq_len=seq_len,
+                    )
             if profile:
                 _checkpoint(f"L{layer_idx}_attention")
 
@@ -1280,10 +1285,15 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             digest.update(os.path.abspath(source_path).encode())
             with open(source_path, "rb") as source_file:
                 digest.update(source_file.read())
+        # The prompt length does NOT change the instruction bytes (the bin is
+        # seq_len-agnostic), but it does change the FLOP meta (FLOPs are accounted at
+        # the real prompt length), so fold it in to refresh a cached meta per length.
+        _pf = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
         digest.update(
             f"layers={layer_size};decode_kernel={self.decode_kernel};"
             f"prefill_kernel={self.prefill_kernel};"
-            f"penalty={getattr(self, 'fpga_penalty', False)}".encode())
+            f"penalty={getattr(self, 'fpga_penalty', False)};"
+            f"prefill_len={len(_pf) - 1}".encode())
         return digest.hexdigest()
 
     def compile_llama(self, layer_size: int | None = None, profile: bool = False) -> None:
@@ -1340,11 +1350,17 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
                 return
             print(f"Rebuilding stale instruction image at {instruction_bin_path}")
 
-        # Compile the prefill template at PREFILL_CONTEXT_SIZE (the max prompt length).
-        # All loop counts are GPR-driven (gpr_seq_len), so the single cached program
-        # handles any actual prompt length <= PREFILL_CONTEXT_SIZE; template_seq_len is
-        # used only for FLOPs accounting and the flash bucket count.
-        template_seq_len = self.PREFILL_CONTEXT_SIZE
+        # FLOP accounting uses the REAL prompt length (len(prefill_seq)-1): the static
+        # M= args and the model-side attention FLOP are then exact for this prompt
+        # (in particular the quadratic attention term, which a fixed-template +
+        # linear rescale would mis-count). The emitted instructions stay fully
+        # seq_len-agnostic — every runtime loop count is GPR-driven and the attention
+        # core's scratch is pinned to PREFILL_CONTEXT_SIZE (see _compile_prefill_program),
+        # so the same bin still serves any prompt <= PREFILL_CONTEXT_SIZE. The prompt
+        # length is folded into the compile fingerprint so a different-length prompt
+        # refreshes the FLOP meta even though the bin bytes are identical.
+        _prefill_seq = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
+        template_seq_len = len(_prefill_seq) - 1
 
         self.clear_inst_id()
         self.start_capture()
@@ -1492,7 +1508,10 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
         self.seq_len = prefill_seq_len
 
         q_seq_len = prefill_seq_len * self.group_size
-        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        # Proper GQA: each query head attends the COMPACT (S-long) per-KV-head K/V,
+        # so the dynamic aligned KV length / flash bucket are align64(S), not
+        # align64(S*group). gpr_q_seq_len is still primed (harmless) for symmetry.
+        aligned_seq_len = ((prefill_seq_len + 63) // 64) * 64
         bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
         flops_prefill = flops_prefill_template * prefill_seq_len // max(template_seq_len, 1)
 
@@ -1543,18 +1562,20 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
+        # Proper-GQA per-head plain causal bias over the compact K/V: query token r
+        # attends key token c <= r, shared by every query head; cols >= S are -inf.
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
-        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        valid_mask = cols <= rows
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, prefill_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
         print(f"Prompt ({len(self.prefill_seq)}) tokens: {self.prefill_seq}")
         timer = time.perf_counter()
-        hw_lat_prefill_us, _ = self.program_execute(preamble_addr, flops=flops_prefill)
+        hw_lat_prefill_us, prefill_gflops = self.program_execute(preamble_addr, flops=flops_prefill)
         latency_prefill = time.perf_counter() - timer
         print(f"Prefill done in {latency_prefill:.2f}s\n")
 
@@ -1714,6 +1735,8 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             "prefill_speed_tok_s": round(prefill_seq_len / latency_prefill, 2),
             "decode_speed_tok_s": round(avg_tokens_per_s, 2),
             "decoder_gflops": round(decoder_gflops, 2),
+            "prefill_gflops": round(prefill_gflops, 2) if prefill_gflops else None,
+            "total_tokens": prefill_seq_len + tokens_decoded,
             "prefill_size_kb": round(meta["prefill_program_size"] / 1024, 1),
             "decoder_size_kb": round(meta["decoder_program_size"] / 1024, 1),
             "prefill_hw_ms": hw_lat_prefill_us / 1e3,
@@ -1722,6 +1745,123 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
             "decode_avg_hw_ms": hw_decode_avg_ms,
             "decode_avg_cpu_ms": cpu_decode_avg_ms,
         }
+
+    def write_run_summary(self, out_path: str, args, run_result: dict, cores: int = 1,
+                          title: str = "llama3.2_1b_test") -> str:
+        """Write a per-run Markdown performance summary (device info, weight/program
+        sizes, prefill + decode HW latency/throughput, and the prompt/decoded text),
+        built from ``run_result`` (the run_llama dict) plus cheap host-side
+        bookkeeping. No FPGA program is launched here, so calling it after a run is
+        free. Mirrors gemma3_test.write_run_summary. Returns the written path."""
+        clock_ns = getattr(user_dma_core, "CLOCK_CYCLE_TIME_NS", 0.0) or 0.0
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        peak_gflops = freq_mhz * 0.128 * cores   # freq(MHz) * 128 MAC/cyc/1000 * cores
+        try:
+            hw_version = self.user_read_reg32(user_dma_core.UE_FPGA_VERSION_ADDR) & 0xFFFFFFFF
+            hw_version_str = f"0x{hw_version:08x}"
+        except Exception as e:
+            hw_version_str = f"(read failed: {e})"
+
+        # Weights.
+        weight_bin_rel = self._cfg["paths"]["weights_bin"]
+        weight_bin_path = os.path.join(self.script_dir, weight_bin_rel)
+        weight_bin_size = os.path.getsize(weight_bin_path) if os.path.exists(weight_bin_path) else 0
+        total_weight_dram_mb = self.get_params_dram_usage() / (1024 * 1024)
+
+        prefill_kb = run_result.get("prefill_size_kb")
+        decoder_kb = run_result.get("decoder_size_kb")
+        combined_kb = (prefill_kb or 0) + (decoder_kb or 0)
+
+        def _mb(n):
+            return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
+        def _kb(v):
+            return f"{v:.1f} KB" if v is not None else "n/a"
+
+        pf_tokens = run_result.get("prefill_tokens")
+        pf_hw_ms = run_result.get("prefill_hw_ms")
+        pf_gflops = run_result.get("prefill_gflops")
+        pf_cpu_ms = run_result.get("prefill_cpu_ms")
+        dec_n = run_result.get("decoded_tokens")
+        total_tok = run_result.get("total_tokens")
+        peak_toks = run_result.get("peak_tokens_per_s")
+        avg_toks = run_result.get("avg_tokens_per_s")
+        dec_gflops = run_result.get("decoder_gflops")
+        dec_first_ms = run_result.get("decode_first_hw_ms")
+        dec_avg_ms = run_result.get("decode_avg_hw_ms")
+
+        try:
+            prompt_text = self.tokenizer.decode(list(self.prefill_seq), skip_special_tokens=False)
+        except Exception:
+            prompt_text = "(decode failed)"
+        decoded_text = run_result.get("decoded_text") or "(none)"
+
+        L = []
+        L.append(f"# {title} run summary")
+        L.append("")
+        L.append(f"- **HW version:** {hw_version_str}")
+        L.append(f"- **--dev:** {args.dev}")
+        L.append(f"- **--device:** {args.device}")
+        L.append(f"- **Clock / frequency:** {clock_ns:.4f} ns ({freq_mhz:.1f} MHz)")
+        L.append(f"- **Cores:** {cores}")
+        L.append(f"- **Prefill kernel:** {run_result.get('prefill_kernel', 'n/a')}")
+        L.append(f"- **Decode kernel:** {run_result.get('decode_kernel', 'n/a')}")
+        L.append(f"- **Peak throughput:** {peak_gflops:.2f} GFLOPS "
+                 f"({freq_mhz:.1f} MHz × 128 × {cores} core(s))")
+        L.append("")
+        L.append(f"## Weights")
+        L.append("")
+        L.append(f"- **Weight bin:** `{os.path.basename(weight_bin_path)}` — {_mb(weight_bin_size)}")
+        L.append(f"- **Total weight DRAM (quantized, on FPGA):** {total_weight_dram_mb:.1f} MB")
+        L.append("")
+        L.append(f"## Program image")
+        L.append("")
+        L.append(f"- **Prefill program:** {_kb(prefill_kb)}")
+        L.append(f"- **Decoder program:** {_kb(decoder_kb)}")
+        L.append(f"- **Combined program image:** {_kb(combined_kb)}")
+        L.append("")
+        L.append(f"## Prefill")
+        L.append("")
+        L.append(f"- **Prefill tokens (seq_len):** {pf_tokens if pf_tokens is not None else 'n/a'}")
+        if pf_hw_ms is not None:
+            L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
+        if pf_gflops is not None:
+            L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+        if pf_cpu_ms is not None:
+            L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
+        L.append("")
+        L.append(f"## Decode")
+        L.append("")
+        L.append(f"- **Decoded tokens:** {dec_n if dec_n is not None else 'n/a'} generated "
+                 f"(sequence total {total_tok if total_tok is not None else 'n/a'})")
+        if peak_toks is not None:
+            L.append(f"- **First-token speed (peak):** {peak_toks:.2f} tok/s")
+        if avg_toks is not None:
+            L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
+        if dec_gflops is not None:
+            L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+        if dec_first_ms is not None:
+            L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
+        if dec_avg_ms is not None:
+            L.append(f"- **Decode average HW latency:** {dec_avg_ms:.1f} ms/tok")
+        L.append("")
+        L.append(f"## Prompt & output")
+        L.append("")
+        L.append(f"### Full prefill prompt")
+        L.append("")
+        L.append("```")
+        L.append(prompt_text)
+        L.append("```")
+        L.append("")
+        L.append(f"### Decoded text")
+        L.append("")
+        L.append("```")
+        L.append(decoded_text)
+        L.append("```")
+        L.append("")
+
+        with open(out_path, "w") as f:
+            f.write("\n".join(L))
+        return out_path
 
     def _profile_execute(self, preamble_addr: int, checkpoints: list,
                          tail_label: str | None = None, timeout: float = 30.0) -> tuple[list, dict]:
@@ -1798,7 +1938,8 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
         self.seq_len = prefill_seq_len
 
         q_seq_len = prefill_seq_len * self.group_size
-        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        # Proper GQA: compact per-head aligned KV length (align64(S)), see run_llama.
+        aligned_seq_len = ((prefill_seq_len + 63) // 64) * 64
         bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
 
         # On-FPGA penalty needs a zeroed bias buffer so the profiled decode step is pure-greedy.
@@ -1821,12 +1962,14 @@ class Llama32_1b_IF8_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
+        # Proper-GQA per-head plain causal bias over the compact K/V: query token r
+        # attends key token c <= r, shared by every query head; cols >= S are -inf.
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
-        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        valid_mask = cols <= rows
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, prefill_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         global _SILENT_MODE
@@ -1886,6 +2029,22 @@ def _clock_ns_default_for_device(device: str) -> float:
     return 10.0
 
 
+def llama_run_summary_filename(args, prefix: str = "llama3.2_1b_IF8_test") -> str:
+    """Per-run summary .md filename encoding the CLI config, e.g.
+    ``llama3.2_1b_IF8_test_xdma1_kintex7_puregreedy.md``. dev/device are always
+    present; other knobs are appended only when non-default."""
+    tokens = [args.dev, args.device]
+    if getattr(args, "pure_greedy", False):
+        tokens.append("puregreedy")
+    if getattr(args, "prefill_kernel", None) == "matmatmul":
+        tokens.append("prefill-matmatmul")
+    if getattr(args, "decode_kernel", None) == "matmatmul":
+        tokens.append("decode-matmatmul")
+    if getattr(args, "cycle", None) is not None:
+        tokens.append(f"cycle_{args.cycle}")
+    return prefix + "_" + "_".join(str(t) for t in tokens) + ".md"
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Llama-3.2-1B IF8 prefill + decode on accelerator.")
@@ -1914,24 +2073,6 @@ def main():
         help='Projection kernel for decode, including the LM head: streaming or matmatmul. '
              'Default: streaming. matmatmul is unsupported on 512-bit AXI devices.',
     )
-    parser.add_argument(
-        '--two-pass-decoder', '--decoder-matmatmul', '--matmatmul',
-        dest='legacy_decoder_matmatmul',
-        action='store_true',
-        help='Compatibility alias for --decode-kernel matmatmul.',
-    )
-    parser.add_argument(
-        '--two-pass-prefill',
-        dest='legacy_prefill_matmatmul',
-        action='store_true',
-        help='Compatibility alias for --prefill-kernel matmatmul.',
-    )
-    parser.add_argument(
-        '--stream-prefill',
-        dest='legacy_prefill_streaming',
-        action='store_true',
-        help='Compatibility alias for --prefill-kernel streaming.',
-    )
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile binary with per-step HALT checkpoints and print one '
                              'per-step HW-latency table (summed over all layers) for prefill and for '
@@ -1957,25 +2098,8 @@ def main():
                              'special tokens). Default 256.')
     args = parser.parse_args()
 
-    if args.legacy_prefill_matmatmul and args.legacy_prefill_streaming:
-        parser.error("--two-pass-prefill conflicts with --stream-prefill")
     prefill_kernel = args.prefill_kernel or Llama32_1b_IF8_UnifiedEngine.DEFAULT_PREFILL_KERNEL
-    if args.legacy_prefill_matmatmul:
-        if args.prefill_kernel not in (None, "matmatmul"):
-            parser.error("--two-pass-prefill conflicts with --prefill-kernel streaming")
-        prefill_kernel = "matmatmul"
-    if args.legacy_prefill_streaming:
-        if args.prefill_kernel not in (None, "streaming"):
-            parser.error("--stream-prefill conflicts with --prefill-kernel matmatmul")
-        prefill_kernel = "streaming"
     decode_kernel = args.decode_kernel or Llama32_1b_IF8_UnifiedEngine.DEFAULT_DECODE_KERNEL
-    if args.legacy_decoder_matmatmul:
-        if args.decode_kernel not in (None, "matmatmul"):
-            parser.error(
-                "--two-pass-decoder/--decoder-matmatmul/--matmatmul conflicts "
-                "with --decode-kernel streaming"
-            )
-        decode_kernel = "matmatmul"
     axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
     if axi_width_bits == 512 and (
         prefill_kernel == "matmatmul" or decode_kernel == "matmatmul"
@@ -2083,6 +2207,15 @@ def main():
     run_result = ue.run_llama()
     print("Llama-3.2-1B IF8 test ends.")
     _original_print(f"TEST_RESULT: {json.dumps(run_result)}")
+
+    # Per-run Markdown performance summary, named for the CLI config, written
+    # next to this script (see llama_run_summary_filename / write_run_summary).
+    _summary_path = os.path.join(SCRIPT_DIR, llama_run_summary_filename(args))
+    try:
+        ue.write_run_summary(_summary_path, args, run_result, title="llama3.2_1b_IF8_test")
+        print(f"Wrote run summary: {_summary_path}")
+    except Exception as _e:
+        print(f"[warn] failed to write run summary: {_e}")
 
 if __name__ == "__main__":
     main()

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -1896,6 +1896,9 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
         def _kb(v):
             return f"{v:.1f} KB" if v is not None else "n/a"
+        def _util(gflops):
+            """Reported throughput as a percent of this run's peak GFLOPS."""
+            return f"{100.0 * gflops / peak_gflops:.1f}%" if peak_gflops else "n/a"
 
         pf_tokens = run_result.get("prefill_tokens")
         pf_hw_ms = run_result.get("prefill_hw_ms")
@@ -1946,6 +1949,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
         if pf_gflops is not None:
             L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+            L.append(f"- **Prefill utilization (% peak):** {_util(pf_gflops)}")
         if pf_cpu_ms is not None:
             L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
         L.append("")
@@ -1959,6 +1963,7 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
         if dec_gflops is not None:
             L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+            L.append(f"- **Decode utilization (% peak):** {_util(dec_gflops)}")
         if dec_first_ms is not None:
             L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
         if dec_avg_ms is not None:

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -17,6 +17,13 @@ Architecture differences vs Gemma3:
   - LM head weight is tied to the embedding weight.
   - gamma_offset = 0.0 (LLaMA uses w directly, not 1+w).
 
+DRAM map (device DRAM is mapped AT 0x80000000; nothing usable below it — see
+__init__ for the authoritative layout + boundary guards):
+  params : 0x80000000 .. 0xB0000000   weights
+  tensor : 0xB0000000 .. 0xFE000000   activations / KV
+  worker : 0xFE000000 .. 0xFF600000   --multi-core prefill worker programs only
+  program: 0xFF600000 .. 0x100000000  master instruction image + preamble
+
 Weights:
   - Default: llama3.2_1b_bin/params.bin (generated from HF model if missing).
   - --local-weights: use llama3.2_1b_bin/full_model_weights.bin instead.
@@ -348,19 +355,36 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
     def __init__(self, script_dir: str | None = None, hf_model_dir: str | None = None, weights_bin: str | None = None,
                  decoder_matmatmul: bool | None = None, stream_prefill: bool | None = None,
                  matmatmul: bool | None = None, prefill_kernel: str | None = None,
-                 decode_kernel: str | None = None):
+                 decode_kernel: str | None = None, multi_core: int = 1):
         # IF4 layout inside the 2 GB window 0x80000000..0xFFFFFFFF.
+        # DRAM is mapped AT 0x80000000 (user_dma_core.DRAM_START_ADDR); there is
+        # NO usable DRAM below it, so every region — including the multi-core
+        # worker ISA band — must be carved out of THIS window. (The scheduler's
+        # default worker arena is DRAM_START + 0x10000000 = 0x90000000, which
+        # lands ~256 MiB deep inside the weights below; --multi-core therefore
+        # passes an explicit base — see _ensure_prefill_scheduler.)
         # At max_context_size=1024 the loaded params use ~642 MiB and tensors/KV
-        # use ~212 MiB. Keep simple aligned boundaries and reserve the final
-        # 10 MiB exclusively for the captured instruction image + preamble.
+        # use ~212 MiB. Keep simple aligned boundaries; reserve the final 10 MiB
+        # for the master instruction image + preamble, and a 22 MiB band just
+        # below it for the multi-core prefill worker programs.
         #   params : 0x80000000 .. 0xB0000000  (768 MiB)
-        #   tensor : 0xB0000000 .. 0xFF600000  (1270 MiB)
+        #   tensor : 0xB0000000 .. 0xFE000000  (1248 MiB)
+        #   worker : 0xFE000000 .. 0xFF600000  (22 MiB, --multi-core only)
         #   program: 0xFF600000 .. 0x100000000 (10 MiB)
         super().__init__(
             params_dram_base=0x80000000,
             tensor_dram_base=0xB0000000,
             program_dram_base=0xFF600000,
         )
+        # Multi-core prefill worker ISA band (consumed in _ensure_prefill_scheduler).
+        # Workers hold ONLY their prefill program here; every data buffer they
+        # touch is addressed absolutely into the shared llama tensors, so no
+        # separate worker params/tensor arena is needed. Each worker gets a
+        # WORKER_ISA_STRIDE-sized slice and the band ends exactly at the master
+        # program base, so the tensor region above and the program region below
+        # both bound it. 3 MiB/worker × ≤7 workers (22 MiB) stays under 0xFF600000.
+        self.WORKER_ISA_BASE   = 0xFE000000
+        self.WORKER_ISA_STRIDE = 0x00300000   # 3 MiB / worker
         self.script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
         # Unified kernel selection. The boolean inputs are legacy constructor
         # aliases retained for callers outside this script.
@@ -400,6 +424,14 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             )
         self.prefill_kernel = prefill_kernel
         self.decode_kernel = decode_kernel
+        # Multi-core prefill: engine 0 is this (primary); engines 1..N-1 are worker
+        # UnifiedEngines built lazily by the scheduler. N>2 is unverified on this
+        # device (the scheduler asserts unless opted in). See _ensure_prefill_scheduler.
+        if not 1 <= multi_core <= 8:
+            raise ValueError(f"multi_core must be between 1 and 8, got {multi_core}")
+        self.multi_core = multi_core
+        self._prefill_scheduler = None
+        self._prefill_worker_addrs = []
         self._cfg = _load_config(self.script_dir)
         self.weight_defs = self._cfg["_weight_defs"]
 
@@ -457,11 +489,13 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 f"tensor_start=0x{self._tensor_dram_base:X}"
             )
         self.tensor_init()
-        if self.get_tensor_dram_addr() > self._program_dram_base:
+        # Tensor now ends at the worker ISA band, not the master program region:
+        # the 22 MiB worker band (0xFE000000..program_base) sits between them.
+        if self.get_tensor_dram_addr() > self.WORKER_ISA_BASE:
             raise MemoryError(
-                f"Tensor DRAM overlaps program DRAM: "
+                f"Tensor DRAM overlaps the multi-core worker ISA band: "
                 f"tensor_end=0x{self.get_tensor_dram_addr():X}, "
-                f"program_start=0x{self._program_dram_base:X}"
+                f"worker_isa_base=0x{self.WORKER_ISA_BASE:X}"
             )
 
     def get_embedding_for_tokens(self, token_ids: list[int] | tuple) -> torch.Tensor:
@@ -633,7 +667,47 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         print(f"    Allocate tensor dram end at DRAM address: 0x{self.get_tensor_dram_addr():X}, usage: {self.get_tensor_dram_usage()} bytes")
 
-    def _compile_prefill_program(self, template_seq_len: int, layer_size: int, profile: bool = False) -> dict:
+    def _ensure_prefill_scheduler(self):
+        """Lazily build (once) the MultiEngineScheduler for prefill row-sharding.
+        Returns None for single-core.
+
+        Worker programs are placed in the dedicated WORKER_ISA band carved out of
+        llama's own address window (0xFE000000..program_base). The scheduler's
+        DEFAULT worker arena (DRAM_START + 0x10000000 = 0x90000000) must NOT be
+        used: DRAM is mapped at 0x80000000, so that default lands inside the
+        weights and silently corrupts them. worker_tensor_offset/
+        worker_program_offset=0 make the passed base the worker's program base
+        directly (workers never use their params/tensor allocators — all data is
+        addressed absolutely into the shared llama tensors)."""
+        if self.multi_core <= 1:
+            return None
+        if self._prefill_scheduler is None:
+            from multi_engine_shard import MultiEngineScheduler
+            # Boundary protection: the whole worker band (one WORKER_ISA_STRIDE
+            # slice per worker) must fit under the master program region.
+            band_end = self.WORKER_ISA_BASE + (self.multi_core - 1) * self.WORKER_ISA_STRIDE
+            if band_end > self._program_dram_base:
+                raise MemoryError(
+                    f"Worker ISA band overflows the program region for "
+                    f"multi_core={self.multi_core}: band_end=0x{band_end:X} > "
+                    f"program_base=0x{self._program_dram_base:X} "
+                    f"(base=0x{self.WORKER_ISA_BASE:X}, stride=0x{self.WORKER_ISA_STRIDE:X})"
+                )
+            # allow_unaligned_rows: the row-local MLP kernels (rms/eltwise/matmul)
+            # loop per token, so a non-64-aligned M shard is safe here and lets a
+            # short prompt (e.g. 44 tokens → 22/22) still split across 2 engines.
+            self._prefill_scheduler = MultiEngineScheduler(
+                self, num_engines=self.multi_core,
+                worker_dram_base=self.WORKER_ISA_BASE,
+                worker_dram_stride=self.WORKER_ISA_STRIDE,
+                worker_tensor_offset=0,
+                worker_program_offset=0,
+                allow_unaligned_rows=True,
+                allow_more_than_two_engines=self.multi_core > 2)
+        return self._prefill_scheduler
+
+    def _compile_prefill_program(self, template_seq_len: int, layer_size: int, profile: bool = False,
+                                 prefill_scheduler=None) -> dict:
         """Compile prefill into the active capture session.
 
         ``template_seq_len`` is used only for FLOPs accounting and static M= args;
@@ -705,6 +779,16 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 kwargs.pop("is_B_quantized", None)
                 return self.quantized_matmat_core(M=M, K=K, N=N, **kwargs)
             return self.matmat_mul_core(M=M, K=K, N=N, **kwargs)
+
+        def _shard_projection_core(ue, M: int, K: int, N: int, **kwargs) -> int:
+            """Emit one row-shard projection onto engine ``ue`` using the same
+            (streaming, compact) kernel as single-core so the master program still
+            fits the 10 MiB region. The row count comes from gpr_M_reg (the caller
+            primes it) — the streaming kernel needs a GPR-driven M, not a baked one."""
+            if self.prefill_kernel == "streaming":
+                kwargs.pop("is_B_quantized", None)
+                return ue.quantized_matmat_core(M=M, K=K, N=N, **kwargs)
+            return ue.matmat_mul_core(M=M, K=K, N=N, **kwargs)
 
         for layer_idx in range(layer_size):
             layer_off = layer_idx * LAYER_WEIGHT_SIZE
@@ -916,48 +1000,92 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             if profile:
                 _checkpoint(f"L{layer_idx}_o_proj_residual")
 
-            # LLaMA: post_attention_layernorm IS the pre-FFN norm
-            total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
-                              OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off,
-                              gpr_M_reg=self.gpr_seq_len)
-            if profile:
-                _checkpoint(f"L{layer_idx}_pre_ffn_norm")
-            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
-                A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True,
-                gpr_M_reg=self.gpr_seq_len)
-            total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
-                A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4,
-                gpr_M_reg=self.gpr_seq_len)
-            # gate × up — per-row PBI loop (gpr_seq_len trips); one row of mlp_elements per iter.
-            self.eltwise_core_dram(
-                M=seq_len, N=self.mlp_elements,
-                dram_a=self.LAYER0_MLP_GATE_DRAM,
-                dram_b=self.LAYER0_MLP_UP_DRAM,
-                dram_out=self.LAYER0_MLP_MULT_DRAM,
-                mode=UE_MODE.ELTWISE_MUL,
-                gpr_M_reg=self.gpr_seq_len,
-            )
-            if profile:
-                _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
-            total_flops += prefill_projection_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
-                A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
-                is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4,
-                gpr_M_reg=self.gpr_seq_len)
+            # ---- MLP block: post-attn norm + gate/up + silu·mul + down + residual.
+            # Every op here is row-local (each token independent), so with
+            # --multi-core it row-shards cleanly across engines: engine e handles
+            # rows [row_offset, row_offset+rows) of every buffer, reading the shared
+            # (read-only) weights by absolute address. The scheduler emits an entry
+            # + exit barrier around the region. Single-core path is unchanged.
+            vlb = self.vector_length * self.bytes_per_element
+            mlpb = self.mlp_elements * self.bytes_per_element
+            if prefill_scheduler is None:
+                # LLaMA: post_attention_layernorm IS the pre-FFN norm
+                total_flops += self.rms_norm_core_dram(M=seq_len, N=self.vector_length, A_DRAM_ADDR=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                                  OUTPUT_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off,
+                                  gpr_M_reg=self.gpr_seq_len)
+                if profile:
+                    _checkpoint(f"L{layer_idx}_pre_ffn_norm")
+                total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+                    A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_GATE_DRAM,
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True,
+                    gpr_M_reg=self.gpr_seq_len)
+                total_flops += prefill_projection_core(M=seq_len, K=self.vector_length, N=self.mlp_elements,
+                    A_DRAM_ADDR=self.LAYER0_PRE_MLP_NORM_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_UP_DRAM,
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4,
+                    gpr_M_reg=self.gpr_seq_len)
+                # gate × up — per-row PBI loop (gpr_seq_len trips); one row of mlp_elements per iter.
+                self.eltwise_core_dram(
+                    M=seq_len, N=self.mlp_elements,
+                    dram_a=self.LAYER0_MLP_GATE_DRAM,
+                    dram_b=self.LAYER0_MLP_UP_DRAM,
+                    dram_out=self.LAYER0_MLP_MULT_DRAM,
+                    mode=UE_MODE.ELTWISE_MUL,
+                    gpr_M_reg=self.gpr_seq_len,
+                )
+                if profile:
+                    _checkpoint(f"L{layer_idx}_mlp_gateup_mul")
+                total_flops += prefill_projection_core(M=seq_len, K=self.mlp_elements, N=self.vector_length,
+                    A_DRAM_ADDR=self.LAYER0_MLP_MULT_DRAM, B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off, OUTPUT_DRAM_ADDR=self.LAYER0_MLP_DOWN_DRAM,
+                    is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4,
+                    gpr_M_reg=self.gpr_seq_len)
 
-            # LLaMA: no post-FFN norm; add residual directly to down_proj output.
-            # Per-row PBI loop (gpr_seq_len trips) — layer_output = POST_ATTN_RESIDUAL + MLP_DOWN.
-            self.eltwise_core_dram(
-                M=seq_len, N=self.vector_length,
-                dram_a=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
-                dram_b=self.LAYER0_MLP_DOWN_DRAM,
-                dram_out=self.LAYER0_OUTPUT_DRAM,
-                mode=UE_MODE.ELTWISE_ADD,
-                gpr_M_reg=self.gpr_seq_len,
-            )
-            if profile:
-                _checkpoint(f"L{layer_idx}_mlp_down_residual")
+                # LLaMA: no post-FFN norm; add residual directly to down_proj output.
+                # Per-row PBI loop (gpr_seq_len trips) — layer_output = POST_ATTN_RESIDUAL + MLP_DOWN.
+                self.eltwise_core_dram(
+                    M=seq_len, N=self.vector_length,
+                    dram_a=self.LAYER0_POST_ATTN_RESIDUAL_DRAM,
+                    dram_b=self.LAYER0_MLP_DOWN_DRAM,
+                    dram_out=self.LAYER0_OUTPUT_DRAM,
+                    mode=UE_MODE.ELTWISE_ADD,
+                    gpr_M_reg=self.gpr_seq_len,
+                )
+                if profile:
+                    _checkpoint(f"L{layer_idx}_mlp_down_residual")
+            else:
+                _mlp_flops = [0]
+                def _emit_mlp_shard(ctx, layer_off=layer_off):
+                    # Per-engine row count via a GPR. gpr_q_seq_len (reg 6) is unused
+                    # in prefill after the proper-GQA rewrite, so repurpose it as the
+                    # shard row-count register on every engine (the master's dynamic
+                    # ISA pool is full; the workers set their own). Primed once per
+                    # shard, then reused by every op in the block.
+                    ue = ctx.unsafe_ue
+                    m = self.gpr_q_seq_len
+                    ue.generate_instruction_add_set(m, ctx.rows)
+                    ue.rms_norm_core_dram(M=ctx.rows, N=self.vector_length,
+                        A_DRAM_ADDR=ctx.rows_addr(self.LAYER0_POST_ATTN_RESIDUAL_DRAM, vlb),
+                        OUTPUT_DRAM_ADDR=ctx.rows_addr(self.LAYER0_PRE_MLP_NORM_DRAM, vlb),
+                        GAMMA_DRAM_ADDR=self.DRAM_ADDR_LAYER0_FFN_NORM_GAMMA + layer_off, gpr_M_reg=m)
+                    _mlp_flops[0] += _shard_projection_core(ue, M=ctx.rows, K=self.vector_length, N=self.mlp_elements,
+                        A_DRAM_ADDR=ctx.rows_addr(self.LAYER0_PRE_MLP_NORM_DRAM, vlb), B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_QUANT + layer_off,
+                        OUTPUT_DRAM_ADDR=ctx.rows_addr(self.LAYER0_MLP_GATE_DRAM, mlpb),
+                        is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_GATE_SCALE + layer_off, data_type=TYPE.IF4, silu_enable=True, gpr_M_reg=m)
+                    _mlp_flops[0] += _shard_projection_core(ue, M=ctx.rows, K=self.vector_length, N=self.mlp_elements,
+                        A_DRAM_ADDR=ctx.rows_addr(self.LAYER0_PRE_MLP_NORM_DRAM, vlb), B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_QUANT + layer_off,
+                        OUTPUT_DRAM_ADDR=ctx.rows_addr(self.LAYER0_MLP_UP_DRAM, mlpb),
+                        is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_UP_SCALE + layer_off, data_type=TYPE.IF4, gpr_M_reg=m)
+                    ue.eltwise_core_dram(M=ctx.rows, N=self.mlp_elements,
+                        dram_a=ctx.rows_addr(self.LAYER0_MLP_GATE_DRAM, mlpb), dram_b=ctx.rows_addr(self.LAYER0_MLP_UP_DRAM, mlpb),
+                        dram_out=ctx.rows_addr(self.LAYER0_MLP_MULT_DRAM, mlpb), mode=UE_MODE.ELTWISE_MUL, gpr_M_reg=m)
+                    _mlp_flops[0] += _shard_projection_core(ue, M=ctx.rows, K=self.mlp_elements, N=self.vector_length,
+                        A_DRAM_ADDR=ctx.rows_addr(self.LAYER0_MLP_MULT_DRAM, mlpb), B_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_QUANT + layer_off,
+                        OUTPUT_DRAM_ADDR=ctx.rows_addr(self.LAYER0_MLP_DOWN_DRAM, vlb),
+                        is_B_quantized=True, SCALE_DRAM_ADDR=self.DRAM_ADDR_LAYER0_MLP_DOWN_SCALE + layer_off, data_type=TYPE.IF4, gpr_M_reg=m)
+                    ue.eltwise_core_dram(M=ctx.rows, N=self.vector_length,
+                        dram_a=ctx.rows_addr(self.LAYER0_POST_ATTN_RESIDUAL_DRAM, vlb), dram_b=ctx.rows_addr(self.LAYER0_MLP_DOWN_DRAM, vlb),
+                        dram_out=ctx.rows_addr(self.LAYER0_OUTPUT_DRAM, vlb), mode=UE_MODE.ELTWISE_ADD, gpr_M_reg=m)
+                prefill_scheduler.sharded_region(seq_len, _emit_mlp_shard)
+                total_flops += _mlp_flops[0]
         self.generate_instruction_halt()
         prefill_program_size = (self.capture_count - count_at_start) * INSTRUCTION_SIZE_BYTES
         _SILENT_MODE = False
@@ -1285,7 +1413,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         )
         print(f"Decode kernel: {self.decode_kernel} — {decode_description}")
         print(f"Prefill kernel: {self.prefill_kernel} — {prefill_description}")
-        if os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
+        # Multi-core prefill writes the worker programs to the workers' DRAM as a
+        # side effect of compiling (scheduler.finalize), and run_llama needs the
+        # returned worker addresses. A cache hit would skip that, so always
+        # (re)compile when sharding is active.
+        prefill_scheduler = self._ensure_prefill_scheduler()
+        if prefill_scheduler is None and os.path.exists(instruction_bin_path) and os.path.exists(instruction_meta_path):
             try:
                 with open(instruction_meta_path, "r") as meta_file:
                     cached_meta = json.load(meta_file)
@@ -1314,10 +1447,37 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.clear_inst_id()
         self.start_capture()
 
-        print(f"Compiling prefill (template_seq_len={template_seq_len}; profile={profile})...")
+        # Multi-core: open the worker capture sessions before the prefill body so
+        # the sharded MLP regions + barriers emit into every engine; close them
+        # (writing each worker program to its DRAM) right after prefill — the
+        # decoder is single-engine (master only).
+        if prefill_scheduler is not None:
+            prefill_scheduler.begin_program()
+
+        print(f"Compiling prefill (template_seq_len={template_seq_len}; profile={profile}; multi_core={self.multi_core})...")
         t0 = time.perf_counter()
-        prefill_prog = self._compile_prefill_program(template_seq_len=template_seq_len, layer_size=layer_size, profile=profile)
+        prefill_prog = self._compile_prefill_program(template_seq_len=template_seq_len, layer_size=layer_size, profile=profile,
+                                                     prefill_scheduler=prefill_scheduler)
         print(f"  prefill compiled: {prefill_prog['size_bytes']} bytes, {time.perf_counter() - t0:.1f}s")
+        if prefill_scheduler is not None:
+            self._prefill_worker_addrs = prefill_scheduler.finalize()
+            # Boundary protection: each worker program must stay inside its own
+            # WORKER_ISA_STRIDE slice (and thus below the next worker / the master
+            # program region). finalize() has already DMA-written them, so a
+            # violation means the write clobbered a neighbour — fail loudly.
+            for engine_idx, (worker, worker_addr) in enumerate(
+                    zip(prefill_scheduler.workers, self._prefill_worker_addrs), start=1):
+                worker_end = worker_addr + worker.get_capture_instruction_size_bytes()
+                slice_limit = self.WORKER_ISA_BASE + engine_idx * self.WORKER_ISA_STRIDE
+                if worker_end > slice_limit:
+                    raise MemoryError(
+                        f"prefill worker{engine_idx} ISA overflow: "
+                        f"end=0x{worker_end:X} > slice_limit=0x{slice_limit:X} "
+                        f"(base=0x{worker_addr:X}, stride=0x{self.WORKER_ISA_STRIDE:X}); "
+                        f"increase WORKER_ISA_STRIDE"
+                    )
+            print(f"  prefill workers: {len(self._prefill_worker_addrs)} program(s), "
+                  f"{prefill_scheduler.worker_program_bytes()} bytes total")
 
         print("Compiling decoder...")
         t0 = time.perf_counter()
@@ -1523,8 +1683,19 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
         print(f"Prompt ({len(self.prefill_seq)}) tokens: {self.prefill_seq}")
+        # Multi-core: launch the worker programs (they spin-wait at the first
+        # barrier) BEFORE the master program, and join them after it halts. The
+        # worker programs were written to their DRAM at compile time
+        # (scheduler.finalize) and self._prefill_worker_addrs was saved.
+        prefill_scheduler = getattr(self, "_prefill_scheduler", None) if self.multi_core > 1 else None
         timer = time.perf_counter()
+        if prefill_scheduler is not None:
+            prefill_scheduler.preclear_flags()
+            prefill_scheduler.start_workers(self._prefill_worker_addrs)
         hw_lat_prefill_us, prefill_gflops = self.program_execute(preamble_addr, flops=flops_prefill)
+        if prefill_scheduler is not None:
+            for w in prefill_scheduler.workers:
+                w.wait_queue(300.0)
         latency_prefill = time.perf_counter() - timer
         print(f"Prefill done in {latency_prefill:.2f}s\n")
 
@@ -1983,6 +2154,8 @@ def llama_run_summary_filename(args, prefix: str = "llama3.2_1b_test") -> str:
     ``llama3.2_1b_test_xdma1_kintex7.md`` or ``..._xdma0_alveo_puregreedy.md``.
     dev/device are always present; other knobs are appended only when non-default."""
     tokens = [args.dev, args.device]
+    if getattr(args, "multi_core", 1) and args.multi_core > 1:
+        tokens.append(f"multi-core-{args.multi_core}")
     if getattr(args, "pure_greedy", False):
         tokens.append("puregreedy")
     if getattr(args, "prefill_kernel", None) == "matmatmul":
@@ -2026,6 +2199,10 @@ def main():
                         help='Compile a profile binary with per-step HALT checkpoints and print one '
                              'per-step HW-latency table (summed over all layers) for prefill and for '
                              'the first decoded token.')
+    parser.add_argument('--multi-core', nargs='?', type=int, const=2, default=1,
+                        help='Row-shard the prefill MLP block across N engines (default 2 when the '
+                             'flag is given with no value). 1 = single-engine. >2 is unverified on '
+                             'this device.')
     # On-FPGA repetition penalty is the DEFAULT decode path: the penalty is folded into the LM-head
     # matmul bias so the HW argmax returns the penalized token directly — no logit readback,
     # fully deterministic. --pure-greedy disables it entirely.
@@ -2093,6 +2270,7 @@ def main():
         weights_bin=weights_bin_rel,
         prefill_kernel=prefill_kernel,
         decode_kernel=decode_kernel,
+        multi_core=args.multi_core,
     )
     cfg = _load_config(script_dir)
 

--- a/models/llama3.2_1b/llama3.2_1b_test.py
+++ b/models/llama3.2_1b/llama3.2_1b_test.py
@@ -675,6 +675,25 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         half_ahd    = ahd // 2              # 32
         rope_row    = hd * 2 * bpe          # bytes per rope table row
 
+        # ---- Proper-GQA prefill attention: seq_len-agnostic static dims ----
+        # `seq_len` here is the REAL prompt length, used ONLY for FLOP accounting
+        # (the caller passes len(prefill_seq)-1). The emitted attention instructions
+        # and the core's baked scratch offsets must instead reserve the MAX runtime
+        # length so one cached bin serves any prompt <= PREFILL_CONTEXT_SIZE. So the
+        # unified_attention_core static batch/aligned are pinned to PREFILL_CONTEXT
+        # (never the prompt), while the real per-token counts come from the GPRs.
+        pc_seq_len     = self.PREFILL_CONTEXT_SIZE
+        attn_aligned_static = ((pc_seq_len + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE) * UE_VECTOR_SIZE
+        real_aligned   = ((seq_len + UE_VECTOR_SIZE - 1) // UE_VECTOR_SIZE) * UE_VECTOR_SIZE
+
+        def _attn_flops(batch: int, aligned: int, head_dim: int) -> int:
+            """Attention FLOPs (matching unified_attention_core's accounting) for one
+            per-head SDPA at the REAL prompt dims: QKᵀ + softmax + PV. Computed
+            model-side because the core is called with the PREFILL_CONTEXT-max static
+            dims (for scratch), so its own returned count would reflect the max, not
+            the real prompt."""
+            return 2 * batch * head_dim * aligned + 5 * batch * aligned + 2 * batch * aligned * head_dim
+
         # The host uploads prompt embeddings to OUTPUT_DRAM. Each layer consumes
         # that recurrent buffer and writes its final residual back to the same
         # buffer, eliminating the old OUTPUT->INPUT inter-layer copy.
@@ -764,7 +783,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 gpr_M_reg=self.gpr_seq_len,
             )
 
-            # Phase 3: Per-KV-head scatter → KV cache + flash buffers → flash_attention
+            # Phase 3: Proper GQA — outer loop over the 8 KV heads, inner loop over
+            # the 4 query heads in each group. Each query head runs ONE compact SDPA
+            # over the un-duplicated per-KV-head K/V (read straight from the KV cache),
+            # so there is no group_size replication of K/V and the score matrix is
+            # [S, align64(S)] per head instead of [4S, 4S] per KV head — group_size×
+            # less attention MAC + KV DMA than the old duplicate-and-batch scheme.
             for kv_h in range(nkvh):
                 k_cache_base = (self.LAYER0_K_ROPE_DRAM
                                 + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
@@ -773,20 +797,12 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                                 + layer_idx * self.MAX_CONTEXT_SIZE * self.k_size
                                 + kv_h * self.MAX_CONTEXT_SIZE * ahd * bpe)
 
-                # Scatter K_h_roped (64-dim) from [lo|hi] K_DRAM → KV cache + FLASH_K
-                # lo half and hi half are non-contiguous in K_DRAM → two PBI loops.
-                k_flash_lo_specs = (
-                    [(k_cache_base,               ahd * bpe)]
-                    + [(self.LAYER0_FLASH_K_DRAM + g * ahd * bpe,               qpkv * ahd * bpe) for g in range(qpkv)]
-                )
-                k_flash_hi_specs = (
-                    [(k_cache_base + half_ahd * bpe, ahd * bpe)]
-                    + [(self.LAYER0_FLASH_K_DRAM + g * ahd * bpe + half_ahd * bpe, qpkv * ahd * bpe) for g in range(qpkv)]
-                )
+                # Scatter K_h_roped (64-dim) from [lo|hi] K_DRAM → KV cache ONLY (the
+                # compact cache row is [lo|hi] = 64 contiguous). No FLASH_K duplication.
                 self._emit_pbi_scatter_per_token(
                     read_base=self.LAYER0_K_DRAM + kv_h * half_ahd * bpe,
                     read_stride_bytes=hd * bpe,
-                    write_specs=k_flash_lo_specs,
+                    write_specs=[(k_cache_base, ahd * bpe)],
                     sram_byte_addr=0x10000,
                     element_count=half_ahd,
                     gpr_seq_len=self.gpr_seq_len,
@@ -795,33 +811,30 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 self._emit_pbi_scatter_per_token(
                     read_base=self.LAYER0_K_DRAM + (hd // 2 + kv_h * half_ahd) * bpe,
                     read_stride_bytes=hd * bpe,
-                    write_specs=k_flash_hi_specs,
+                    write_specs=[(k_cache_base + half_ahd * bpe, ahd * bpe)],
                     sram_byte_addr=0x10080,
                     element_count=half_ahd,
                     gpr_seq_len=self.gpr_seq_len,
                     template_seq_len=seq_len,
                 )
 
-                # Scatter V_h (64-dim, standard layout) from V_PROJ_TEMP → KV cache + FLASH_V
-                # V_PROJ_TEMP layout: [seq_len, nkvh, ahd] → stride = nkvh*ahd*bpe per token.
+                # Scatter V_h (64-dim, standard layout) from V_PROJ_TEMP → KV cache ONLY.
                 self._emit_pbi_scatter_per_token(
                     read_base=self.LAYER0_V_PROJ_TEMP + kv_h * ahd * bpe,
                     read_stride_bytes=nkvh * ahd * bpe,
-                    write_specs=(
-                        [(v_cache_base, ahd * bpe)]
-                        + [(self.LAYER0_FLASH_V_DRAM + g * ahd * bpe, qpkv * ahd * bpe) for g in range(qpkv)]
-                    ),
+                    write_specs=[(v_cache_base, ahd * bpe)],
                     sram_byte_addr=0x20000,
                     element_count=ahd,
                     gpr_seq_len=self.gpr_seq_len,
                     template_seq_len=seq_len,
                 )
 
-                # Scatter Q_h_q (64-dim) from [lo|hi] Q_DRAM → FLASH_Q
-                # Q group g_for_kv = kv_h//2; sub-heads 0..qpkv-1 within that group.
                 g_for_kv = kv_h // 2
                 local_kv = kv_h % 2
                 for q in range(qpkv):
+                    # Scatter this ONE query head (64-dim) from [lo|hi] Q_DRAM into a
+                    # contiguous FLASH_Q [S, 64] (lo at 0, hi at half_ahd) — the layout
+                    # unified_attention_core expects for Q=[batch, head_dim].
                     sub_idx = local_kv * qpkv + q
                     q_lo_base = (self.LAYER0_Q_DRAM
                                  + g_for_kv * hd * bpe
@@ -829,12 +842,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     q_hi_base = (self.LAYER0_Q_DRAM
                                  + g_for_kv * hd * bpe
                                  + (hd // 2 + sub_idx * half_ahd) * bpe)
-                    flash_q_lo = self.LAYER0_FLASH_Q_DRAM + q * ahd * bpe
-                    flash_q_hi = flash_q_lo + half_ahd * bpe
                     self._emit_pbi_scatter_per_token(
                         read_base=q_lo_base,
                         read_stride_bytes=total_q_dim * bpe,
-                        write_specs=[(flash_q_lo, qpkv * ahd * bpe)],
+                        write_specs=[(self.LAYER0_FLASH_Q_DRAM, ahd * bpe)],
                         sram_byte_addr=0x30000,
                         element_count=half_ahd,
                         gpr_seq_len=self.gpr_seq_len,
@@ -843,53 +854,47 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                     self._emit_pbi_scatter_per_token(
                         read_base=q_hi_base,
                         read_stride_bytes=total_q_dim * bpe,
-                        write_specs=[(flash_q_hi, qpkv * ahd * bpe)],
+                        write_specs=[(self.LAYER0_FLASH_Q_DRAM + half_ahd * bpe, ahd * bpe)],
                         sram_byte_addr=0x30080,
                         element_count=half_ahd,
                         gpr_seq_len=self.gpr_seq_len,
                         template_seq_len=seq_len,
                     )
 
-                # Scaled dot-product attention for this KV head's qpkv query heads,
-                # called inline per KV head (unified_attention_core replaces the old
-                # shared flash_attention_core subroutine + JUMP_ABS call-site pattern).
-                attn_result = self.unified_attention_core(
-                    batch=q_seq_len,
-                    aligned_seq_len=aligned_seq_len,
-                    head_dim=ahd,
-                    Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
-                    K_DRAM_ADDR=self.LAYER0_FLASH_K_DRAM,
-                    V_DRAM_ADDR=self.LAYER0_FLASH_V_DRAM,
-                    BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
-                    OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
-                    SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
-                    IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
-                    gpr_batch_reg=self.gpr_q_seq_len,
-                    gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
-                    q_pre_scaled=True,
-                )
-                total_flops += attn_result or 0
+                    # Compact per-head SDPA: Q=[S,64] (FLASH_Q), K/V=[S,64] straight
+                    # from the cache, plain causal bias [S, align64(S)]. Static
+                    # batch/aligned pinned to PREFILL_CONTEXT (scratch/instructions
+                    # seq_len-agnostic); real per-token counts come from the GPRs.
+                    self.unified_attention_core(
+                        batch=pc_seq_len,
+                        aligned_seq_len=attn_aligned_static,
+                        head_dim=ahd,
+                        Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
+                        K_DRAM_ADDR=k_cache_base,
+                        V_DRAM_ADDR=v_cache_base,
+                        BIAS_DRAM_ADDR=self.LAYER0_FLASH_BIAS_DRAM,
+                        OUTPUT_DRAM_ADDR=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                        SCRATCH_DRAM_ADDR=self.LAYER0_FLASH_SCRATCH_DRAM,
+                        IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
+                        gpr_batch_reg=self.gpr_seq_len,
+                        gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
+                        q_pre_scaled=True,
+                    )
+                    # FLOP counted at the REAL prompt dims (model-side, see _attn_flops).
+                    total_flops += _attn_flops(seq_len, real_aligned, ahd)
 
-                # Assemble output into LAYER0_FLASH_OUTPUT_DRAM
-                # Standard GQA layout per token: [kv0_q0(64), kv0_q1..q3, kv1_q0..q3, ...]
-                out_h_base = kv_h * qpkv * ahd * bpe
-                t_reg = self.alloc_isa_reg()
-                src_off_reg = self.alloc_isa_reg()
-                dst_off_reg = self.alloc_isa_reg()
-                self.generate_instruction_add_set(t_reg, 0)
-                self.loop_start(loop_cnt=seq_len, gpr_loop_cnt=self.gpr_seq_len)
-                self.generate_instruction_reg_mul_imm(src_off_reg, t_reg, ue_35bit_addr_shifter(qpkv * ahd * bpe))
-                self.generate_instruction_reg_mul_imm(dst_off_reg, t_reg, ue_35bit_addr_shifter(total_q_dim * bpe))
-                for g in range(qpkv):
-                    self.generate_instruction_add_imm(src_off_reg, ue_35bit_addr_shifter(self.LAYER0_FLASH_OUT_HEAD_DRAM + g * ahd * bpe), self.TMP_REG)
-                    self.accelerator_memory_to_sram(0, 0x40000, ahd, general_reg_src=self.TMP_REG)
-                    self.generate_instruction_add_imm(dst_off_reg, ue_35bit_addr_shifter(self.LAYER0_FLASH_OUTPUT_DRAM + out_h_base + g * ahd * bpe), self.TMP_REG)
-                    self.sram_to_accelerator_memory(0x40000, 0, ahd, general_reg_src=self.TMP_REG)
-                self.generate_instruction_add_inc(t_reg)
-                self.loop_end()
-                self.release_isa_reg()  # dst_off_reg
-                self.release_isa_reg()  # src_off_reg
-                self.release_isa_reg()  # t_reg
+                    # Assemble this head's [S, 64] output into FLASH_OUTPUT at its
+                    # standard-GQA slot: token row = [kv0_q0..q3, kv1_q0..q3, ...].
+                    head_pos = (kv_h * qpkv + q) * ahd * bpe
+                    self._emit_pbi_scatter_per_token(
+                        read_base=self.LAYER0_FLASH_OUT_HEAD_DRAM,
+                        read_stride_bytes=ahd * bpe,
+                        write_specs=[(self.LAYER0_FLASH_OUTPUT_DRAM + head_pos, total_q_dim * bpe)],
+                        sram_byte_addr=0x40000,
+                        element_count=ahd,
+                        gpr_seq_len=self.gpr_seq_len,
+                        template_seq_len=seq_len,
+                    )
             if profile:
                 _checkpoint(f"L{layer_idx}_attention")
 
@@ -1229,10 +1234,15 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             digest.update(os.path.abspath(source_path).encode())
             with open(source_path, "rb") as source_file:
                 digest.update(source_file.read())
+        # The prompt length does NOT change the instruction bytes (the bin is
+        # seq_len-agnostic), but it does change the FLOP meta (FLOPs are accounted at
+        # the real prompt length), so fold it in to refresh a cached meta per length.
+        _pf = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
         digest.update(
             f"layers={layer_size};decode_kernel={self.decode_kernel};"
             f"prefill_kernel={self.prefill_kernel};"
-            f"penalty={getattr(self, 'fpga_penalty', False)}".encode())
+            f"penalty={getattr(self, 'fpga_penalty', False)};"
+            f"prefill_len={len(_pf) - 1}".encode())
         return digest.hexdigest()
 
     def compile_llama(self, layer_size: int | None = None, profile: bool = False) -> None:
@@ -1289,11 +1299,17 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
                 return
             print(f"Rebuilding stale instruction image at {instruction_bin_path}")
 
-        # Compile the prefill template at PREFILL_CONTEXT_SIZE (the max prompt length).
-        # All loop counts are GPR-driven (gpr_seq_len), so the single cached program
-        # handles any actual prompt length <= PREFILL_CONTEXT_SIZE; template_seq_len is
-        # used only for FLOPs accounting and the flash bucket count.
-        template_seq_len = self.PREFILL_CONTEXT_SIZE
+        # FLOP accounting uses the REAL prompt length (len(prefill_seq)-1): the static
+        # M= args and the model-side attention FLOP are then exact for this prompt
+        # (in particular the quadratic attention term, which a fixed-template +
+        # linear rescale would mis-count). The emitted instructions stay fully
+        # seq_len-agnostic — every runtime loop count is GPR-driven and the attention
+        # core's scratch is pinned to PREFILL_CONTEXT_SIZE (see _compile_prefill_program),
+        # so the same bin still serves any prompt <= PREFILL_CONTEXT_SIZE. The prompt
+        # length is folded into the compile fingerprint so a different-length prompt
+        # refreshes the FLOP meta even though the bin bytes are identical.
+        _prefill_seq = self.prefill_seq or tuple(self._cfg["default_prefill_tokens"])
+        template_seq_len = len(_prefill_seq) - 1
 
         self.clear_inst_id()
         self.start_capture()
@@ -1441,7 +1457,10 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.seq_len = prefill_seq_len
 
         q_seq_len = prefill_seq_len * self.group_size
-        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        # Proper GQA: each query head attends the COMPACT (S-long) per-KV-head K/V,
+        # so the dynamic aligned KV length / flash bucket are align64(S), not
+        # align64(S*group). gpr_q_seq_len is still primed (harmless) for symmetry.
+        aligned_seq_len = ((prefill_seq_len + 63) // 64) * 64
         bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
         flops_prefill = flops_prefill_template * prefill_seq_len // max(template_seq_len, 1)
 
@@ -1492,18 +1511,20 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
+        # Proper-GQA per-head plain causal bias over the compact K/V: query token r
+        # attends key token c <= r, shared by every query head; cols >= S are -inf.
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
-        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        valid_mask = cols <= rows
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, prefill_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         print(f"\n--- Starting prefill (seq_len={prefill_seq_len}) ---")
         print(f"Prompt ({len(self.prefill_seq)}) tokens: {self.prefill_seq}")
         timer = time.perf_counter()
-        hw_lat_prefill_us, _ = self.program_execute(preamble_addr, flops=flops_prefill)
+        hw_lat_prefill_us, prefill_gflops = self.program_execute(preamble_addr, flops=flops_prefill)
         latency_prefill = time.perf_counter() - timer
         print(f"Prefill done in {latency_prefill:.2f}s\n")
 
@@ -1663,6 +1684,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             "prefill_speed_tok_s": round(prefill_seq_len / latency_prefill, 2),
             "decode_speed_tok_s": round(avg_tokens_per_s, 2),
             "decoder_gflops": round(decoder_gflops, 2),
+            "prefill_gflops": round(prefill_gflops, 2) if prefill_gflops else None,
+            "total_tokens": prefill_seq_len + tokens_decoded,
             "prefill_size_kb": round(meta["prefill_program_size"] / 1024, 1),
             "decoder_size_kb": round(meta["decoder_program_size"] / 1024, 1),
             "prefill_hw_ms": hw_lat_prefill_us / 1e3,
@@ -1671,6 +1694,123 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
             "decode_avg_hw_ms": hw_decode_avg_ms,
             "decode_avg_cpu_ms": cpu_decode_avg_ms,
         }
+
+    def write_run_summary(self, out_path: str, args, run_result: dict, cores: int = 1,
+                          title: str = "llama3.2_1b_test") -> str:
+        """Write a per-run Markdown performance summary (device info, weight/program
+        sizes, prefill + decode HW latency/throughput, and the prompt/decoded text),
+        built from ``run_result`` (the run_llama dict) plus cheap host-side
+        bookkeeping. No FPGA program is launched here, so calling it after a run is
+        free. Mirrors gemma3_test.write_run_summary. Returns the written path."""
+        clock_ns = getattr(user_dma_core, "CLOCK_CYCLE_TIME_NS", 0.0) or 0.0
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        peak_gflops = freq_mhz * 0.128 * cores   # freq(MHz) * 128 MAC/cyc/1000 * cores
+        try:
+            hw_version = self.user_read_reg32(user_dma_core.UE_FPGA_VERSION_ADDR) & 0xFFFFFFFF
+            hw_version_str = f"0x{hw_version:08x}"
+        except Exception as e:
+            hw_version_str = f"(read failed: {e})"
+
+        # Weights.
+        weight_bin_rel = self._cfg["paths"]["weights_bin"]
+        weight_bin_path = os.path.join(self.script_dir, weight_bin_rel)
+        weight_bin_size = os.path.getsize(weight_bin_path) if os.path.exists(weight_bin_path) else 0
+        total_weight_dram_mb = self.get_params_dram_usage() / (1024 * 1024)
+
+        prefill_kb = run_result.get("prefill_size_kb")
+        decoder_kb = run_result.get("decoder_size_kb")
+        combined_kb = (prefill_kb or 0) + (decoder_kb or 0)
+
+        def _mb(n):
+            return f"{n / (1024 * 1024):.2f} MB" if n else "n/a"
+        def _kb(v):
+            return f"{v:.1f} KB" if v is not None else "n/a"
+
+        pf_tokens = run_result.get("prefill_tokens")
+        pf_hw_ms = run_result.get("prefill_hw_ms")
+        pf_gflops = run_result.get("prefill_gflops")
+        pf_cpu_ms = run_result.get("prefill_cpu_ms")
+        dec_n = run_result.get("decoded_tokens")
+        total_tok = run_result.get("total_tokens")
+        peak_toks = run_result.get("peak_tokens_per_s")
+        avg_toks = run_result.get("avg_tokens_per_s")
+        dec_gflops = run_result.get("decoder_gflops")
+        dec_first_ms = run_result.get("decode_first_hw_ms")
+        dec_avg_ms = run_result.get("decode_avg_hw_ms")
+
+        try:
+            prompt_text = self.tokenizer.decode(list(self.prefill_seq), skip_special_tokens=False)
+        except Exception:
+            prompt_text = "(decode failed)"
+        decoded_text = run_result.get("decoded_text") or "(none)"
+
+        L = []
+        L.append(f"# {title} run summary")
+        L.append("")
+        L.append(f"- **HW version:** {hw_version_str}")
+        L.append(f"- **--dev:** {args.dev}")
+        L.append(f"- **--device:** {args.device}")
+        L.append(f"- **Clock / frequency:** {clock_ns:.4f} ns ({freq_mhz:.1f} MHz)")
+        L.append(f"- **Cores:** {cores}")
+        L.append(f"- **Prefill kernel:** {run_result.get('prefill_kernel', 'n/a')}")
+        L.append(f"- **Decode kernel:** {run_result.get('decode_kernel', 'n/a')}")
+        L.append(f"- **Peak throughput:** {peak_gflops:.2f} GFLOPS "
+                 f"({freq_mhz:.1f} MHz × 128 × {cores} core(s))")
+        L.append("")
+        L.append(f"## Weights")
+        L.append("")
+        L.append(f"- **Weight bin:** `{os.path.basename(weight_bin_path)}` — {_mb(weight_bin_size)}")
+        L.append(f"- **Total weight DRAM (quantized, on FPGA):** {total_weight_dram_mb:.1f} MB")
+        L.append("")
+        L.append(f"## Program image")
+        L.append("")
+        L.append(f"- **Prefill program:** {_kb(prefill_kb)}")
+        L.append(f"- **Decoder program:** {_kb(decoder_kb)}")
+        L.append(f"- **Combined program image:** {_kb(combined_kb)}")
+        L.append("")
+        L.append(f"## Prefill")
+        L.append("")
+        L.append(f"- **Prefill tokens (seq_len):** {pf_tokens if pf_tokens is not None else 'n/a'}")
+        if pf_hw_ms is not None:
+            L.append(f"- **Prefill FPGA run time (HW latency):** {pf_hw_ms:.2f} ms")
+        if pf_gflops is not None:
+            L.append(f"- **Prefill reported FLOPS:** {pf_gflops:.2f} GFLOPS")
+        if pf_cpu_ms is not None:
+            L.append(f"- **Prefill end-to-end (CPU timer):** {pf_cpu_ms / 1e3:.2f} s")
+        L.append("")
+        L.append(f"## Decode")
+        L.append("")
+        L.append(f"- **Decoded tokens:** {dec_n if dec_n is not None else 'n/a'} generated "
+                 f"(sequence total {total_tok if total_tok is not None else 'n/a'})")
+        if peak_toks is not None:
+            L.append(f"- **First-token speed (peak):** {peak_toks:.2f} tok/s")
+        if avg_toks is not None:
+            L.append(f"- **Average speed:** {avg_toks:.2f} tok/s")
+        if dec_gflops is not None:
+            L.append(f"- **Average FLOPS:** {dec_gflops:.2f} GFLOPS")
+        if dec_first_ms is not None:
+            L.append(f"- **Decode 1st-token HW latency:** {dec_first_ms:.1f} ms/tok")
+        if dec_avg_ms is not None:
+            L.append(f"- **Decode average HW latency:** {dec_avg_ms:.1f} ms/tok")
+        L.append("")
+        L.append(f"## Prompt & output")
+        L.append("")
+        L.append(f"### Full prefill prompt")
+        L.append("")
+        L.append("```")
+        L.append(prompt_text)
+        L.append("```")
+        L.append("")
+        L.append(f"### Decoded text")
+        L.append("")
+        L.append("```")
+        L.append(decoded_text)
+        L.append("```")
+        L.append("")
+
+        with open(out_path, "w") as f:
+            f.write("\n".join(L))
+        return out_path
 
     def _profile_execute(self, preamble_addr: int, checkpoints: list,
                          tail_label: str | None = None, timeout: float = 30.0) -> tuple[list, dict]:
@@ -1747,7 +1887,8 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
         self.seq_len = prefill_seq_len
 
         q_seq_len = prefill_seq_len * self.group_size
-        aligned_seq_len = ((q_seq_len + 63) // 64) * 64
+        # Proper GQA: compact per-head aligned KV length (align64(S)), see run_llama.
+        aligned_seq_len = ((prefill_seq_len + 63) // 64) * 64
         bucket_idx = aligned_seq_len // UE_VECTOR_SIZE
 
         # On-FPGA penalty needs a zeroed bias buffer so the profiled decode step is pure-greedy.
@@ -1770,12 +1911,14 @@ class Llama32_1b_UnifiedEngine(UnifiedEngine):
 
         embedding_tensor = self.get_embedding_for_tokens(prefill_seq)
         self.dma_to_accelerator_memory(self.LAYER0_OUTPUT_DRAM, embedding_tensor)
+        # Proper-GQA per-head plain causal bias over the compact K/V: query token r
+        # attends key token c <= r, shared by every query head; cols >= S are -inf.
         bias_one_group = torch.full((aligned_seq_len, aligned_seq_len), float("-inf"), dtype=torch.bfloat16)
         rows = torch.arange(aligned_seq_len).unsqueeze(1)
         cols = torch.arange(aligned_seq_len).unsqueeze(0)
-        valid_mask = (cols // self.group_size) <= (rows // self.group_size)
+        valid_mask = cols <= rows
         bias_one_group.masked_fill_(valid_mask, 0.0)
-        bias_one_group[:, q_seq_len:] = float("-inf")
+        bias_one_group[:, prefill_seq_len:] = float("-inf")
         self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_DRAM, bias_one_group)
 
         global _SILENT_MODE
@@ -1835,6 +1978,22 @@ def _clock_ns_default_for_device(device: str) -> float:
     return 10.0
 
 
+def llama_run_summary_filename(args, prefix: str = "llama3.2_1b_test") -> str:
+    """Per-run summary .md filename encoding the CLI config, e.g.
+    ``llama3.2_1b_test_xdma1_kintex7.md`` or ``..._xdma0_alveo_puregreedy.md``.
+    dev/device are always present; other knobs are appended only when non-default."""
+    tokens = [args.dev, args.device]
+    if getattr(args, "pure_greedy", False):
+        tokens.append("puregreedy")
+    if getattr(args, "prefill_kernel", None) == "matmatmul":
+        tokens.append("prefill-matmatmul")
+    if getattr(args, "decode_kernel", None) == "matmatmul":
+        tokens.append("decode-matmatmul")
+    if getattr(args, "cycle", None) is not None:
+        tokens.append(f"cycle_{args.cycle}")
+    return prefix + "_" + "_".join(str(t) for t in tokens) + ".md"
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Llama-3.2-1B prefill + decode on accelerator.")
@@ -1863,18 +2022,6 @@ def main():
         help='Projection kernel for decode, including the LM head: streaming or matmatmul. '
              'Default: streaming. matmatmul is unsupported on 512-bit AXI devices.',
     )
-    parser.add_argument(
-        '--two-pass-decoder', '--decoder-matmatmul', '--matmatmul',
-        dest='legacy_decoder_matmatmul',
-        action='store_true',
-        help='Compatibility alias for --decode-kernel matmatmul.',
-    )
-    parser.add_argument(
-        '--two-pass-prefill',
-        dest='legacy_prefill_matmatmul',
-        action='store_true',
-        help='Compatibility alias for --prefill-kernel matmatmul.',
-    )
     parser.add_argument('--profile', action='store_true',
                         help='Compile a profile binary with per-step HALT checkpoints and print one '
                              'per-step HW-latency table (summed over all layers) for prefill and for '
@@ -1901,18 +2048,7 @@ def main():
     args = parser.parse_args()
 
     prefill_kernel = args.prefill_kernel or Llama32_1b_UnifiedEngine.DEFAULT_PREFILL_KERNEL
-    if args.legacy_prefill_matmatmul:
-        if args.prefill_kernel not in (None, "matmatmul"):
-            parser.error("--two-pass-prefill conflicts with --prefill-kernel streaming")
-        prefill_kernel = "matmatmul"
     decode_kernel = args.decode_kernel or Llama32_1b_UnifiedEngine.DEFAULT_DECODE_KERNEL
-    if args.legacy_decoder_matmatmul:
-        if args.decode_kernel not in (None, "matmatmul"):
-            parser.error(
-                "--two-pass-decoder/--decoder-matmatmul/--matmatmul conflicts "
-                "with --decode-kernel streaming"
-            )
-        decode_kernel = "matmatmul"
     axi_width_bits = 512 if args.device in ("bittware", "rk") else 256
     if axi_width_bits == 512 and (
         prefill_kernel == "matmatmul" or decode_kernel == "matmatmul"
@@ -2020,6 +2156,15 @@ def main():
     run_result = ue.run_llama()
     print("Llama-3.2-1B test ends.")
     _original_print(f"TEST_RESULT: {json.dumps(run_result)}")
+
+    # Per-run Markdown performance summary, named for the CLI config, written
+    # next to this script (see llama_run_summary_filename / write_run_summary).
+    _summary_path = os.path.join(SCRIPT_DIR, llama_run_summary_filename(args))
+    try:
+        ue.write_run_summary(_summary_path, args, run_result)
+        print(f"Wrote run summary: {_summary_path}")
+    except Exception as _e:
+        print(f"[warn] failed to write run summary: {_e}")
 
 if __name__ == "__main__":
     main()

--- a/models/llama3.2_1b/performance.md
+++ b/models/llama3.2_1b/performance.md
@@ -38,6 +38,7 @@ and decoded **pure-greedy** (deterministic, matches `user_hw_test.py`).
 | Prefill tokens (seq_len) | 44 | 44 |
 | Prefill FPGA time (HW latency) | 3,664.0 ms | 3,629.4 ms |
 | Prefill throughput | - GFLOPS | 23.71 GFLOPS |
+| — utilization (% peak) | - | 93.4% |
 | Prefill end-to-end (CPU) | 3.66 s | 3.63 s |
 | Decoded tokens | 62 generated (total 106) | 62 generated (total 106) |
 | Decode 1st-token speed (peak) | 8.47 tok/s | 8.47 tok/s |
@@ -45,6 +46,7 @@ and decoded **pure-greedy** (deterministic, matches `user_hw_test.py`).
 | Decode 1st-token HW latency | 118.1 ms/tok | 118.1 ms/tok |
 | Decode average HW latency | 120.6 ms/tok | 120.6 ms/tok |
 | Decode average throughput | 21.65 GFLOPS | 21.65 GFLOPS |
+| — utilization (% peak) | 85.3% | 85.3% |
 | Correctness | coherent (solves x = 2) | coherent (solves x = 2, identical text) |
 
 > **proper-gqa** (IF4, xdma1/kintex7, HW `0x4a6cf588`, pure-greedy, 44-token
@@ -84,11 +86,13 @@ Same proper-GQA + real-seq_len FLOP change applied to `llama3.2_1b_IF8.py`
 | Prefill tokens (seq_len) | 44 | 44 |
 | Prefill FPGA time (HW latency) | 7,037.2 ms | 7,002.7 ms |
 | Prefill throughput | - GFLOPS | 12.29 GFLOPS |
+| — utilization (% peak) | - | 48.4% |
 | Decoded tokens | 68 generated (total 112) | 68 generated (total 112) |
 | Decode average speed | 4.57 tok/s | 4.57 tok/s |
 | Decode 1st-token HW latency | 215.3 ms/tok | 215.3 ms/tok |
 | Decode average HW latency | 217.9 ms/tok | 217.9 ms/tok |
 | Decode average throughput | 11.98 GFLOPS | 11.98 GFLOPS |
+| — utilization (% peak) | 47.2% | 47.2% |
 | Correctness | coherent (solves x = 2) | coherent (solves x = 2, identical text) |
 
 > **Same verdict as IF4, and same not-worth-it at 44 tokens.** Prefill latency

--- a/models/llama3.2_1b/performance.md
+++ b/models/llama3.2_1b/performance.md
@@ -1,42 +1,102 @@
 # LLaMA 3.2 1B Performance
 
-Hardware: Andromeda FPGA (HW version 0x25e4082c), clock cycle 5.15 ns (194 MHz), device kintex7.
+Baseline numbers captured from the per-run summary written by
+`llama3.2_1b_test.py` (IF4). The run compiled the program image **from scratch**
+and decoded **pure-greedy** (deterministic, matches `user_hw_test.py`).
 
-Architecture: 16 layers, hidden 2048, GQA (8 KV heads × 1 Q/KV = 8 Q heads), actual_head_dim 64, MLP 8192, IF4 quantization.
+- **HW version:** `0x4a6cf588`
+- **--dev / --device:** `xdma1` / `kintex7`
+- **Clock / frequency:** 5.0422 ns (198.3 MHz)
+- **Cores:** 1
+- **Prompt:** `default_prefill_tokens` (`x+3=5, what is x?`), 44 prefill tokens
+- **Architecture:** 16 layers, hidden 2048, GQA 8 KV heads × 4 Q/KV = 32 Q heads,
+  actual_head_dim 64, MLP 8192, IF4 quantization.
+- **Source summaries:** the run now auto-writes a per-run Markdown summary
+  (`write_run_summary`, same format as gemma3) named for the CLI config, e.g.
+  [llama3.2_1b_test_xdma1_kintex7_puregreedy.md](llama3.2_1b_test_xdma1_kintex7_puregreedy.md);
+  see also [run.md](run.md) for the FLOPs/scratch audit.
 
-## Instruction Size
+> **⚠️ Discrepancy vs the previous performance.md (2025-06-22, HW `0x25e4082c`,
+> 5.15 ns).** The instruction image is now **~2.7–3× larger**: prefill
+> **842.2 → 2,517.1 kB**, decoder **666.4 → 1,617.6 kB**, combined
+> **1,508.7 → 4,134.6 kB**. This is expected: the current build **inlines**
+> `unified_attention_core` once per KV head (8×) inside every layer body (16×),
+> replacing the old shared `flash_attention` subroutine + `JUMP_ABS` call-site
+> pattern — it trades image size for removing per-call dispatch. Timing improved
+> on the newer bitstream/clock: prefill HW **3,944 → 3,664 ms**, decode average
+> **~7.67 → 8.15 tok/s**. (The old and new rows use different HW versions and
+> clock periods, so treat the timing deltas as indicative, not controlled.)
 
-| Stage   | Baseline (kB) | Current — streaming LM head (kB) |
-|---------|--------------|----------------------------------|
-| Prefill | 842.2        | 842.2                            |
-| Decoder | 877.0        | 666.4                            |
-| Total   | 1,719.2      | 1,508.7                          |
+## LLaMA 3.2 1B IF4
 
-## Run Performance
+| Metric | Baseline | proper-gqa |
+|---|---:|---:|
+| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS |
+| Prefill program | 2,517.1 kB | 6,156.1 kB |
+| Decoder program | 1,617.6 kB | 1,617.6 kB |
+| Combined program image | 4,134.6 kB | 7,773.6 kB |
+| Prefill tokens (seq_len) | 44 | 44 |
+| Prefill FPGA time (HW latency) | 3,664.0 ms | 3,629.4 ms |
+| Prefill throughput | - GFLOPS | 23.71 GFLOPS |
+| Prefill end-to-end (CPU) | 3.66 s | 3.63 s |
+| Decoded tokens | 62 generated (total 106) | 62 generated (total 106) |
+| Decode 1st-token speed (peak) | 8.47 tok/s | 8.47 tok/s |
+| Decode average speed | 8.15 tok/s | 8.20 tok/s |
+| Decode 1st-token HW latency | 118.1 ms/tok | 118.1 ms/tok |
+| Decode average HW latency | 120.6 ms/tok | 120.6 ms/tok |
+| Decode average throughput | 21.65 GFLOPS | 21.65 GFLOPS |
+| Correctness | coherent (solves x = 2) | coherent (solves x = 2, identical text) |
 
-| Metric | Baseline | Current — streaming LM head |
-|--------|----------|-----------------------------|
-| Prompt tokens (prefill) | 44 | 44 |
-| Decode tokens generated | 71 | 71 |
-| **Prefill HW time (ms)** | 3,944.0 | 3,944.0 |
-| **Prefill CPU time (ms)** | 3,943.5 | 3,948.8 |
-| **Decode 1st token HW (ms/tok)** | 144.2 | 120.6 |
-| **Decode 1st token (tok/s)** | 6.93 | 8.29 |
-| **Decode avg HW time (ms/tok)** | 146.8 | 123.9 |
-| **Decode avg CPU time (ms/tok)** | 153.3 | 130.3 |
-| Decode throughput (inc. host detokenizer) (tok/s) | 6.52 | 7.67 |
+> **proper-gqa** (IF4, xdma1/kintex7, HW `0x4a6cf588`, pure-greedy, 44-token
+> prompt): prefill attention rewritten from *duplicate-and-batch* (per KV head:
+> replicate K/V `group_size`× and one `[4S,4S]` SDPA) to true GQA — an outer loop
+> over the 8 KV heads × inner loop over the 4 query heads, each a compact `[S,S]`
+> SDPA reading the un-duplicated K/V straight from the cache (plain causal bias).
+> That's `group_size`(=4)× less attention MAC + KV DMA. **Bundled with the FLOP
+> accounting fix**: prefill FLOPs are now computed at the *real* prompt length
+> (projections `M = prompt_seq_len`; attention counted at the real compact dims),
+> so the reported prefill GFLOPS reflects the actual work — which is *why the
+> number drops vs Baseline (24.21 → 23.71): Baseline over-counted the duplicated
+> attention*. Instructions stay fully seq_len-agnostic (all runtime loops GPR-driven;
+> the attention core's static `batch`/`aligned` are pinned to `PREFILL_CONTEXT_SIZE`
+> for scratch, never the prompt).
+>
+> **Verdict at 44 tokens: not worth it.** Prefill latency improves only **~1%
+> (3,664 → 3,629 ms)** because at this length attention is a tiny slice of prefill
+> (projections/MLP dominate), while the prefill image **grows 2.4× (2,517 → 6,156
+> kB)** from inlining 32 attention call-sites per layer instead of 8. Output is
+> byte-identical (llama's group-aware duplicate bias was already numerically exact,
+> so no token drift). The `O(seq²)` compute win only turns net-positive at long
+> context; for short prompts the duplicate-and-batch baseline is the better trade.
 
-## Decoder Step Breakdown (1st token, all 16 layers)
+## LLaMA 3.2 1B IF8
 
-| Step | Baseline (ms) | Current — streaming LM head (ms) |
-|------|--------------|----------------------------------|
-| pre_norm | 0.14 | 0.14 |
-| qkv_proj | 8.95 | 8.95 |
-| rope | 0.24 | 0.24 |
-| kv_scatter_attn | 11.01 | 11.01 |
-| o_proj_residual | 6.02 | 6.02 |
-| pre_ffn_norm | 0.11 | 0.11 |
-| mlp_gateup_silu | 47.53 | 47.53 |
-| mlp_down_residual | 23.74 | 23.74 |
-| norm_lm_head | 46.49 | 23.20 |
-| **Total** | **144.24** | **120.95** |
+Same proper-GQA + real-seq_len FLOP change applied to `llama3.2_1b_IF8.py`
+(xdma1/kintex7, pure-greedy, 44-token prompt). Summary:
+[llama3.2_1b_IF8_test_xdma1_kintex7_puregreedy.md](llama3.2_1b_IF8_test_xdma1_kintex7_puregreedy.md).
+
+| Metric | Baseline | proper-gqa |
+|---|---:|---:|
+| Peak throughput | 25.39 GFLOPS | 25.39 GFLOPS |
+| Prefill program | 2,517.1 kB | 6,156.1 kB |
+| Decoder program | 1,617.6 kB | 1,617.6 kB |
+| Combined program image | 4,134.6 kB | 7,773.6 kB |
+| Prefill tokens (seq_len) | 44 | 44 |
+| Prefill FPGA time (HW latency) | 7,037.2 ms | 7,002.7 ms |
+| Prefill throughput | - GFLOPS | 12.29 GFLOPS |
+| Decoded tokens | 68 generated (total 112) | 68 generated (total 112) |
+| Decode average speed | 4.57 tok/s | 4.57 tok/s |
+| Decode 1st-token HW latency | 215.3 ms/tok | 215.3 ms/tok |
+| Decode average HW latency | 217.9 ms/tok | 217.9 ms/tok |
+| Decode average throughput | 11.98 GFLOPS | 11.98 GFLOPS |
+| Correctness | coherent (solves x = 2) | coherent (solves x = 2, identical text) |
+
+> **Same verdict as IF4, and same not-worth-it at 44 tokens.** Prefill latency
+> moves **~0.5% (7,037 → 7,003 ms)** while the prefill image grows the identical
+> **2.4× (2,517 → 6,156 kB)** — the prefill *instruction* structure is the same for
+> IF4 and IF8 (only weight quantization differs), so proper-GQA's image cost is
+> identical; IF8 is just ~2× slower per token from the 8-bit weight traffic.
+> Decode is untouched (68 tokens, byte-identical text — matches the IF8 golden in
+> `user_hw_test.py`, so no golden change). Reported prefill GFLOPS drops
+> (12.60 → 12.29) for the same reason as IF4: the FLOP fix now counts the real
+> compact attention instead of the duplicated work.

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -5688,17 +5688,23 @@ def gemma3_inference_test() -> None:
     from gemma3_test import Gemma3_UnifiedEngine
     import user_dma_core
 
+    # Golden refreshed 2026-08-19 for the proper-GQA prefill (per-head loop over
+    # the compact K/V; the old duplicate-KV + plain-tril path under-weighted the
+    # diagonal token for non-last query heads — now fixed to match the HF GQA
+    # reference). IF4's greedy decode shifted to this coherent completion; the
+    # legacy/streaming/matmatmul labels all share this golden (all use the same
+    # corrected prefill attention).
     expected_text = (
-        "Let's solve the equation x + 3 = 5\n\n"
-        "To find the value of 'x', we need to isolate it.  "
-        "Subtract 3 from both sides of the equation:\n\n"
-        "x + 3 - 3 = 5 - 3\n\n"
+        "If you add 3 to both sides of the equation, you get:\n\n"
+        "x + 3 + 3 = 5 + 3\n\n"
         "This simplifies to:\n\n"
-        "x = 2\n\n"
+        "x + 6 = 8\n\n"
+        "Now, subtract 6 from both sides:\n\n"
+        "x = 8 - 6\n\n"
         "Therefore, x = 2\n\n"
         "So the answer is **2**"
     )
-    expected_tokens = 80
+    expected_tokens = 76
     token_tol = 0
 
     # Peak (1st-token) decode throughput floors were measured on bittware

--- a/user_hw_test.py
+++ b/user_hw_test.py
@@ -5437,62 +5437,61 @@ def isa_mult_div_shift_test() -> None:
     ue.reset_inst_ptr_counter()
     ue.reset_isa_reg_counter()
 
-def software_reset_test():
+# Per-core AXI-Lite register base spacing. Core i's register block lives at
+# UE_0_BASE_ADDR + i * ENGINE_BASE_STRIDE — the same stride MultiEngineScheduler
+# uses to build worker engines (multi_engine_shard.py engine_base_stride), which
+# is what the multi-core llama3.2_1b prefill runs on.
+ENGINE_BASE_STRIDE = 0x00010000
+
+
+def software_reset_test(cores: int = 1):
+    """Software-reset AXI cores 0..cores-1 and verify each recovers cleanly.
+
+    software_reset() is PER-CORE: it writes SW_RESET_CMD to UE_QUEUE_CTRL_ADDR
+    translated through the engine's OWN _base_addr, so a plain UnifiedEngine()
+    (base = UE_0_BASE_ADDR) resets ONLY core 0 — it does not touch cores 1..N.
+
+    A hung multi-core prefill (e.g. llama3.2_1b --multi-core) leaves every worker
+    core spin-waiting on a FLAG_CHECK too (no timeout). Pass ``cores=N`` to clear
+    every engine that run used: core i lives at UE_0_BASE_ADDR + i*ENGINE_BASE_STRIDE.
+
+    For each core: issue software_reset() to break any stale FLAG_CHECK spin-wait
+    / drain the queue, then run a bare HALT and confirm the core reports idle.
     """
-    Verifies that software reset breaks a deterministic deadlock caused
-    by flag registers, and that the engine recovers cleanly afterwards.
+    if not 1 <= cores <= 8:
+        raise ValueError(f"cores must be 1..8, got {cores}")
+    import user_dma_core
 
-    Phase 1 — flag deadlock (expect engine stuck):
-      Program engine 0 to FLAG_CHECK on engine 1 whose flag is never set.
-      This causes an infinite spin-wait (deadlock).  Confirm the engine
-      is stuck, then issue software_reset() to break it.
+    for core in range(cores):
+        base = user_dma_core.UE_0_BASE_ADDR + core * ENGINE_BASE_STRIDE
+        print(f"--- software_reset: core {core} (base 0x{base:08x}) ---")
+        ue = UnifiedEngine(BASE_ADDR=base)
 
-    Phase 2 — simple halt instruction (expect PASS):
-    """
-    # ---- Phase 1: cause a flag deadlock, then reset ----
-    ue = UnifiedEngine()
+        # Break any stale FLAG_CHECK spin-wait and drain this core's queue.
+        ue.software_reset()
 
-    # ue.start_capture()
-    # ue.generate_instruction_flag_check(target_engine_idx=1)
-    # ue.generate_instruction_halt()
-    # ue.stop_capture()
-    # program_dram_addr = ue.get_program_dram_addr()
-    # print(f"program_dram_addr: {program_dram_addr:08x}")
-    # print(f"capture_instruction_size_bytes: {ue.get_capture_instruction_size_bytes()}")
-    # ue.write_captured_instructions_to_dram(program_dram_addr)
-    # ue.allocate_program_dram(ue.get_capture_instruction_size_bytes())
-    # ue.start_execute_from_dram(program_dram_addr)
+        # Recovery check: a bare HALT must complete, not report busy.
+        ue.start_capture()
+        ue.generate_instruction_halt()
+        ue.stop_capture()
+        program_dram_addr = ue.get_program_dram_addr()
+        print(f"program_dram_addr: {program_dram_addr:08x}")
+        print(f"capture_instruction_size_bytes: {ue.get_capture_instruction_size_bytes()}")
+        ue.write_captured_instructions_to_dram(program_dram_addr)
+        ue.allocate_program_dram(ue.get_capture_instruction_size_bytes())
 
-    # ue.clear_capture_buffer()
-    # ue.reset_tensor_dram_addr()
+        ue.start_execute_from_dram(program_dram_addr)
+        ue.wait_queue(3.0)  # 3 seconds timeout
 
-    # ue.wait_queue(1.0) # 3 seconds timeout
+        assert not ue.is_queue_busy(), \
+            f"core {core} should have completed HALT but still reports busy"
 
-    # assert ue.is_queue_busy(), \
-    #     "Engine should be stuck in FLAG_CHECK spin-wait but reports idle"
-    # print("Engine is deadlocked on FLAG_CHECK(engine 1) — issuing software reset...")
-    ue.software_reset()
+        print(f"core {core} software reset + recovery PASSED")
+        ue.clear_capture_buffer()
+        ue.reset_tensor_dram_addr()
 
-    # ---- Phase 2: run flag set/clear after reset, expect completion ----
-    ue.start_capture()
-    ue.generate_instruction_halt()
-    ue.stop_capture()
-    program_dram_addr = ue.get_program_dram_addr()
-    print(f"program_dram_addr: {program_dram_addr:08x}")
-    print(f"capture_instruction_size_bytes: {ue.get_capture_instruction_size_bytes()}")
-    ue.write_captured_instructions_to_dram(program_dram_addr)
-    ue.allocate_program_dram(ue.get_capture_instruction_size_bytes())
-
-    ue.start_execute_from_dram(program_dram_addr)
-    ue.wait_queue(3.0) # 3 seconds timeout
-
-    assert not ue.is_queue_busy(), \
-        "Engine should have completed HALT but still reports busy"
-
-    print("Software reset test PASSED")
+    print(f"Software reset test PASSED ({cores} core(s))")
     record_test("software_reset", "n/a")
-    ue.clear_capture_buffer()
-    ue.reset_tensor_dram_addr()
 
 
 def test_ue_int_reg_read():
@@ -6086,6 +6085,12 @@ if __name__ == "__main__":
         action='store_true',
         help='Run the large nested-loop sweeps at the end of the suite (slow).',
     )
+    parser.add_argument(
+        '--multi-core', type=int, default=1,
+        help='Number of AXI cores (1..8) to software-reset in software_reset_test. '
+             'Use N to clear all engines a hung multi-core run left spin-waiting '
+             '(e.g. llama3.2_1b --multi-core 2 -> --multi-core 2). Default: 1.',
+    )
     args = parser.parse_args()
 
     import user_dma_core
@@ -6151,7 +6156,7 @@ if __name__ == "__main__":
 
     atexit.register(_atexit_write_test_summary)
 
-    software_reset_test()
+    software_reset_test(cores=args.multi_core)
     dram_read_write_speed_test()
     isa_rela_loop_test()
     isa_abs_loop_test()


### PR DESCRIPTION
## Performance comparison

| Metric | Kintex | Kintex 2-core | rk | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
|---|---:|---:|---:|---:|---:|---:|---:|
| Peak throughput | 25.39 GFLOPS | 50.77 GFLOPS | 42.67 GFLOPS | 46.93 GFLOPS | 93.87 GFLOPS | 187.73 GFLOPS | 375.47 GFLOPS |
| Vision FPGA execution | 53.78 s | 27.74 s | 32.05 s | **29.21 s** | **15.54 s** | **8.08 s** | **4.94 s** |
| Vision end-to-end path | 53.81 s | 27.81 s | 32.62 s | **29.26 s** | **15.60 s** | **8.15 s** | **5.05 s** |
| Vision throughput | 21.37 GFLOPS | 41.42 GFLOPS | 35.85 GFLOPS | **39.35 GFLOPS** | **73.96 GFLOPS** | **142.20 GFLOPS** | **232.38 GFLOPS** |
| — utilization (% peak) | 84.2% | 81.6% | 84.0% | **83.8%** | **78.8%** | **75.7%** | **61.9%** |
| Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
| LM prefill sequence executed | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens | 272 actual tokens |
| LM prefill FPGA latency | 43.95 s | 23.46 s | 28.02 s | **26.29 s** | **12.93 s** | **6.94 s** | **4.02 s** |
| LM prefill throughput | 24.08 GFLOPS | 45.12 GFLOPS | 37.78 GFLOPS | **40.26 GFLOPS** | **81.89 GFLOPS** | **152.56 GFLOPS** | **263.61 GFLOPS** |
| — utilization (% peak) | 94.9% | 88.9% | 88.5% | **85.8%** | **87.2%** | **81.3%** | **70.2%** |
| Decode average throughput | 3.78 tok/s | 3.76 tok/s | 5.85 tok/s | **6.32 tok/s** | **5.78 tok/s** | **6.53 tok/s** | **6.53 tok/s** |
| Decode peak first-token throughput | 3.99 tok/s | 4.00 tok/s | 6.21 tok/s | **6.65 tok/s** | **6.53 tok/s** | **7.08 tok/s** | **6.90 tok/s** |
| Decode average hardware throughput | 23.06 GFLOPS | 22.95 GFLOPS | 36.47 GFLOPS | **39.01 GFLOPS** | **35.71 GFLOPS** | **40.56 GFLOPS** | **40.56 GFLOPS** |
| — utilization (% peak) | 90.8% | 45.2% | 85.5% | **83.1%** | **38.0%** | **21.6%** | **10.8%** |
| Vision program section | 3.22 MiB | 2.39 MiB | 3.22 MiB | 3.22 MiB | 2.39 MiB | 1.90 MiB | 1.75 MiB |
| Prefill program section | 5.85 MiB | 4.77 MiB | 5.85 MiB | 5.85 MiB | 4.77 MiB | 4.06 MiB | 3.72 MiB |
| Decode program section | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB | 1.42 MiB |
| Combined program image | 10.49 MiB | 13.73 MiB | 10.49 MiB | 10.49 MiB | 13.73 MiB | 19.20 MiB | 30.40 MiB |
| Weight image (`params.bin`) | 6.91 GiB | same | same | same | same | same | same |
| Correctness | coherent, total 656 | coherent, total 699 | coherent, total 656 | coherent, total 656 | coherent, total 699 | coherent, total 699 | coherent, total 699 |