### PR TITLE
correct decode gflops

### DIFF
--- a/models/gemma4_e2b/gemma4_e2b_lm.py
+++ b/models/gemma4_e2b/gemma4_e2b_lm.py
@@ -694,12 +694,16 @@ class Gemma4LMMixin:
         self._loud(f"  Emitting dynamic prefill: {layer_size} layers, accounting_seq={seq_len}, attention=unified-inline"
                         + (" (+profile checkpoints)" if profile else ""))
         checkpoints: list[list] = []
+        last_checkpoint_flops = 0
         def _checkpoint(name: str) -> None:
+            nonlocal last_checkpoint_flops
             if not profile:
                 return
             self.generate_instruction_halt()
             resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
-            checkpoints.append([name, f"0x{resume:X}"])
+            phase_flops = int(total_flops - last_checkpoint_flops)
+            checkpoints.append([name, f"0x{resume:X}", phase_flops])
+            last_checkpoint_flops = int(total_flops)
         def _projection_core(**kwargs) -> int:
             """Dynamic quantized projection selected for the whole prefill stage."""
             kwargs.setdefault("gpr_M_reg", self.gpr_seq_len)
@@ -908,7 +912,6 @@ class Gemma4LMMixin:
                 self._emit_strided_copy_pbi(tmp_out, self.LAYER0_FLASH_Q_DRAM, rope_n, rope_bytes, head_bytes, q_rows, self.gpr_q_seq_len)
                 self._emit_strided_copy_pbi(self.LAYER0_Q_NORM_DRAM + rope_bytes, self.LAYER0_FLASH_Q_DRAM + rope_bytes, non_rot, head_bytes, head_bytes, q_rows, self.gpr_q_seq_len)
             _checkpoint(f"L{layer_idx}_rope")
-            _checkpoint(f"L{layer_idx}_kv_gather")
 
             # ---- GQA = an outer loop over the group's query heads ----
             # Standard GQA: the group_size query heads all attend the SAME K/V
