### PR TITLE
Benchmark Gemma3 single-DMA elementwise paths

### DIFF
--- a/models/gemma3/gemma3_test.py
+++ b/models/gemma3/gemma3_test.py
@@ -267,6 +267,10 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         program_dram_base = DRAM_INSTRUCTION_ADDR + 0x10000000 if engine_slave else DRAM_INSTRUCTION_ADDR
         engine_base = user_dma_core.UE_0_BASE_ADDR + 0x00010000 if engine_slave else user_dma_core.UE_0_BASE_ADDR
         super().__init__(BASE_ADDR=engine_base, program_dram_base=program_dram_base)
+        # Performance experiment: omit the second input DMA in dynamic vector elementwise ops.
+        # This intentionally sacrifices numerical correctness and must not be used as a model
+        # correctness configuration; it isolates the latency benefit of single-DMA eltwise.
+        self._benchmark_single_dma_eltwise = True
         self.dual_engine = dual_engine
         self.legacy = legacy
         self.two_pass_prefill = two_pass_prefill
@@ -1861,6 +1865,12 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
         global _SILENT_MODE
         _SILENT_MODE = True
 
+        # Benchmark-only decoder shortcut.  Mirroring the dynamic DRAM eltwise experiment,
+        # is_broadcast=True suppresses each vector op's second DRAM->SRAM input transfer while
+        # leaving its ADD/MUL compute and writeback instructions in place.  URAM_B is therefore
+        # stale and numerical output is intentionally invalid; this isolates DMA latency only.
+        is_broadcast = bool(getattr(self, "_benchmark_single_dma_eltwise", False))
+
         # ---- persistent registers (seeded once, before the loop) ----
         # PBI row-loop trip-count registers (matmul/rms gpr_M_reg) must be low GPRs (1..15) because
         # the hardware loop-counter field is narrow — allocate the two decode row-counts (M=1 and
@@ -2091,7 +2101,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         # --- post-attention residual (SRAM-staged; layer-invariant buffers, literal addrs) ---
         self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_INPUT_DRAM, sram_address=0x10000, element_size=self.vector_length)
-        self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
+        if not is_broadcast:
+            self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
         self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
         self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, element_size=self.vector_length)
         if profile:
@@ -2121,7 +2132,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         # --- gate * up (SRAM-staged) ---
         self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_GATE_DRAM, sram_address=0x10000, element_size=self.mlp_elements)
-        self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
+        if not is_broadcast:
+            self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_MLP_UP_DRAM, sram_address=0x90000, element_size=self.mlp_elements)
         self.eltwise_mul_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.mlp_elements)
         self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_MLP_MULT_DRAM, element_size=self.mlp_elements)
         if profile:
@@ -2143,7 +2155,8 @@ class Gemma3_UnifiedEngine(UnifiedEngine):
 
         # --- post-MLP residual (SRAM-staged) -> LAYER0_OUTPUT_DRAM ---
         self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_ATTN_RESIDUAL_DRAM, sram_address=0x10000, element_size=self.vector_length)
-        self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_MLP_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
+        if not is_broadcast:
+            self.accelerator_memory_to_sram(accelerator_dram_address=self.LAYER0_POST_MLP_NORM_DRAM, sram_address=0x90000, element_size=self.vector_length)
         self.eltwise_add_core(vector_A_sram_start_addr=0x10000, vector_B_sram_start_addr=0x90000, vector_C_sram_wb_addr=0x10000, element_size=self.vector_length)
         self.sram_to_accelerator_memory(sram_address=0x10000, accelerator_dram_address=self.LAYER0_OUTPUT_DRAM, element_size=self.vector_length)
         if profile:

--- a/user_dma_core.py
+++ b/user_dma_core.py
@@ -2480,8 +2480,8 @@ class UnifiedEngine:
         _BROADCAST_MODES = (UE_MODE.MUL_BROADCAST, UE_MODE.ADD_BROADCAST)
         if mode not in _VECTOR_MODES + _BROADCAST_MODES:
             raise ValueError(f"{fn}: mode must be ELTWISE_ADD/MUL/SUB or MUL_BROADCAST/ADD_BROADCAST, got {mode!r}")
-        is_broadcast = mode in _BROADCAST_MODES
-        if is_broadcast:
+        is_broadcast_mode = mode in _BROADCAST_MODES
+        if is_broadcast_mode:
             if scalar is None:
                 raise ValueError(f"{fn}: scalar required for {mode!r}")
             if dram_b is not None:
@@ -2533,9 +2533,16 @@ class UnifiedEngine:
         tail_rows_reg  = _alloc()  # (total mod CHUNK)/64 (tail compute URAM_ROW_SIZE; 0 iff no tail)
         tail_bytes_reg = _alloc()  # (total mod CHUNK)*2 (tail DMA length)
         chunk_rows_reg = _alloc()  # constant CHUNK_ROWS (populates the compute pointer's row size)
-        zb_reg         = _alloc() if not is_broadcast else None  # constant b-operand URAM row
+        # Benchmark-only Gemma shortcut: treat vector elementwise staging like a broadcast so
+        # the B-side DRAM->URAM DMA is omitted.  Keep the real mode separately so the emitted
+        # compute descriptor is still ELTWISE_ADD/MUL/SUB and measures the same arithmetic path;
+        # URAM_B intentionally contains stale data, so this knob is for latency measurement only.
+        is_broadcast = is_broadcast_mode or bool(
+            getattr(self, "_benchmark_single_dma_eltwise", False)
+        )
+        zb_reg         = _alloc() if not is_broadcast_mode else None  # constant b-operand URAM row
         # UE_PBI broadcasts source their Y-row stride from pointer field 10.
-        one_reg        = _alloc() if is_broadcast else None
+        one_reg        = _alloc() if is_broadcast_mode else None
 
         self.generate_instruction_mul32_reg(total_reg, gpr_M_reg, gpr_N_reg)
         self.generate_instruction_shr(n_chunks_reg, total_reg, CHUNK_LOG2)
@@ -2579,7 +2586,7 @@ class UnifiedEngine:
         # tail compute (runtime row size) and by vector full chunks; broadcast full chunks avoid it.
         self.generate_instruction_pbi_init(
             inst_pointer_idx=ptr_comp,
-            lalu_scalar=(self.float_to_bf16(scalar) if is_broadcast else 0),
+            lalu_scalar=(self.float_to_bf16(scalar) if is_broadcast_mode else 0),
         )
         _set(ptr_comp, PBI_FIELD.URAM_START_ADDR_Y, 0)   # reg 0 = hardwired zero (A row 0)
         if zb_reg is not None:
@@ -2596,7 +2603,7 @@ class UnifiedEngine:
         def _emit_compute(rows: int, elems: int, pbi_tail: bool) -> None:
             """One chunk/tail compute. Full chunks are plain baked ops (fast path); the vector-mode
             and all broadcast operations that need runtime pointer state use UE_PBI via ptr_comp."""
-            if not is_broadcast:
+            if not is_broadcast_mode:
                 if pbi_tail:
                     self.start_queue_eltwise(mode, a_uram_row, b_uram_row, a_uram_row,
                                              URAM_SECTION.URAM_A.value, rows, inst_pointer_idx=ptr_comp)


### PR DESCRIPTION
## Gemma3 Single-DMA Elementwise Benchmark

Tested on `xdma1` with 35 prefill tokens and 477 generated decode tokens (512 total sequence tokens).

| Metric | `_benchmark_single_dma_eltwise=False` | `_benchmark_single_dma_eltwise=True` | Difference |
|---|---:|---:|---:|
| Prefill tokens | 35 | 35 | — |
| Decoded tokens | 477 | 477 | — |
| Total sequence tokens | 512 | 512 | — |
| Prefill program | 88.9 KB | 88.4 KB | −0.5 KB |
| Decoder program | 66.6 KB | 66.6 KB | No change |
| Combined program image | 155.5 KB | 155.0 KB | −0.5 KB |
| Prefill HW latency | 1312.09 ms | 1310.16 ms | **−1.93 ms (−0.147%)** |
| Prefill throughput | 26.68 tok/s | 26.71 tok/s | **+0.147%** |
| Prefill FLOPS | 37.82 GFLOPS | 37.88 GFLOPS | +0.06 GFLOPS |
| Prefill utilization | 88.7% | 88.8% | +0.1 pp |
| First-token speed | 16.65 tok/s | 16.67 tok/s | **+0.12%** |
| Average decode speed | 14.55 tok/s | 14.58 tok/s | **+0.21%** |
| First-token HW latency | 60.0 ms/tok | 60.0 ms/tok | Below displayed precision |
| Average decode HW latency | 66.7 ms/tok | 66.6 ms/tok | **−0.1 ms/tok** |
| Average decode FLOPS | 30.82 GFLOPS | 30.85 GFLOPS | +0.03 GFLOPS |
| Decode utilization | 72.3% | 72.3% | No displayed change |

### Result

Suppressing the second elementwise DMA reduced prefill latency by **1.93 ms (0.147%)** and improved average decode throughput by approximately **0.21%**. The decoder program size remained unchanged because of instruction alignment.

The performance improvement is consistent but small and close to normal measurement variance. With the benchmark flag enabled, the second elementwise operand is stale, so numerical output is intentionally invalid.