@@ -935,11 +938,10 @@ class Gemma4LMMixin:
             # V-projection output, so it is not reused here.
             per_head_rows = ((self.max_prefill_seq_len + 63) // 64) * 64
             qhm_head_bytes = per_head_rows * cur_head_dim * self.bytes_per_element
-            # Compile-time runtime dims for multi-core workers (prefill compiles
-            # per prompt, so seq_len is a constant here): batch=seq_len,
-            # aligned=align64(seq_len). Master's single-core path uses the primed
-            # GPRs instead.
-            attn_aligned_ct = ((seq_len + 63) // 64) * 64
+            # The core receives maximum-capacity static dimensions so its
+            # internal scratch partition is safe for any reusable prompt. Live
+            # execution dimensions still come exclusively from the GPRs.
+            attn_aligned_live = ((seq_len + 63) // 64) * 64
             for g in range(self.group_size):
                 self._emit_strided_copy_pbi(
                     self.LAYER0_FLASH_Q_DRAM + g * head_bytes,       # token-major head g
@@ -962,17 +964,12 @@ class Gemma4LMMixin:
 
             def _emit_prefill_head(ue, h, scratch_addr, batch_reg, aligned_reg):
                 head_slot = self.LAYER0_FLASH_K_DRAM + h * qhm_head_bytes
-                # Static batch/aligned = the ACTUAL per-prompt dims (seq_len,
-                # align64(seq_len)), NOT per_head_rows. Prefill compiles per
-                # prompt so these are the true max the runtime GPRs take, which
-                # (a) makes the returned FLOP count accurate — per_head_rows=512
-                # over-counted the 272/320 attention ~3x, nudging reported
-                # prefill throughput above the MAC-array peak — and (b) reserves
-                # exactly the scratch the core uses. The head-major slot stride
-                # (qhm_head_bytes) stays at per_head_rows so buffer layout is
-                # seq-independent.
-                f = ue.unified_attention_core(
-                    batch=seq_len, aligned_seq_len=attn_aligned_ct,
+                # Static core dimensions reserve max-capacity scratch. Ignore
+                # the core's exaggerated return value and account the real live
+                # prompt dimensions outside the core.
+                ue.unified_attention_core(
+                    batch=self.max_prefill_seq_len,
+                    aligned_seq_len=per_head_rows,
                     head_dim=cur_head_dim,
                     Q_DRAM_ADDR=head_slot, K_DRAM_ADDR=k_cache_base,
                     V_DRAM_ADDR=v_cache_base, BIAS_DRAM_ADDR=bias_addr_layer,
@@ -980,7 +977,8 @@ class Gemma4LMMixin:
                     IDENTITY_DRAM_ADDR=self.IDENTITY_DRAM_ADDR,
                     gpr_batch_reg=batch_reg, gpr_aligned_seq_len_reg=aligned_reg,
                     q_scale=1.0)
-                return f if isinstance(f, (int, float)) else 0
+                return self._dynamic_attention_flops(
+                    seq_len, attn_aligned_live, cur_head_dim)
 
             if prefill_scheduler is None:
                 # Single core: loop all group heads on the master, reusing the
@@ -1004,7 +1002,7 @@ class Gemma4LMMixin:
                     b_reg = ctx.ue.alloc_isa_reg()
                     ctx.ue.generate_instruction_add_set(b_reg, seq_len)
                     a_reg = ctx.ue.alloc_isa_reg()
-                    ctx.ue.generate_instruction_add_set(a_reg, attn_aligned_ct)
+                    ctx.ue.generate_instruction_add_set(a_reg, attn_aligned_live)
                     scr = ctx.scratch("prefill_attn_scratch")
                     for h in range(ctx.head_off, ctx.head_off + ctx.heads):
                         _attn_flops[0] += _emit_prefill_head(ctx.ue, h, scr, b_reg, a_reg)
@@ -1365,7 +1363,27 @@ class Gemma4LMMixin:
             _pf_th.join(timeout=1.0)
         return latency, flop_rate_program
 
-    def compile_decoder(self, layer_size: int = 35, profile: bool = False) -> tuple[None, list[int], list[int]]:
+    @staticmethod
+    def _dynamic_attention_flops(batch: int, aligned_seq_len: int,
+                                 head_dim: int) -> int:
+        """Q scale + QK (bias + softmax) + PV at the live runtime shape."""
+        return (batch * head_dim
+                + batch * aligned_seq_len * (4 * head_dim + 6))
+
+    def _decoder_flops_for_aligned_seq_len(self, aligned_seq_len: int) -> int:
+        """Total decoder FLOPs for one token at a live aligned context length."""
+        base = getattr(self, "_decoder_non_attention_flops", None)
+        if base is None:
+            raise RuntimeError("decoder non-attention FLOPs metadata is unavailable")
+        attention = sum(
+            self._dynamic_attention_flops(
+                self.group_size, aligned_seq_len,
+                self._get_layer_attention_dims(layer_idx)[0])
+            for layer_idx in range(self.LAYER_SIZE))
+        return int(base + attention)
+
+    def compile_decoder(self, layer_size: int = 35, profile: bool = False,
+                        accounting_seq_len: int | None = None) -> tuple[None, list[int], list[int]]:
         """Compile a single decoder program with dynamic PBI.
 
         DYNAMIC PBI (see notes_gemma4_e2b.md): one captured
@@ -1380,12 +1398,23 @@ class Gemma4LMMixin:
         single-element lists; caller uses [0] index.
         """
         LAYER_WEIGHT_SIZE = self.weight_defs["LAYER_WEIGHT_SIZE"]
+        if accounting_seq_len is None:
+            accounting_seq_len = self.MAX_CONTEXT_SIZE
+        accounting_seq_len = int(accounting_seq_len)
+        if (accounting_seq_len < self.group_size
+                or accounting_seq_len > self.MAX_CONTEXT_SIZE
+                or accounting_seq_len % 64):
+            raise ValueError(
+                "decoder accounting_seq_len must be 64-aligned and within "
+                f"[{self.group_size}, {self.MAX_CONTEXT_SIZE}], got "
+                f"{accounting_seq_len}")
 
         self._set_silent(True)
         self._loud(f"  Emitting dynamic-PBI decoder: 1 segment x {layer_size} layers, attention=unified-inline")
         seg_t0 = time.perf_counter()
         count_at_start = self.capture_count
         total_flops = 0
+        decoder_attention_flops = 0
 
         # Optional per-phase profiling (see run_gemma4_profile / --profile).
         # _checkpoint emits a HALT at a phase boundary and records the resume
@@ -1394,12 +1423,16 @@ class Gemma4LMMixin:
         # placed at UNCONDITIONAL points so every layer contributes one sample
         # per phase (never inside a loop_start/loop_end or a per-layer branch).
         checkpoints: list[list] = []
+        last_checkpoint_flops = 0
         def _checkpoint(name: str) -> None:
+            nonlocal last_checkpoint_flops
             if not profile:
                 return
             self.generate_instruction_halt()
             resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
-            checkpoints.append([name, f"0x{resume:X}"])
+            phase_flops = int(total_flops - last_checkpoint_flops)
+            checkpoints.append([name, f"0x{resume:X}", phase_flops])
+            last_checkpoint_flops = int(total_flops)
         def _projection_core(**kwargs) -> int:
             """Uniform kernel selection for configurable decode IF4 projections."""
             if self.decode_kernel == "matmatmul":
@@ -1460,7 +1493,9 @@ class Gemma4LMMixin:
 
         # Iterate once (no bucket loop)
         for _bi_unused in [0]:
-            seq_len = self.MAX_CONTEXT_SIZE  # template only — for FLOPs
+            # Live-length FLOP accounting only. The core receives global maximum
+            # capacity below so its internal scratch partition remains reusable.
+            seq_len = accounting_seq_len
             for layer_idx in range(layer_size):
                 layer_off = layer_idx * LAYER_WEIGHT_SIZE
                 cur_head_dim, cur_q_size, cur_k_size = self._get_layer_attention_dims(layer_idx)
@@ -1594,8 +1629,6 @@ class Gemma4LMMixin:
                 # Compact per-slot rows already satisfy unified attention's
                 # [aligned_seq_len, head_dim] contract. Read the cache directly;
                 # zero-initialized future rows cover alignment padding.
-                _checkpoint(f"L{layer_idx}_kv_gather")
-
                 # unified_attention_core uses bias_mode="full_matrix"; run_decoder
                 # uploads group_size identical bias rows for this call.
                 bias_addr_layer = (self.LAYER0_FLASH_BIAS_FULL_DRAM
@@ -1611,9 +1644,9 @@ class Gemma4LMMixin:
                 # Multi-core will shard these group rows across engines
                 # (batch=shard_size per engine); this is the single-core (shard=
                 # group_size) case.
-                total_flops += self.unified_attention_core(
+                self.unified_attention_core(
                     batch=self.group_size,
-                    aligned_seq_len=seq_len,
+                    aligned_seq_len=self.MAX_CONTEXT_SIZE,
                     head_dim=cur_head_dim,
                     Q_DRAM_ADDR=self.LAYER0_FLASH_Q_DRAM,
                     K_DRAM_ADDR=kv_k_base,
@@ -1626,6 +1659,10 @@ class Gemma4LMMixin:
                     gpr_aligned_seq_len_reg=self.gpr_aligned_seq_len,
                     q_scale=1.0,
                 )
+                live_attention_flops = self._dynamic_attention_flops(
+                    self.group_size, seq_len, cur_head_dim)
+                total_flops += live_attention_flops
+                decoder_attention_flops += live_attention_flops
                 _checkpoint(f"L{layer_idx}_attention")
 
                 # O projection: INT4, K=cur_q_size (actual per-layer attention output dim)
@@ -1787,6 +1824,8 @@ class Gemma4LMMixin:
             self._loud(f"    decoder segment ({instr_count} instr) done in {time.perf_counter()-seg_t0:.1f}s")
         program_sizes = [instr_count * 32]
         total_flops_list = [total_flops]
+        self._decoder_non_attention_flops = int(
+            total_flops - decoder_attention_flops)
         self._decoder_checkpoints = checkpoints
         self._set_silent(False)
         return None, program_sizes, total_flops_list
@@ -1895,6 +1934,12 @@ class Gemma4LMMixin:
             self.seq_len += 1
             decode_pos = self.seq_len - 1               # 0-based pos of token now being computed
             aligned_seq_len = ((self.seq_len + 63) // 64) * 64
+            try:
+                live_flops_per_token = self._decoder_flops_for_aligned_seq_len(
+                    aligned_seq_len)
+            except RuntimeError:
+                # Backward compatibility for older program metadata.
+                live_flops_per_token = flops_per_token_scalar
 
             embedding_tensor = self.get_embedding_for_tokens([token_id])
             self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, embedding_tensor)
@@ -1922,7 +1967,7 @@ class Gemma4LMMixin:
             # advanced by the decoder's trailing add_inc.
             latency, flop_rate_program = self._dispatch_program(
                 [(self.gpr_aligned_seq_len, aligned_seq_len)],
-                prog_addr, timeout=300.0, flops=flops_per_token_scalar)
+                prog_addr, timeout=300.0, flops=live_flops_per_token)
             total_latency += latency
             total_flop_rate += flop_rate_program
             # HW argmax of the streaming LM-head logits.

--- a/models/gemma4_e2b/gemma4_e2b_performance.md
+++ b/models/gemma4_e2b/gemma4_e2b_performance.md
@@ -23,32 +23,32 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device kintex7 --dev xdma1 --image
 ```
 
 ## Performance comparison
-> `--device alveo` with HW version `0x3d04c689`
+> `--device alveo` with HW version `0x68f0c76c`
 > `--dev xdma1` (kintex7) with HW version `0x6ee171b8`
 > `--device rk_256` with HW version `0x3d04c689`
 
 | Metric | Kintex | Kintex 2-core | rk_256 | Alveo | Alveo 2-core | Alveo 4-core | Alveo 8-core |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Peak throughput (GFLOPS) | 25.4 | 50.8 | 42.7 | 46.9 | 93.9 | 187.7 | 375.5 |
-| DRAM read speed (MB/s) | 5875.9 | 6884.3 | 9272.2 | **10484.2** | **11271.0** | **15132.2** | **22940.2** |
+| DRAM read speed (MB/s) | 5875.9 | 6980.4 | 9272.2 | **10484.2** | **11176.7** | **15094.1** | **22918.3** |
 | **Vision** |
 | Vision soft tokens | 256 | 256 | 256 | 256 | 256 | 256 | 256 |
-| Vision throughput (GFLOPS) | 21.4 | 41.4 | 35.9 | **39.5** | **74.3** | **142.0** | **231.9** |
-| — utilization (% peak) | 84.2% | 81.6% | 84.0% | **84.1%** | **79.1%** | **75.7%** | **61.8%** |
-| Vision FPGA execution (s)| 53.8 | 27.7 | 32.1 | **29.1** | **15.5** | **8.1** | **5.0** |
-| Vision end-to-end (CPU)(s) | 53.8 | 27.8 | 32.1 | **29.2** | **15.5** | **8.2** | **5.1** |
+| Vision throughput (GFLOPS) | 21.4 | 41.4 | 35.9 | **39.5** | **74.9** | **142.2** | **232.2** |
+| — utilization (% peak) | 84.2% | 81.6% | 84.0% | **84.1%** | **79.8%** | **75.7%** | **61.9%** |
+| Vision FPGA execution (s)| 53.8 | 27.7 | 32.1 | **29.1** | **15.3** | **8.1** | **4.9** |
+| Vision end-to-end (CPU)(s) | 53.8 | 27.8 | 32.1 | **29.2** | **15.4** | **8.2** | **5.1** |
 | **LM PREFILL** |
 | LM prefill seq length | 272 | 272 | 272 | 272 | 272 | 272 | 272 |
-| LM prefill throughput (GFLOPS) | 24.1 | 45.1 | 37.8 | **42.5** | **82.2** | **152.6** | **263.6** |
-| — utilization (% peak) | 94.9% | 88.9% | 88.6% | **90.5%** | **87.6%** | **81.3%** | **70.2%** |
+| LM prefill throughput (GFLOPS) | 24.1 | 45.1 | 37.8 | **42.5** | **82.3** | **152.7** | **263.4** |
+| — utilization (% peak) | 94.9% | 88.9% | 88.5% | **90.5%** | **87.7%** | **81.3%** | **70.2%** |
 | Prefill FPGA execution (s)| 44.0 | 23.5 | 28.0 | **24.9** | **12.9** | **6.9** | **4.0** |
-| Prefill end-to-end (CPU)(s) | 44.1 | 23.6 | 28.1 | **25.0** | **13.0** | **7.1** | **4.2** |
+| Prefill end-to-end (CPU)(s) | 44.1 | 23.6 | 28.1 | **25.0** | **13.0** | **7.1** | **4.3** |
 | **LM DECODE** |
-| Decode 1-st tok throughput (tok/s)| 3.9 | 3.9 | 6.2 | **6.8** | **6.7** | **6.9** | **6.7** |
-| Decode average throughput (GFLOPS) | 23.1 | 22.9 | 36.5 | **40.8** | **40.6** | **40.6** | **40.6** |
-| — utilization (% peak) | 90.8% | 45.2% | 85.5% | **86.9%** | **43.2%** | **21.6%** | **10.8%** |
-| Decode end-to-end (CPU)(s) | 104.5 | 116.1 | 66.6 | **60.2** | **68.0** | **67.8** | **67.3** |
-| Decode average throughput (CPU)(tok/s)| 3.7 | 3.7 | 5.8 | **6.4** | **6.3** | **6.3** | **6.3** |
+| Decode 1-st tok throughput (tok/s)| 4.0 | 3.9 | 6.2 | **6.8** | **6.7** | **6.6** | **6.8** |
+| Decode average throughput (GFLOPS) | 18.3 | 18.2 | 28.9 | **32.3** | **32.2** | **32.2** | **32.2** |
+| — utilization (% peak) | 71.9% | 35.8% | 67.7% | **68.8%** | **34.3%** | **17.1%** | **8.6%** |
+| Decode end-to-end (CPU)(s) | 104.0 | 115.9 | 66.3 | **60.3** | **67.3** | **67.1** | **67.5** |
+| Decode average throughput (CPU)(tok/s)| 3.7 | 3.7 | 5.8 | **6.4** | **6.3** | **6.4** | **6.3** |
 | **ARTIFACT** |
 | Vision program section (MiB) | 3.2 | 2.4 | 3.2 | 3.2 | 2.4 | 1.9 | 1.8 |
 | Prefill program section (MiB)| 5.8 | 4.8 | 5.8 | 5.8 | 4.8 | 4.1 | 3.7 |
@@ -59,51 +59,59 @@ python models/gemma4_e2b/gemma4_e2b_test.py --device kintex7 --dev xdma1 --image
 
 ## Profile backup: vision encoder (kintex7)
 
-Vision multi-core segments tile cleanly (they sum to the single-shot master total)
+Vision multi-core segments tile cleanly (they sum to the single-shot master total).
 
-| Phase | Single-core | --multi-core 2 |
-|---|---:|---:|
-| Patch embedding | 123.6 ms | 123.6 ms |
-| Projection (Q/K/V) † | 6,682.4 ms | **3,361.0 ms** |
-| RoPE | 1,072.8 ms | **740.0 ms** |
-| Permute | 269.6 ms | 269.6 ms |
-| Attention † | 16,642.2 ms | **8,664.7 ms** |
-| Post-attention (O + MLP) † | 28,911.4 ms | **14,541.1 ms** |
-| Pooler tail | 75.3 ms | 75.3 ms |
-| Tail | 0.0 ms | 0.0 ms |
-| **Total** | **53,777.3 ms** | **27,775 ms** |
+| Phase | Work (GFLOPs) | Samples | Single-core | | | `--multi-core 2` | | |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| | | | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
+| patch_embed | 2.97 | 1 | 123.6 | 24.1 | 94.8% | 123.6 | 24.1 | 47.4% |
+| proj † | 147.15 | 16 | 6,682.5 | 22.0 | 86.7% | 3,361.0 | 43.8 | 86.2% |
+| rope † | 8.24 | 16 | 1,072.9 | 7.7 | 30.2% | 738.2 | 11.2 | 22.0% |
+| permute | 0.00 | 16 | 269.6 | 0.0 | 0.0% | 269.6 | 0.0 | 0.0% |
+| attention † | 329.70 | 16 | 16,642.3 | 19.8 | 78.0% | 8,636.4 | 38.2 | 75.2% |
+| post_attn † | 659.51 | 16 | 28,912.0 | 22.8 | 89.9% | 14,539.7 | 45.4 | 89.3% |
+| pooler_tail | 1.51 | 1 | 75.3 | 20.1 | 79.0% | 75.3 | 20.1 | 39.5% |
+| **TOTAL** | **1149.1** | | **53,778.1** | **21.4** | **84.2%** | **27,743.7** | **41.4** | **81.6%** |
 
-† row-sharded across 2 engines
+† Multicore implemented: `proj` and `post_attn` are row-sharded, `rope` is row-sharded, and `attention` is head-sharded across the two engines. `patch_embed`, `permute`, and `pooler_tail` run on core 0 only.
 
 ## Profile backup: LM prefill (kintex7)
 
-| Phase | Single-core | --multi-core 2 | Single-core GQA | --multi-core 2 GQA |
-|---|---:|---:|---:|---:|
-| Per-layer preparation ‡ | 596.0 ms | 596.0 ms | 596.0 ms | 0.0 ms |
-| QKV/V projection † | 3,302.5 ms | **1,682.3 ms** | 3,302.5 ms | **1,693.6 ms** |
-| RoPE | 162.6 ms | 162.6 ms | 162.6 ms | 162.5 ms |
-| KV gather | 70.0 ms | 70.0 ms | 0.1 ms | 0.1 ms |
-| Q permute | — | — | 75.2 ms | 75.3 ms |
-| Attention † | 9,268.7 ms | 9,268.7 ms | 1,697.2 ms | **906.3 ms** |
-| MLP (incl. O projection) † | 37,426.6 ms | **19,309.4 ms** | 37,426.7 ms | **19,331.5 ms** |
-| Injection | 694.2 ms | 694.2 ms | 694.2 ms | 694.2 ms |
-| Tail halt | 0.0 ms | 0.0 ms | 0.0 ms | 0.0 ms |
-| **Total** | **51,520.6 ms** | **31,782.4 ms** | **43,954.5 ms** | **22,863.3 ms** |
+| Phase | Work (GFLOPs) | Samples | Single-core | | | `--multi-core 2` | | |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| | | | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
+| per_layer_prepare | 14.11 | 1 | 595.9 | 23.7 | 93.3% | 595.9 | 23.7 | 93.3% |
+| qkv_vproj † | 79.73 | 35 | 3,302.6 | 24.1 | 95.1% | 1,693.6 | 47.1 | 92.7% |
+| rope | 0.08 | 35 | 162.6 | 0.5 | 1.9% | 162.4 | 0.5 | 1.0% |
+| q_permute | 0.00 | 35 | 75.2 | 0.0 | 0.0% | 75.2 | 0.0 | 0.0% |
+| attention † | 30.12 | 35 | 1,697.2 | 17.7 | 69.9% | 906.5 | 33.2 | 65.4% |
+| mlp † | 919.50 | 35 | 37,426.7 | 24.6 | 96.8% | 19,333.1 | 47.6 | 93.7% |
+| inject | 15.07 | 35 | 694.2 | 21.7 | 85.5% | 694.2 | 21.7 | 42.8% |
+| **TOTAL** | **1058.6** | | **43,954.4** | **24.1** | **94.9%** | **23,460.9** | **45.1** | **88.9%** |
 
-† row-sharded across 2 engines (these ~halve).
+† Multicore implemented: `qkv_vproj`, `attention`, and `mlp` are sharded across the two engines. `per_layer_prepare`, `rope`, `q_permute`, and `inject` run on core 0 only.
 
-## Profile backup: one decode token at position 272 (kintex7) no multicore usecase in decoder
+## Profile backup: decode tokens (kintex7; no multicore use case)
 
-| Phase | Single-core | 
-|---|---:|
-| Per-layer preparation | 5.6 ms |
-| QKV/V projection | 13.2 ms |
-| RoPE | 1.0 ms |
-| KV gather | 0.1 ms |
-| Attention | 30.5 ms |
-| O projection | 11.8 ms |
-| MLP | 135.8 ms |
-| Injection | 12.6 ms |
-| LM head | 34.8 ms |
-| Tail increment | 0.0 ms |
-| **Total** | **245.3 ms** |
+| Phase | Samples | First decode step (position 272) | | | | 1024th token (position 1023) | | | |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| | | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
+| per_layer_prepare | 1 | 0.03 | 5.6 | 5.0 | 19.6% | 0.03 | 5.6 | 5.0 | 19.6% |
+| qkv_vproj | 35 | 0.29 | 13.2 | 22.3 | 87.7% | 0.29 | 13.2 | 22.3 | 87.7% |
+| rope | 35 | 0.00 | 1.0 | 0.6 | 2.4% | 0.00 | 1.0 | 0.6 | 2.4% |
+| attention | 35 | 0.11 | 30.6 | 3.6 | 14.3% | 0.35 | 92.5 | 3.8 | 15.1% |
+| o_proj | 35 | 0.26 | 11.8 | 22.5 | 88.6% | 0.26 | 11.8 | 22.5 | 88.5% |
+| mlp | 35 | 3.12 | 135.8 | 22.9 | 90.4% | 3.12 | 135.8 | 22.9 | 90.4% |
+| inject | 35 | 0.06 | 12.6 | 4.4 | 17.3% | 0.06 | 12.6 | 4.4 | 17.3% |
+| lm_head | 1 | 0.81 | 34.8 | 23.1 | 91.1% | 0.81 | 34.8 | 23.1 | 91.1% |
+| **TOTAL** | | **4.7** | **245.3** | **19.1** | **75.0%** | **4.9** | **307.2** | **16.0** | **63.0%** |
+
+### Ideal attention prediction (100% peak throughput)
+
+All non-attention phase latencies remain measured values. Predicted attention latency is `attention work / 25.4 GFLOPS`.
+
+| Phase | First decode step (position 272) | | | | 1024th token (position 1023) | | | |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
+| attention | 0.11 | 4.4 | 25.4 | 100.0% | 0.35 | 13.9 | 25.4 | 100.0% |
+| **TOTAL** | **4.7** | **219.1** | **21.3** | **84.0%** | **4.9** | **228.6** | **21.5** | **84.7%** |

--- a/models/gemma4_e2b/gemma4_e2b_test.py
+++ b/models/gemma4_e2b/gemma4_e2b_test.py
@@ -1176,8 +1176,11 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
                 self._prefill_shard_m_regs = None
 
             decoder_count_at_start = self.capture_count
+            decoder_accounting_seq_len = (
+                (len(self.prefill_seq) + 63) // 64) * 64
             _, decoder_program_sizes, decoder_total_flops = self.compile_decoder(
-                layer_size=layer_size, profile=profile)
+                layer_size=layer_size, profile=profile,
+                accounting_seq_len=decoder_accounting_seq_len)
             decoder_program_addr = instruction_base_addr + decoder_count_at_start * INSTRUCTION_SIZE_BYTES
             decoder_size_bytes = decoder_program_sizes[0]
 
@@ -1203,6 +1206,8 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             "decoder_program_start_addr": f"0x{decoder_program_addr:X}",
             "decoder_program_size": decoder_size_bytes,
             "decoder_total_flops": decoder_total_flops[0],
+            "decoder_non_attention_flops": self._decoder_non_attention_flops,
+            "decoder_accounting_seq_len": decoder_accounting_seq_len,
             "layer_size": layer_size,
             "prefill_kernel": self.prefill_kernel,
             "multi_core": self.multi_core,
@@ -1252,6 +1257,9 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         base_addr = meta["_dram_base_int"]
         prefill_program_addr = int(meta["prefill_program_start_addr"], 16)
         decoder_program_addr = int(meta["decoder_program_start_addr"], 16)
+        if "decoder_non_attention_flops" in meta:
+            self._decoder_non_attention_flops = int(
+                meta["decoder_non_attention_flops"])
         self._preamble_addr = self.get_program_dram_addr()
         print(f"[run] loaded LM section at 0x{base_addr:X} ({meta['prefill_program_size']/1024:.1f} + "
               f"{meta['decoder_program_size']/1024:.1f} KB); dispatch preamble @ 0x{self._preamble_addr:X}")
@@ -1464,11 +1472,122 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
             f.write("\n".join(lines))
         return out_path
 
+    def write_profile_summary(self, out_path: str, args) -> str:
+        """Write run metadata followed only by Vision/Prefill/Decode profiles."""
+        clock_ns = self._clock_period_ns
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        cores = self.multi_core
+        peak_gflops = self._profile_peak_gflops()
+        try:
+            hw_version = self.user_read_reg32(
+                user_dma_core.UE_FPGA_VERSION_ADDR) & 0xFFFFFFFF
+            hw_version_str = f"0x{hw_version:08x}"
+        except Exception as e:
+            hw_version_str = f"(read failed: {e})"
+
+        weight_bin_path = os.path.join(self.script_dir, self._weights_bin_rel)
+        weight_bin_size = (os.path.getsize(weight_bin_path)
+                           if os.path.exists(weight_bin_path) else 0)
+        total_weight_dram_mb = getattr(
+            self, "_lm_weight_dram_bytes", self.get_params_dram_usage()) / (1024 * 1024)
+        sections, _ = self._read_program_sections(profile=True)
+        prog_bin_path, _ = self._program_image_paths(profile=True)
+        prog_bin_size = (os.path.getsize(prog_bin_path)
+                         if os.path.exists(prog_bin_path) else 0)
+        vision_sect = sections.get("vision")
+        lm_sect = sections.get("lm") or {}
+
+        def _mb(n):
+            return f"{n / (1024 * 1024):.1f} MB" if n is not None else "n/a"
+        def _kb(n):
+            return f"{n / 1024:.1f} KB" if n is not None else "n/a"
+
+        lines = [
+            "# gemma4_e2b_test profile summary",
+            "",
+            f"- **HW version:** {hw_version_str}",
+            f"- **--dev:** {args.dev}",
+            f"- **--device:** {args.device}",
+            f"- **Clock / frequency:** {clock_ns:.1f} ns ({freq_mhz:.1f} MHz)",
+            f"- **Cores (--multi-core):** {cores}",
+            f"- **Peak throughput:** {peak_gflops:.1f} GFLOPS "
+            f"({freq_mhz:.1f} MHz × 128 × {cores} core(s))",
+        ]
+        dram_read_speed = getattr(self, "_dram_read_speed_mbps", None)
+        if dram_read_speed is not None:
+            lines.append(f"- **DRAM read speed:** {dram_read_speed:.1f} MB/s "
+                         f"({cores}-core aggregate, private regions)")
+        lines.extend([
+            "",
+            "## Weights",
+            "",
+            f"- **Weight bin:** `{os.path.basename(weight_bin_path)}` — {_mb(weight_bin_size)}",
+            f"- **Total weight DRAM (quantized, on FPGA):** {total_weight_dram_mb:.1f} MB",
+            "",
+            f"## Program image (`{os.path.basename(prog_bin_path)}`)",
+            "",
+            f"- **Total programs.bin size:** {_mb(prog_bin_size)}",
+        ])
+        if getattr(args, "image", None):
+            lines.append(f"- **Vision section:** "
+                         f"{_mb(vision_sect['size'] if vision_sect else None)}")
+        lines.extend([
+            f"- **Prefill program:** {_kb(lm_sect.get('prefill_program_size'))}",
+            f"- **Decoder program:** {_kb(lm_sect.get('decoder_program_size'))}",
+            "",
+        ])
+
+        def _append_profile_section(title: str, results, level: int = 2) -> None:
+            lines.extend([f"{'#' * level} {title}", ""])
+            if not results:
+                lines.extend(["Profile data unavailable.", ""])
+                return
+            rows = self._aggregate_profile_results(results)
+            lines.extend([
+                "| Phase | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | Samples |",
+                "|---|---:|---:|---:|---:|---:|",
+            ])
+            for row in rows:
+                work_gflops = (f"{row['flops'] / 1e9:.2f}"
+                               if row["flops"] is not None else "n/a")
+                gflops = f"{row['gflops']:.1f}" if row["gflops"] is not None else "n/a"
+                util = f"{row['util_pct']:.1f}%" if row["util_pct"] is not None else "n/a"
+                lines.append(f"| {row['phase']} | {work_gflops} | {row['ms']:.1f} | "
+                             f"{gflops} | {util} | {row['n']} |")
+            total_ms = sum(row["ms"] for row in rows)
+            known_flops = [row["flops"] for row in rows if row["flops"] is not None]
+            total_flops = sum(known_flops) if len(known_flops) == len(rows) else None
+            total_rate = (total_flops / (total_ms * 1e6)
+                          if total_flops is not None and total_ms else None)
+            total_util = (100.0 * total_rate / peak_gflops
+                          if total_rate is not None and peak_gflops else None)
+            lines.append(
+                f"| **TOTAL** | **{f'{total_flops / 1e9:.1f}' if total_flops is not None else 'n/a'}** | "
+                f"**{total_ms:.1f}** | **{f'{total_rate:.1f}' if total_rate is not None else 'n/a'}** | "
+                f"**{f'{total_util:.1f}%' if total_util is not None else 'n/a'}** | |")
+            lines.append("")
+
+        _append_profile_section("Vision", getattr(self, "_vision_profile_results", None))
+        _append_profile_section("Prefill", getattr(self, "_prefill_profile_results", None))
+        lines.extend(["## Decode", ""])
+        first_pos = getattr(self, "_decode_first_profile_position", "n/a")
+        _append_profile_section(
+            f"First decode step (position {first_pos})",
+            getattr(self, "_decode_profile_results", None), level=3)
+        target_pos = getattr(self, "_decode_1024_profile_position", 1023)
+        _append_profile_section(
+            f"1024th token (position {target_pos})",
+            getattr(self, "_decode_1024_profile_results", None), level=3)
+
+        with open(out_path, "w") as f:
+            f.write("\n".join(lines))
+        return out_path
+
     def _profile_execute(self, gpr_sets: list[tuple[int, int]], target_addr: int,
                          checkpoints: list, tail_name: str, timeout: float = 120.0,
                          worker_scheduler=None, worker_addrs=None) -> list:
-        """Run a checkpointed program segment-by-segment, returning [(name, ms)]
-        HW latency per segment. A preamble at self._preamble_addr primes each
+        """Run checkpointed segments, returning ``(name, ms, FLOPs)`` samples.
+        A preamble at self._preamble_addr primes each
         (reg, value) in ``gpr_sets`` then jumps into ``target_addr``; each
         checkpoint HALT stops the FPGA so the per-segment latency counter can be
         read before resuming from the recorded address. The final ``tail_name``
@@ -1493,15 +1612,29 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
 
         results = []
         if worker_scheduler is not None:
-            worker_scheduler.preclear_flags()
+            # run_prefill() already preclears every engine after loading the
+            # worker programs.  Do not preclear again here: that redundant
+            # core-0 program corrupts the first segmented latency sample.
             worker_scheduler.start_workers(worker_addrs or [])
         self.start_execute_from_dram(self._preamble_addr)
-        for name, resume_hex in checkpoints:
+        for checkpoint in checkpoints:
+            name, resume_hex, *extra = checkpoint
+            phase_flops = int(extra[0]) if extra else None
             self.wait_queue(timeout)
-            results.append((name, self.report_latency_in_us() / 1e3))   # ms
+            measured_ms = self.report_latency_in_us() / 1e3
+            results.append((name, measured_ms,
+                            phase_flops))   # ms, FLOPs
             self.start_execute_from_dram(int(resume_hex, 16))
         self.wait_queue(timeout)   # tail segment: everything up to the terminal HALT
-        results.append((tail_name, self.report_latency_in_us() / 1e3))
+        tail_ms = self.report_latency_in_us() / 1e3
+        if results:
+            # The terminal segment is a coverage boundary, not a useful report
+            # row. Fold prefill's HALT into inject and decode's position
+            # increment/HALT into lm_head.
+            prev_name, prev_ms, prev_flops = results[-1]
+            results[-1] = (prev_name, prev_ms + tail_ms, prev_flops)
+        else:
+            results.append((tail_name, tail_ms, 0))
         for worker in (worker_scheduler.workers if worker_scheduler is not None else []):
             worker.wait_queue(timeout)
         return results
@@ -1511,36 +1644,97 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         """One decode step through the profile-bin's HALT checkpoints. Preamble
         primes gpr_seq_len (=decode_pos) / gpr_aligned_seq_len; the tail segment
         is the add_inc(gpr_seq_len) + terminal HALT."""
-        return self._profile_execute(
+        results = self._profile_execute(
             [(self.gpr_seq_len, self.seq_len - 1),
              (self.gpr_aligned_seq_len, aligned_seq_len)],
             decoder_addr, checkpoints, tail_name="tail_addinc", timeout=timeout)
+        # The decoder program is captured with MAX_CONTEXT_SIZE as its template
+        # aligned length, so compile-time attention FLOPs describe that maximum.
+        # Replace only attention FLOPs with the exact live-length formula used by
+        # unified_attention_core_dynamic: Q scale + QK (incl. bias/softmax) + PV.
+        adjusted = []
+        import re
+        for name, ms, flops in results:
+            match = re.fullmatch(r"L(\d+)_attention", name)
+            if match:
+                layer_idx = int(match.group(1))
+                head_dim, _, _ = self._get_layer_attention_dims(layer_idx)
+                batch = self.group_size
+                flops = (batch * head_dim
+                         + batch * aligned_seq_len * (4 * head_dim + 6))
+            adjusted.append((name, ms, flops))
+        return adjusted
 
     def _print_phase_breakdown(self, title: str, results: list, per_token: bool) -> None:
-        """Aggregate per-layer checkpoints ("L<idx>_<phase>") into phase totals
-        and print a table. ``per_token`` adds a decode throughput line."""
+        """Print aggregated phase latency, FLOPs, throughput, and utilization."""
+        rows = self._aggregate_profile_results(results)
+        total_ms = sum(row["ms"] for row in rows)
+        all_flops_known = all(row["flops"] is not None for row in rows)
+        total_flops = (sum(row["flops"] for row in rows)
+                       if all_flops_known else None)
+        print(f"\n=== {title} per-phase FPGA profile ===")
+        print(f"{'phase':<16}{'work GFLOPs':>14}{'total ms':>11}{'n':>5}"
+              f"{'GFLOPS':>11}{'% peak':>9}")
+        print("-" * 66)
+        for row in rows:
+            flops_s = (f"{row['flops'] / 1e9:.2f}"
+                       if row["flops"] is not None else "n/a")
+            gflops_s = (f"{row['gflops']:.1f}" if row["gflops"] is not None else "n/a")
+            util_s = (f"{row['util_pct']:.1f}%" if row["util_pct"] is not None else "n/a")
+            print(f"{row['phase']:<16}{flops_s:>14}{row['ms']:>11.1f}{row['n']:>5}"
+                  f"{gflops_s:>11}{util_s:>9}")
+        print("-" * 66)
+        total_gflops = (total_flops / (total_ms * 1e6)
+                        if total_flops is not None and total_ms else None)
+        peak = self._profile_peak_gflops()
+        total_util = (100.0 * total_gflops / peak
+                      if total_gflops is not None and peak else None)
+        total_flops_s = (f"{total_flops / 1e9:.2f}"
+                         if total_flops is not None else "n/a")
+        total_gflops_s = f"{total_gflops:.1f}" if total_gflops is not None else "n/a"
+        total_util_s = f"{total_util:.1f}%" if total_util is not None else "n/a"
+        print(f"{'TOTAL':<16}{total_flops_s:>14}{total_ms:>11.1f}{'':>5}"
+              f"{total_gflops_s:>11}{total_util_s:>9}")
+        if per_token and total_ms:
+            print(f"Decode HW throughput: {1000.0/total_ms:.1f} tok/s ({total_ms:.1f} ms/token)")
+
+    def _profile_peak_gflops(self) -> float:
+        clock_ns = self._clock_period_ns
+        freq_mhz = 1000.0 / clock_ns if clock_ns else 0.0
+        return freq_mhz * 0.128 * self.multi_core
+
+    def _aggregate_profile_results(self, results: list) -> list[dict]:
+        """Aggregate ``L<idx>_<phase>`` samples while preserving phase order."""
         import re
-        from collections import defaultdict
-        phase_ms: dict = defaultdict(float)
-        phase_n: dict = defaultdict(int)
-        for name, ms in results:
+        phases = {}
+        for result in results:
+            name, ms, *extra = result
+            flops = extra[0] if extra else None
             m = re.match(r"L\d+_(.+)", name)
             phase = m.group(1) if m else name
-            phase_ms[phase] += ms
-            phase_n[phase] += 1
-        total_ms = sum(phase_ms.values())
-
-        print(f"\n=== {title} per-phase HW latency ===")
-        print(f"{'phase':<16}{'total ms':>10}{'%':>7}{'n':>5}{'ms/layer':>10}")
-        print("-" * 48)
-        for phase, ms in sorted(phase_ms.items(), key=lambda kv: -kv[1]):
-            n = phase_n[phase]
-            pct = ms / total_ms * 100 if total_ms else 0.0
-            print(f"{phase:<16}{ms:>10.3f}{pct:>6.1f}%{n:>5}{ms/n:>10.4f}")
-        print("-" * 48)
-        print(f"{'TOTAL':<16}{total_ms:>10.3f}{100.0:>6.1f}%")
-        if per_token and total_ms:
-            print(f"Decode HW throughput: {1000.0/total_ms:.2f} tok/s ({total_ms:.1f} ms/token)")
+            row = phases.setdefault(phase, {"phase": phase, "ms": 0.0,
+                                             "flops": 0, "n": 0,
+                                             "flops_known": True})
+            row["ms"] += float(ms)
+            row["n"] += 1
+            if flops is None:
+                row["flops_known"] = False
+            else:
+                row["flops"] += int(flops)
+        peak = self._profile_peak_gflops()
+        rows = []
+        for row in phases.values():
+            if not row.pop("flops_known"):
+                row["flops"] = None
+            row["gflops"] = (row["flops"] / (row["ms"] * 1e6)
+                              if row["flops"] is not None and row["ms"] else None)
+            phase_peak = peak
+            if row["phase"] == "per_layer_prepare" and self.multi_core > 1:
+                phase_peak = peak / self.multi_core
+            row["util_pct"] = (100.0 * row["gflops"] / phase_peak
+                                if row["gflops"] is not None and phase_peak else None)
+            rows.append(row)
+        return rows
 
     def run_gemma4_profile(self) -> None:
         """Load the profile image (programs_profile.bin, built with per-phase
@@ -1566,34 +1760,60 @@ class Gemma4_UnifiedEngine(Gemma4LMMixin, Gemma4VisionMixin,
         prefill_results = self.run_prefill(
             prefill_program_addr, flops=meta["prefill_total_flops"],
             profile_checkpoints=prefill_checkpoints)
+        self._prefill_profile_results = prefill_results
         self._print_phase_breakdown("PREFILL", prefill_results, per_token=False)
 
-        # Host prep for ONE decode step (mirrors run_decoder's per-step work).
+        # Host prep for a decode position (mirrors run_decoder's per-step work).
         token_id = self.prefill_seq[-1]
         self.dma_to_accelerator_memory(
             self.PENALTY_BIAS_DRAM,
             torch.zeros(1, self.EMBEDDING_ELEMENTS, dtype=torch.bfloat16))
-        self.seq_len += 1
-        aligned_seq_len = ((self.seq_len + 63) // 64) * 64
         emb = self.get_embedding_for_tokens([token_id])
-        self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, emb)
         pli_embed = self._lookup_per_layer_embeddings([token_id])
-        self.dma_to_accelerator_memory(
-            self.PER_LAYER_EMBED_DRAM,
-            pli_embed)
-        full_bias = torch.full((self.group_size, aligned_seq_len), -1e36, dtype=torch.bfloat16)
-        full_bias[:, :self.seq_len] = 0.0
-        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_FULL_DRAM, full_bias)
-        if self.seq_len <= self.sliding_window:
-            sliding_bias = full_bias
-        else:
-            sliding_bias = torch.full((self.group_size, aligned_seq_len), -1e36, dtype=torch.bfloat16)
-            sliding_bias[:, self.seq_len - self.sliding_window:self.seq_len] = 0.0
-        self.dma_to_accelerator_memory(self.LAYER0_FLASH_BIAS_SLIDING_DRAM, sliding_bias)
 
-        print(f"\n--- Profiling one decode step (pos {self.seq_len - 1}) ---", flush=True)
-        decode_results = self._decode_profile_execute(decoder_program_addr, aligned_seq_len, decoder_checkpoints)
-        self._print_phase_breakdown("DECODE (1 token)", decode_results, per_token=True)
+        def _prepare_decode_position(context_len: int) -> int:
+            self.seq_len = context_len
+            aligned = ((context_len + 63) // 64) * 64
+            self.dma_to_accelerator_memory(self.LAYER0_INPUT_DRAM, emb)
+            self.dma_to_accelerator_memory(self.PER_LAYER_EMBED_DRAM, pli_embed)
+            full_bias = torch.full(
+                (self.group_size, aligned), -1e36, dtype=torch.bfloat16)
+            full_bias[:, :context_len] = 0.0
+            self.dma_to_accelerator_memory(
+                self.LAYER0_FLASH_BIAS_FULL_DRAM, full_bias)
+            if context_len <= self.sliding_window:
+                sliding_bias = full_bias
+            else:
+                sliding_bias = torch.full(
+                    (self.group_size, aligned), -1e36, dtype=torch.bfloat16)
+                sliding_bias[:, context_len - self.sliding_window:context_len] = 0.0
+            self.dma_to_accelerator_memory(
+                self.LAYER0_FLASH_BIAS_SLIDING_DRAM, sliding_bias)
+            return aligned
+
+        # First decode step immediately following the real prefill.
+        first_context_len = self.seq_len + 1
+        aligned_seq_len = _prepare_decode_position(first_context_len)
+        self._decode_first_profile_position = first_context_len - 1
+        print(f"\n--- Profiling first decode step (pos {first_context_len - 1}) ---",
+              flush=True)
+        decode_results = self._decode_profile_execute(
+            decoder_program_addr, aligned_seq_len, decoder_checkpoints)
+        self._decode_profile_results = decode_results
+        self._print_phase_breakdown("DECODE (first step)", decode_results, per_token=True)
+
+        # Performance-only 1024th-token profile. Intermediate KV rows are left
+        # as initialized/prefill data; values do not affect the execution path.
+        target_context_len = 1024
+        aligned_seq_len = _prepare_decode_position(target_context_len)
+        self._decode_1024_profile_position = target_context_len - 1
+        print(f"\n--- Profiling 1024th token (pos {target_context_len - 1}) ---",
+              flush=True)
+        decode_1024_results = self._decode_profile_execute(
+            decoder_program_addr, aligned_seq_len, decoder_checkpoints)
+        self._decode_1024_profile_results = decode_1024_results
+        self._print_phase_breakdown(
+            "DECODE (1024th token)", decode_1024_results, per_token=True)
 
     @staticmethod
     def _parse_offset(val) -> int:
@@ -1805,7 +2025,8 @@ def run_summary_filename(args) -> str:
         tokens.append("bin-reuse")
     if args.cycle is not None:
         tokens.append(f"cycle_{args.cycle}")
-    return "gemma4_e2b_test_" + "_".join(str(t) for t in tokens) + ".md"
+    suffix = "_profile" if args.profile else ""
+    return "gemma4_e2b_test_" + "_".join(str(t) for t in tokens) + suffix + ".md"
 
 
 def main():
@@ -1881,6 +2102,12 @@ def main():
         ue.compile_gemma4(profile=True)
         print(f"Profile compile done in {time.perf_counter() - timer:.2f} seconds")
         ue.run_gemma4_profile()
+        _summary_path = os.path.join(SCRIPT_DIR, _summary_name)
+        try:
+            ue.write_profile_summary(_summary_path, args)
+            print(f"Wrote profile summary: {_summary_path}")
+        except Exception as _e:
+            print(f"[warn] failed to write profile summary: {_e}")
         print("Gemma4 E2B decode profile ends.")
         return
 

--- a/models/gemma4_e2b/gemma4_e2b_vision.py
+++ b/models/gemma4_e2b/gemma4_e2b_vision.py
@@ -554,12 +554,16 @@ class Gemma4VisionMixin:
               f"{' (+profile checkpoints)' if profile else ''} ...", flush=True)
         t0 = time.perf_counter()
         enc_checkpoints: list[list] = []
+        last_checkpoint_flops = 0
         def _checkpoint(name: str) -> None:
+            nonlocal last_checkpoint_flops
             if not profile:
                 return
             self.generate_instruction_halt()
             resume = self.get_program_dram_addr() + self.capture_count * INSTRUCTION_SIZE_BYTES
-            enc_checkpoints.append([name, f"0x{resume:X}"])
+            phase_flops = int(self._vis_flops - last_checkpoint_flops)
+            enc_checkpoints.append([name, f"0x{resume:X}", phase_flops])
+            last_checkpoint_flops = int(self._vis_flops)
         _prev_silent = self._set_silent(False)
         self.reset_program_dram_addr()
         base_addr = self.get_program_dram_addr()
@@ -907,7 +911,7 @@ class Gemma4VisionMixin:
 
         ``profile``: run the profile-compiled bin **segment-by-segment** through
         its per-phase HALT checkpoints, timing each with the HW latency counter,
-        and return the per-segment [(name, ms)] list instead. The encoder still
+        and return per-segment ``(name, ms, FLOPs)`` samples instead. The encoder still
         computes its full output (segments tile the whole program). No preamble
         is needed — the vision ops prime their own GPRs inline."""
         import threading
@@ -948,14 +952,22 @@ class Gemma4VisionMixin:
             if gate_scheduler is not None:
                 gate_scheduler.start_workers(worker_addrs)
             self.start_execute_from_dram(program_addr)
-            for name, resume_hex in checkpoints:
+            for checkpoint in checkpoints:
+                name, resume_hex, *extra = checkpoint
+                phase_flops = int(extra[0]) if extra else None
                 self.wait_queue(180.0)
-                results.append((name, self.report_latency_in_us() / 1e3))   # ms
+                results.append((name, self.report_latency_in_us() / 1e3,
+                                phase_flops))   # ms, FLOPs
                 self.start_execute_from_dram(int(resume_hex, 16))
             self.wait_queue(180.0)   # tail: final HALT after the last checkpoint
             for worker in gate_scheduler.workers if gate_scheduler is not None else []:
                 worker.wait_queue(180.0)
-            results.append(("tail", self.report_latency_in_us() / 1e3))
+            tail_ms = self.report_latency_in_us() / 1e3
+            if results:
+                # The terminal HALT is only the final coverage boundary; fold
+                # it into pooler_tail instead of reporting a fake phase.
+                prev_name, prev_ms, prev_flops = results[-1]
+                results[-1] = (prev_name, prev_ms + tail_ms, prev_flops)
             return results
 
         _anchor = getattr(self, "_vis_fpga_t0", t0)
@@ -1149,6 +1161,7 @@ class Gemma4VisionMixin:
 
         # Major-step FPGA-latency breakdown of the encoder (profile mode only).
         if profile and isinstance(enc_result, list):
+            self._vision_profile_results = enc_result
             self._print_phase_breakdown("VISION ENCODER", enc_result, per_token=False)
         fpga_total_s = time.perf_counter() - fpga_total_t0
         # Per-stage host wall-clock breakdown of the whole vision path (--profile only).


### PR DESCRIPTION
## Profile backup: vision encoder (kintex7)

Vision multi-core segments tile cleanly (they sum to the single-shot master total).

| Phase | Work (GFLOPs) | Samples | Single-core | | | `--multi-core 2` | | |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| | | | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
| patch_embed | 2.97 | 1 | 123.6 | 24.1 | 94.8% | 123.6 | 24.1 | 47.4% |
| proj † | 147.15 | 16 | 6,682.5 | 22.0 | 86.7% | 3,361.0 | 43.8 | 86.2% |
| rope † | 8.24 | 16 | 1,072.9 | 7.7 | 30.2% | 738.2 | 11.2 | 22.0% |
| permute | 0.00 | 16 | 269.6 | 0.0 | 0.0% | 269.6 | 0.0 | 0.0% |
| attention † | 329.70 | 16 | 16,642.3 | 19.8 | 78.0% | 8,636.4 | 38.2 | 75.2% |
| post_attn † | 659.51 | 16 | 28,912.0 | 22.8 | 89.9% | 14,539.7 | 45.4 | 89.3% |
| pooler_tail | 1.51 | 1 | 75.3 | 20.1 | 79.0% | 75.3 | 20.1 | 39.5% |
| **TOTAL** | **1149.1** | | **53,778.1** | **21.4** | **84.2%** | **27,743.7** | **41.4** | **81.6%** |

† Multicore implemented: `proj` and `post_attn` are row-sharded, `rope` is row-sharded, and `attention` is head-sharded across the two engines. `patch_embed`, `permute`, and `pooler_tail` run on core 0 only.

## Profile backup: LM prefill (kintex7)

| Phase | Work (GFLOPs) | Samples | Single-core | | | `--multi-core 2` | | |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| | | | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
| per_layer_prepare | 14.11 | 1 | 595.9 | 23.7 | 93.3% | 595.9 | 23.7 | 93.3% |
| qkv_vproj † | 79.73 | 35 | 3,302.6 | 24.1 | 95.1% | 1,693.6 | 47.1 | 92.7% |
| rope | 0.08 | 35 | 162.6 | 0.5 | 1.9% | 162.4 | 0.5 | 1.0% |
| q_permute | 0.00 | 35 | 75.2 | 0.0 | 0.0% | 75.2 | 0.0 | 0.0% |
| attention † | 30.12 | 35 | 1,697.2 | 17.7 | 69.9% | 906.5 | 33.2 | 65.4% |
| mlp † | 919.50 | 35 | 37,426.7 | 24.6 | 96.8% | 19,333.1 | 47.6 | 93.7% |
| inject | 15.07 | 35 | 694.2 | 21.7 | 85.5% | 694.2 | 21.7 | 42.8% |
| **TOTAL** | **1058.6** | | **43,954.4** | **24.1** | **94.9%** | **23,460.9** | **45.1** | **88.9%** |

† Multicore implemented: `qkv_vproj`, `attention`, and `mlp` are sharded across the two engines. `per_layer_prepare`, `rope`, `q_permute`, and `inject` run on core 0 only.

## Profile backup: decode tokens (kintex7; no multicore use case)

| Phase | Samples | First decode step (position 272) | | | | 1024th token (position 1023) | | | |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| | | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
| per_layer_prepare | 1 | 0.03 | 5.6 | 5.0 | 19.6% | 0.03 | 5.6 | 5.0 | 19.6% |
| qkv_vproj | 35 | 0.29 | 13.2 | 22.3 | 87.7% | 0.29 | 13.2 | 22.3 | 87.7% |
| rope | 35 | 0.00 | 1.0 | 0.6 | 2.4% | 0.00 | 1.0 | 0.6 | 2.4% |
| attention | 35 | 0.11 | 30.6 | 3.6 | 14.3% | 0.35 | 92.5 | 3.8 | 15.1% |
| o_proj | 35 | 0.26 | 11.8 | 22.5 | 88.6% | 0.26 | 11.8 | 22.5 | 88.5% |
| mlp | 35 | 3.12 | 135.8 | 22.9 | 90.4% | 3.12 | 135.8 | 22.9 | 90.4% |
| inject | 35 | 0.06 | 12.6 | 4.4 | 17.3% | 0.06 | 12.6 | 4.4 | 17.3% |
| lm_head | 1 | 0.81 | 34.8 | 23.1 | 91.1% | 0.81 | 34.8 | 23.1 | 91.1% |
| **TOTAL** | | **4.7** | **245.3** | **19.1** | **75.0%** | **4.9** | **307.2** | **16.0** | **63.0%** |

### Ideal attention prediction (100% peak throughput)

All non-attention phase latencies remain measured values. Predicted attention latency is `attention work / 25.4 GFLOPS`.

| Phase | First decode step (position 272) | | | | 1024th token (position 1023) | | | |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) | Work (GFLOPs) | FPGA execution time (ms) | Throughput (GFLOPS) | Utilization (% peak) |
| attention | 0.11 | 4.4 | 25.4 | 100.0% | 0.35 | 13.9 | 25.4 | 100.0% |
| **TOTAL** | **4.7** | **219.1** | **21.3** | **84.0%** | **4.9** | **228.6** | **21.5** | **84.7%** |